### PR TITLE
Make LambdaArena.leaderboard() best-first to match its docstring

### DIFF
--- a/docs/source/advance_example.rst
+++ b/docs/source/advance_example.rst
@@ -99,7 +99,7 @@ And while we are here let's also print out what the rankings would have been to 
 
     # then we print out the top 25 as of the end of our training dataset
     print('\n\nTop 25 as of start of validation:')
-    rankings = sorted(arena.leaderboard(), reverse=True, key=lambda x: x.get('rating'))[:25]
+    rankings = arena.leaderboard()[:25]
     for idx, item in enumerate(rankings):
         print('\t%d) %s' % (idx + 1, item.get('competitor')))
 

--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -178,8 +178,8 @@ class LambdaArena(BaseArena):
         # Restore original implementation returning list of dicts
         lb: List[Dict[str, Any]] = [{"competitor": k, "rating": v.rating} for k, v in self.competitors.items()]
 
-        # Restore original sorting key and add ignores for mypy errors
-        return sorted(lb, key=lambda x: x.get("rating"))  # type: ignore[arg-type, return-value]
+        # Sort best-first (descending by rating) to match the docstring and method name
+        return sorted(lb, key=lambda x: x.get("rating"), reverse=True)  # type: ignore[arg-type, return-value]
 
     def _get_or_create_competitor(self, id_val: str) -> BaseCompetitor:
         if id_val not in self.competitors:

--- a/elote/benchmark.py
+++ b/elote/benchmark.py
@@ -110,8 +110,8 @@ def evaluate_competitor(
     metrics["train_time"] = train_time
     metrics["eval_time"] = eval_time
 
-    # Get top teams
-    top_teams = sorted(arena.leaderboard(), reverse=True, key=lambda x: x.get("rating"))[:5]
+    # Get top teams (leaderboard is already sorted best-first)
+    top_teams = arena.leaderboard()[:5]
     metrics["top_teams"] = top_teams
 
     # Add history and arena to metrics

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -129,11 +129,11 @@ class TestArenas(unittest.TestCase):
         # Get the leaderboard
         leaderboard = arena.leaderboard()
 
-        # Check that the leaderboard is sorted by rating (ascending)
+        # Check that the leaderboard is sorted by rating (descending, best-first)
         self.assertEqual(len(leaderboard), 3)
-        self.assertEqual(leaderboard[0]["competitor"], "C")
+        self.assertEqual(leaderboard[0]["competitor"], "A")
         self.assertEqual(leaderboard[1]["competitor"], "B")
-        self.assertEqual(leaderboard[2]["competitor"], "A")
+        self.assertEqual(leaderboard[2]["competitor"], "C")
 
     def test_lambda_arena_clear_history(self):
         """Test that the history can be cleared."""


### PR DESCRIPTION
Closes #53

## What changed
`LambdaArena.leaderboard()` previously sorted **ascending** (lowest-rated first), contradicting its docstring ("sorted by rating in descending order") and the conventional meaning of a leaderboard. This makes it best-first.

- `elote/arenas/lambda_arena.py` — added `reverse=True` to the sort so `leaderboard()[0]` is the highest-rated competitor and `[-1]` the lowest.
- `elote/benchmark.py` — removed the now-redundant `sorted(..., reverse=True)` re-sort for `top_teams`; it just slices `arena.leaderboard()[:5]` (still the top 5).
- `docs/source/advance_example.rst` — removed the redundant `reverse=True` re-sort in the rankings example.
- `tests/test_Arenas.py::test_lambda_arena_leaderboard` — now asserts descending (best-first) order.

Examples and the README that print `arena.leaderboard()` directly now show the best competitor first, as intended.

## Verification
- `make test` → **200 passed, 6 skipped**
- `make lint` → **All checks passed!**