### PR TITLE
Fix TypeError crash in LambdaArena.process_history / evaluate_performance / validate

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -199,16 +199,14 @@ class LambdaArena(BaseArena):
             c_b = self._get_or_create_competitor(b)
 
             if outcome is not None:
-                predicted_outcome = self.expected_score(c_a, c_b)
+                predicted_outcome = c_a.expected_score(c_b)
                 if outcome == 1:
                     c_a.beat(c_b)
                 elif outcome == 0:
                     c_b.beat(c_a)
                 else:
                     c_a.tied(c_b)
-                new_bout = Bout(
-                    a=a, b=b, outcome=outcome, timestamp=datetime.datetime.now(), predicted_outcome=predicted_outcome
-                )
+                new_bout = Bout(a=a, b=b, outcome=outcome, predicted_outcome=predicted_outcome)
                 self.history.add_bout(bout=new_bout)
             else:
                 skipped_bouts += 1
@@ -255,10 +253,8 @@ class LambdaArena(BaseArena):
                 continue
 
             # Calculate the expected outcome
-            predicted_outcome = self.expected_score(c_a, c_b)
-            new_bout = Bout(
-                a=a, b=b, outcome=outcome, timestamp=datetime.datetime.now(), predicted_outcome=predicted_outcome
-            )
+            predicted_outcome = c_a.expected_score(c_b)
+            new_bout = Bout(a=a, b=b, outcome=outcome, predicted_outcome=predicted_outcome)
             self.eval_history.add_bout(bout=new_bout)
 
         if skipped_bouts > 0:
@@ -302,10 +298,8 @@ class LambdaArena(BaseArena):
                 continue
 
             # Calculate the expected outcome
-            predicted_outcome = self.expected_score(c_a, c_b)
-            new_bout = Bout(
-                a=a, b=b, outcome=outcome, timestamp=datetime.datetime.now(), predicted_outcome=predicted_outcome
-            )
+            predicted_outcome = c_a.expected_score(c_b)
+            new_bout = Bout(a=a, b=b, outcome=outcome, predicted_outcome=predicted_outcome)
             self.validation_history.add_bout(bout=new_bout)
 
         if skipped_bouts > 0:

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -1,5 +1,5 @@
 import unittest
-from elote import LambdaArena, EloCompetitor
+from elote import LambdaArena, EloCompetitor, GlickoCompetitor
 
 
 class TestArenas(unittest.TestCase):
@@ -164,3 +164,67 @@ class TestArenas(unittest.TestCase):
 
         # Reset the class variable for other tests
         arena.set_competitor_class_var("_k_factor", 32)
+
+    def _assert_history_recorded(self, history, expected_len):
+        """Assert that a history has the expected number of bouts with sane predictions."""
+        self.assertEqual(len(history.bouts), expected_len)
+        for bout in history.bouts:
+            self.assertIsNotNone(bout.predicted_outcome)
+            self.assertGreaterEqual(bout.predicted_outcome, 0.0)
+            self.assertLessEqual(bout.predicted_outcome, 1.0)
+
+    def test_process_history_non_colley_competitors(self):
+        """process_history should run end-to-end for non-Colley competitors.
+
+        Regression test for a TypeError ('unhashable type') that occurred because
+        the method passed competitor *objects* to expected_score, which expects IDs.
+        """
+        for competitor_cls in (EloCompetitor, GlickoCompetitor):
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = LambdaArena(func=lambda x, y: True, base_competitor=competitor_cls)
+                bouts = [("x", "y", 1), ("y", "z", 0), ("x", "z", 0.5)]
+                arena.process_history(bouts, progress_bar=False)
+
+                # All bouts have non-None outcomes, so all should be recorded.
+                self._assert_history_recorded(arena.history, len(bouts))
+                for cid in ("x", "y", "z"):
+                    self.assertIn(cid, arena.competitors)
+
+    def test_process_history_skips_none_outcome(self):
+        """Bouts with a None outcome should be skipped, not recorded."""
+        arena = LambdaArena(func=lambda x, y: True)
+        bouts = [("x", "y", 1), ("y", "z", None)]
+        arena.process_history(bouts, progress_bar=False)
+        self.assertEqual(len(arena.history.bouts), 1)
+
+    def test_evaluate_performance_non_colley_competitors(self):
+        """evaluate_performance should run end-to-end for non-Colley competitors."""
+        for competitor_cls in (EloCompetitor, GlickoCompetitor):
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = LambdaArena(func=lambda x, y: True, base_competitor=competitor_cls)
+                arena.process_history([("x", "y", 1), ("y", "z", 0)], progress_bar=False)
+
+                eval_bouts = [("x", "y", 1), ("y", "z", 0)]
+                arena.evaluate_performance(eval_bouts, progress_bar=False)
+
+                # evaluate_performance must not modify the training history.
+                self.assertEqual(len(arena.history.bouts), 2)
+                self._assert_history_recorded(arena.eval_history, len(eval_bouts))
+
+    def test_validate_non_colley_competitors(self):
+        """validate should run end-to-end for non-Colley competitors without updating ratings."""
+        for competitor_cls in (EloCompetitor, GlickoCompetitor):
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = LambdaArena(func=lambda x, y: True, base_competitor=competitor_cls)
+                arena.process_history([("x", "y", 1), ("y", "z", 0)], progress_bar=False)
+
+                ratings_before = {cid: c.rating for cid, c in arena.competitors.items()}
+
+                validation_bouts = [("x", "y", 1), ("y", "z", 0)]
+                arena.validate(validation_bouts, progress_bar=False)
+
+                self._assert_history_recorded(arena.validation_history, len(validation_bouts))
+
+                # validate only records predictions; it must not update ratings.
+                ratings_after = {cid: c.rating for cid, c in arena.competitors.items()}
+                self.assertEqual(ratings_before, ratings_after)


### PR DESCRIPTION
Closes #52

## Summary
`LambdaArena.process_history`, `evaluate_performance`, and `validate` crashed with `TypeError: unhashable type` for every competitor except `ColleyMatrixCompetitor`. Each method resolved competitor **objects** via `_get_or_create_competitor(...)` and passed them to `self.expected_score(...)`, which actually expects competitor **IDs** and does dict-membership tests (`a not in self.competitors`). Because `BaseCompetitor` defines `__eq__` without `__hash__`, all competitors except Colley are unhashable, so the `in` check raised.

## Changes
- `elote/arenas/lambda_arena.py`: in all three methods, compute the prediction directly from the already-resolved objects via `c_a.expected_score(c_b)` (an existing, tested code path) instead of `self.expected_score(c_a, c_b)`.
- Same code path also constructed `Bout(...)` with an unsupported `timestamp=` kwarg (`Bout.__init__` accepts no such argument) — a second latent `TypeError` that only surfaced once the first was fixed. Removed it to match how `matchup()` builds `Bout`.
- `tests/test_Arenas.py`: added regression tests for all three methods, end-to-end, with `EloCompetitor` and `GlickoCompetitor` (non-Colley). They assert bouts are recorded in `history`/`eval_history`/`validation_history` with sane `predicted_outcome` values, that `evaluate_performance` leaves the training history intact, that `validate` does not mutate ratings, and that `process_history` skips `None`-outcome bouts.

## Verification
- `make test` → **204 passed, 6 skipped** (previously these methods were untested and broken).
- `make lint` (`ruff check .`) → **All checks passed!**
- Issue reproduction now runs cleanly for `EloCompetitor` across all three methods.
