### PR TITLE
Honor configurable _base_rating divisor in EloCompetitor

### DIFF
--- a/elote/competitors/elo.py
+++ b/elote/competitors/elo.py
@@ -213,7 +213,7 @@ class EloCompetitor(BaseCompetitor):
         Returns:
             float: The transformed rating.
         """
-        return float(10 ** (self.rating / 400))
+        return float(10 ** (self.rating / self._base_rating))
 
     @property
     def rating(self) -> float:

--- a/tests/test_EloCompetitor_known_values.py
+++ b/tests/test_EloCompetitor_known_values.py
@@ -136,6 +136,29 @@ class TestEloKnownValues(unittest.TestCase):
         self.assertAlmostEqual(player1.rating, p1_new_rating)
         self.assertAlmostEqual(player2.rating, p2_new_rating)
 
+    def test_base_rating_affects_transformed_rating(self):
+        """Test that a non-default _base_rating divisor is honored in the rating math."""
+        original_base_rating = EloCompetitor._base_rating
+        try:
+            EloCompetitor.configure_class(base_rating=200)
+
+            player = EloCompetitor(initial_rating=400)
+            # 10 ** (400 / 200) == 10 ** 2 == 100, not the default 10 ** (400 / 400) == 10
+            self.assertEqual(player.transformed_rating, 100.0)
+
+            # expected_score is derived from transformed_rating, so it must change too
+            player1 = EloCompetitor(initial_rating=400)
+            player2 = EloCompetitor(initial_rating=600)
+            p1_transformed = 10 ** (400 / 200)
+            p2_transformed = 10 ** (600 / 200)
+            expected = p1_transformed / (p1_transformed + p2_transformed)
+            self.assertAlmostEqual(player1.expected_score(player2), expected)
+        finally:
+            EloCompetitor.configure_class(base_rating=original_base_rating)
+
+        # Restoring the default divisor restores the original transformed rating
+        self.assertEqual(EloCompetitor(initial_rating=400).transformed_rating, 10.0)
+
     def test_k_factor_effect(self):
         """Test that k_factor affects the rating change magnitude."""
         # With k_factor = 32


### PR DESCRIPTION
Closes #54

## Summary
`EloCompetitor` exposes a configurable `_base_rating` class variable (documented as the "Base rating divisor used in the transformed rating calculation"), but `transformed_rating` hardcoded the divisor to `400`. As a result, `EloCompetitor.configure_class(base_rating=...)` (and the legacy `from_state` `class_vars` path that assigns `cls._base_rating`) silently had no effect on ratings or expected scores.

## Changes
- `elote/competitors/elo.py`: `transformed_rating` now divides by `self._base_rating` instead of the literal `400`. With the default (`400`) this is numerically identical to before.
- `tests/test_EloCompetitor_known_values.py`: added `test_base_rating_affects_transformed_rating`, a regression test confirming a non-default divisor (`base_rating=200`) is honored by both `transformed_rating` and `expected_score`. The test restores the default in a `finally` block so it does not leak class state to other tests.

## Verification
- `make test` → **201 passed, 6 skipped** (existing `test_EloCompetitor*` known-value tests still pass; default behavior unchanged).
- `make lint` → **All checks passed!**
- Issue reproduction now behaves as documented:
  ```
  EloCompetitor.configure_class(base_rating=200)
  EloCompetitor(initial_rating=400).transformed_rating  # 100.0 (was 10.0)
  ```
  and restoring `base_rating=400` returns `transformed_rating` to `10.0`.
