### PR TITLE
Add Bradley-Terry rating system

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/glicko
    rating_systems/ecf
    rating_systems/dwz
+   rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison
 

--- a/docs/source/rating_systems/bradley_terry.rst
+++ b/docs/source/rating_systems/bradley_terry.rst
@@ -1,0 +1,124 @@
+Bradley-Terry Model
+===================
+
+Overview
+--------
+
+The Bradley-Terry model is a probabilistic model for paired comparisons, introduced by
+Ralph Bradley and Milton Terry in 1952. Each competitor is assigned a single latent
+*strength*, and the outcome of any head-to-head matchup is modeled as a function of the two
+competitors' strengths. It is one of the most widely used models for analyzing paired
+comparison data across sports analytics, ranking systems, and preference learning.
+
+Unlike Elo, which nudges ratings incrementally after every game, Bradley-Terry estimates the
+strengths by **maximum likelihood** over the full set of observed comparisons. In Elote this
+is done the same way as the Colley Matrix method: results are recorded as they happen, and the
+strengths of the entire connected group of competitors are re-fit after each result.
+
+How It Works
+------------
+
+Each competitor ``i`` has a positive strength ``p_i``. The probability that ``i`` beats ``j`` is
+
+.. math::
+
+   P(i \\text{ beats } j) = \\frac{p_i}{p_i + p_j}
+
+Writing the strengths in the log domain as ``p_i = e^{\\beta_i}`` turns this into the logistic
+function
+
+.. math::
+
+   P(i \\text{ beats } j) = \\frac{1}{1 + e^{-(\\beta_i - \\beta_j)}}
+
+which is exactly the functional form of the Elo expected score. Elote reports Bradley-Terry
+ratings on an Elo-like scale, ``rating = 1500 + s \\cdot \\beta`` with ``s = 400 / \\ln(10)``,
+so that the expected score is numerically identical to Elo's and the ratings are directly
+comparable to Elo ratings.
+
+The strengths are fit with the iterative MM update of Newman (2023). Given win counts
+``w_{ij}`` (the number of times ``i`` beat ``j``), each iteration applies
+
+.. math::
+
+   p_i' = \\frac{\\sum_j w_{ij}\\, p_j / (p_i + p_j)}{\\sum_j w_{ji} / (p_i + p_j)}
+
+followed by normalization by the geometric mean of the strengths. Because the strengths are
+only identified up to an overall scale, Elote re-centers them so that the mean log-strength of
+a connected group is zero.
+
+A small amount of **regularization** (a virtual win and loss against an average phantom
+opponent) is added so that a unique, finite maximum-likelihood estimate exists even when a
+competitor is undefeated or winless within its group -- a case where the unregularized estimate
+would diverge to infinity.
+
+Ties are counted as half a win for each side.
+
+Advantages
+----------
+
+- **Order independent**: the fit depends only on the set of results, not the order they were
+  played.
+- **Statistically principled**: produces the maximum-likelihood strengths given the data.
+- **Elo-compatible scale**: expected scores match Elo, so ratings are easy to interpret.
+
+Limitations
+-----------
+
+- **Recomputes globally**: like Colley, every result re-fits the whole connected group, which
+  is more expensive than Elo's constant-time update for very large populations.
+- **No margin of victory**: only win/loss/tie outcomes are used.
+- **Serialization**: the match graph (opponent references) cannot be serialized, so a
+  competitor restored from state keeps its rating and aggregate win/loss/tie counts but not the
+  live links to its opponents.
+
+Implementation in Elote
+-----------------------
+
+.. code-block:: python
+
+   from elote import BradleyTerryCompetitor
+
+   player_a = BradleyTerryCompetitor(initial_rating=1500)
+   player_b = BradleyTerryCompetitor(initial_rating=1500)
+
+   # Record results; strengths are re-fit after each one.
+   player_a.beat(player_b)
+   player_a.beat(player_b)
+   player_b.beat(player_a)
+
+   print(player_a.rating, player_b.rating)
+   print(player_a.expected_score(player_b))
+
+It also plugs directly into an arena:
+
+.. code-block:: python
+
+   from elote import LambdaArena, BradleyTerryCompetitor
+
+   arena = LambdaArena(comparison_func, base_competitor=BradleyTerryCompetitor)
+
+Customization
+-------------
+
+Class-level parameters can be tuned with ``configure_class``:
+
+- ``anchor_rating`` -- the rating assigned to the mean log-strength (default ``1500``).
+- ``scale`` -- points per unit of log-strength (default ``400 / ln(10)``).
+- ``reg`` -- regularization strength (default ``0.01``).
+- ``max_iter`` / ``tol`` -- iteration budget and convergence tolerance for the fit.
+
+Real-World Applications
+-----------------------
+
+- Ranking sports teams or players from head-to-head results.
+- Aggregating pairwise human preferences (e.g. A/B choices) into a single ranking.
+- Any setting where you want a maximum-likelihood ranking rather than an online estimate.
+
+References
+----------
+
+- Bradley, R. A., & Terry, M. E. (1952). Rank Analysis of Incomplete Block Designs: I. The
+  Method of Paired Comparisons. *Biometrika*, 39(3/4), 324-345.
+- Newman, M. E. J. (2023). Efficient computation of rankings from pairwise comparisons.
+  *Journal of Machine Learning Research*, 24(238), 1-25.

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -25,6 +25,7 @@ Available rating systems:
 - ECF: The English Chess Federation rating system
 - DWZ: The Deutsche Wertungszahl (German evaluation number) system
 - Colley Matrix: A least-squares rating system that solves a system of linear equations
+- Bradley-Terry: A maximum-likelihood paired-comparison model
 - Ensemble: A meta-rating system that combines multiple rating systems
 
 Datasets (require optional dependencies):
@@ -45,6 +46,7 @@ from elote.competitors.trueskill import TrueSkillCompetitor
 from elote.competitors.ecf import ECFCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
+from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
 # Core arenas - always available
@@ -79,6 +81,7 @@ __all__ = [
     "ECFCompetitor",
     "DWZCompetitor",
     "ColleyMatrixCompetitor",
+    "BradleyTerryCompetitor",
     "BlendedCompetitor",
     # Arenas
     "LambdaArena",

--- a/elote/competitors/bradley_terry.py
+++ b/elote/competitors/bradley_terry.py
@@ -1,0 +1,404 @@
+"""
+Bradley-Terry model implementation for the Elote library.
+
+The Bradley-Terry model is a probabilistic model for paired comparisons. Each competitor
+is assigned a latent strength, and the probability that competitor ``i`` beats competitor
+``j`` is ``p_i / (p_i + p_j)``. Working in the log domain with ``p_i = exp(beta_i)`` this is
+the logistic function ``sigmoid(beta_i - beta_j)`` -- the same functional form as the Elo
+expected score.
+
+Unlike Elo, which nudges ratings incrementally after every game, the Bradley-Terry strengths
+are obtained by maximum likelihood estimation over the full set of observed comparisons. This
+implementation follows the same approach as :class:`~elote.competitors.colley.ColleyMatrixCompetitor`:
+each competitor accumulates its match history and, after every result, the strengths of the
+whole connected component are re-fit. The fit uses the iterative MM update of Newman (2023)
+with geometric-mean normalization and a small amount of regularization so that a unique, finite
+solution exists even when a competitor is undefeated or winless within its component.
+
+References:
+- Bradley, R. A., & Terry, M. E. (1952). Rank Analysis of Incomplete Block Designs: I. The
+  Method of Paired Comparisons. Biometrika, 39(3/4), 324-345.
+- Newman, M. E. J. (2023). Efficient computation of rankings from pairwise comparisons.
+  Journal of Machine Learning Research, 24(238), 1-25.
+"""
+
+import math
+from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException
+from elote.logging import logger
+
+T = TypeVar("T", bound="BradleyTerryCompetitor")
+
+
+class BradleyTerryCompetitor(BaseCompetitor):
+    """Bradley-Terry model competitor.
+
+    The Bradley-Terry model assigns each competitor a latent strength and models the
+    probability that one competitor beats another as a function of the difference of their
+    log-strengths. Unlike Elo, which updates ratings incrementally, Bradley-Terry re-fits the
+    strengths of every connected competitor via maximum likelihood after each result.
+
+    Ratings are reported on an Elo-like scale via ``rating = anchor + scale * beta``, where
+    ``beta`` is the internal log-strength (re-centered so the mean log-strength of a component
+    is zero). Choosing ``scale = 400 / ln(10)`` makes :meth:`expected_score` numerically
+    identical to the Elo expected score, so ratings are directly comparable to Elo ratings.
+
+    Key characteristics:
+    - Global maximum-likelihood fit (does not depend on the order of results)
+    - Considers only wins and losses (ties are counted as half a win for each side)
+    - Regularized so a unique, finite fit exists even for undefeated/winless competitors
+
+    Class Attributes:
+        _minimum_rating (float): The minimum allowed rating value. Default: 0.0.
+        _anchor_rating (float): Rating assigned to the mean log-strength. Default: 1500.0.
+        _scale (float): Points per unit of log-strength. Default: 400 / ln(10).
+        _reg (float): Regularization strength (virtual wins/losses against an average
+            phantom opponent). Default: 0.01.
+        _max_iter (int): Maximum MM iterations per fit. Default: 1000.
+        _tol (float): Convergence tolerance on the max change in log-strength. Default: 1e-8.
+    """
+
+    _minimum_rating: ClassVar[float] = 0.0
+    _anchor_rating: ClassVar[float] = 1500.0
+    _scale: ClassVar[float] = 400.0 / math.log(10.0)
+    _reg: ClassVar[float] = 0.1
+    _max_iter: ClassVar[int] = 1000
+    _tol: ClassVar[float] = 1e-8
+
+    def __init__(self, initial_rating: Optional[float] = None):
+        """Initialize a new Bradley-Terry competitor.
+
+        Args:
+            initial_rating (float, optional): The initial rating of this competitor, on the
+                Elo-like reporting scale. Default: the anchor rating (1500).
+
+        Raises:
+            InvalidParameterException: If the regularization or iteration parameters are invalid.
+        """
+        super().__init__()  # Call base class constructor
+
+        self._initial_rating = initial_rating if initial_rating is not None else self._anchor_rating
+        # Internal log-strength; derived so that rating == anchor + scale * beta.
+        self._beta = (self._initial_rating - self._anchor_rating) / self._scale
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        self._opponents: Dict["BradleyTerryCompetitor", float] = {}  # Opponent -> num games
+        self._head_to_head: Dict["BradleyTerryCompetitor", float] = {}  # Opponent -> wins against
+        # Unique ID for hashing (instances are used as dict keys in the match graph).
+        self._id = id(self)
+        logger.debug(
+            "Initialized BradleyTerryCompetitor %d with initial rating %.3f", self._id, self._initial_rating
+        )
+
+    @property
+    def rating(self) -> float:
+        """Get the current rating of this competitor on the Elo-like reporting scale.
+
+        Returns:
+            float: The current rating.
+        """
+        return self._anchor_rating + self._scale * self._beta
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        """Set the current rating of this competitor on the Elo-like reporting scale.
+
+        Args:
+            value (float): The new rating value.
+        """
+        logger.debug("Setting rating for competitor %d to %.3f", self._id, value)
+        self._beta = (value - self._anchor_rating) / self._scale
+
+    @property
+    def num_games(self) -> int:
+        """Get the total number of games played by this competitor.
+
+        Returns:
+            int: The total number of games played.
+        """
+        return self._wins + self._losses + self._ties
+
+    def expected_score(self, competitor: "BaseCompetitor") -> float:
+        """Calculate the expected score against another competitor.
+
+        Args:
+            competitor (BaseCompetitor): The competitor to compare against.
+
+        Returns:
+            float: The expected score (probability of winning).
+        """
+        self.verify_competitor_types(competitor)
+        other = cast(BradleyTerryCompetitor, competitor)
+        return 1.0 / (1.0 + math.exp(-(self._beta - other._beta)))
+
+    def beat(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has won against the given competitor.
+
+        The result is recorded on both competitors and the strengths of the entire connected
+        component are re-fit by maximum likelihood.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that lost.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s beat %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        opponent = cast(BradleyTerryCompetitor, competitor)
+
+        self._wins += 1
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._head_to_head[opponent] = self._head_to_head.get(opponent, 0) + 1
+
+        opponent._losses += 1
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._head_to_head.setdefault(self, 0)
+
+        logger.debug("Recorded win for %d, loss for %d", self._id, opponent._id)
+        self._recalculate_ratings()
+
+    def tied(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has tied with the given competitor.
+
+        A tie is counted as half a win for each side.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that tied.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s tied with %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        opponent = cast(BradleyTerryCompetitor, competitor)
+
+        self._ties += 1
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._head_to_head[opponent] = self._head_to_head.get(opponent, 0) + 0.5
+
+        opponent._ties += 1
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._head_to_head[self] = opponent._head_to_head.get(self, 0) + 0.5
+
+        logger.debug("Recorded tie for %d and %d", self._id, opponent._id)
+        self._recalculate_ratings()
+
+    def lost_to(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that won.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s lost to %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        competitor.beat(self)
+
+    def _get_connected_competitors(self) -> List["BradleyTerryCompetitor"]:
+        """Get all competitors connected to this competitor in the match graph.
+
+        Returns:
+            List[BradleyTerryCompetitor]: A list of all connected competitors.
+        """
+        visited: Set["BradleyTerryCompetitor"] = set()
+        to_visit: List["BradleyTerryCompetitor"] = [self]
+        all_competitors = []
+
+        while to_visit:
+            current = to_visit.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            all_competitors.append(current)
+            for opponent in current._opponents:
+                if opponent not in visited:
+                    to_visit.append(opponent)
+
+        logger.debug("Found %d connected competitors", len(all_competitors))
+        return all_competitors
+
+    def _recalculate_ratings(self) -> None:
+        """Re-fit the Bradley-Terry strengths for all connected competitors.
+
+        Uses the iterative MM update of Newman (2023) with geometric-mean normalization and a
+        small regularization term (virtual results against an average phantom opponent) so that
+        the maximum-likelihood estimate exists and is unique even when a competitor is
+        undefeated or winless within its component.
+        """
+        competitors = self._get_connected_competitors()
+        n = len(competitors)
+        if n <= 1:
+            logger.debug("Only one competitor in network, skipping recalculation.")
+            return
+
+        idx = {comp: i for i, comp in enumerate(competitors)}
+
+        # Win counts: wins[i][j] = number of times i beat j (ties count as 0.5 to each side).
+        wins = [[0.0] * n for _ in range(n)]
+        for i, comp in enumerate(competitors):
+            for opponent, w in comp._head_to_head.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    wins[i][j] += w
+
+        # Total games between each pair (symmetric).
+        games = [[wins[i][j] + wins[j][i] for j in range(n)] for i in range(n)]
+
+        # Strengths p_i = exp(beta_i). The Bradley-Terry log-likelihood is concave with a
+        # unique maximum, so we seed from a flat, well-conditioned starting point rather than
+        # warm-starting from the (possibly extreme) current strengths, which converges reliably.
+        p = [1.0] * n
+
+        reg = self._reg
+        for iteration in range(self._max_iter):
+            new_p = [0.0] * n
+            for i in range(n):
+                numerator = 0.0
+                denominator = 0.0
+                for j in range(n):
+                    if i == j or games[i][j] == 0:
+                        continue
+                    denom_ij = p[i] + p[j]
+                    numerator += wins[i][j] * p[j] / denom_ij
+                    denominator += wins[j][i] / denom_ij
+                # Regularization: a virtual win and loss against a phantom opponent of unit
+                # strength, guaranteeing a finite, unique solution.
+                numerator += reg * 1.0 / (p[i] + 1.0)
+                denominator += reg * 1.0 / (p[i] + 1.0)
+                new_p[i] = numerator / denominator if denominator > 0 else p[i]
+
+            # Normalize by the geometric mean to fix the overall scale.
+            log_sum = sum(math.log(v) for v in new_p if v > 0)
+            geo_mean = math.exp(log_sum / n)
+            if geo_mean > 0:
+                new_p = [v / geo_mean for v in new_p]
+
+            max_delta = max(abs(math.log(new_p[i]) - math.log(p[i])) for i in range(n) if new_p[i] > 0)
+            p = new_p
+            if max_delta < self._tol:
+                logger.debug("Bradley-Terry fit converged in %d iterations", iteration + 1)
+                break
+
+        # Write back re-centered log-strengths (mean beta == 0).
+        betas = [math.log(v) for v in p]
+        mean_beta = sum(betas) / n
+        for i, comp in enumerate(competitors):
+            comp._beta = betas[i] - mean_beta
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        """Export the parameters used to initialize this competitor.
+
+        Returns:
+            dict: A dictionary containing the initialization parameters.
+        """
+        return {
+            "initial_rating": self._initial_rating,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        """Export the current state variables of this competitor.
+
+        Returns:
+            dict: A dictionary containing the current state variables.
+        """
+        return {
+            "rating": self.rating,
+            "beta": self._beta,
+            "wins": self._wins,
+            "losses": self._losses,
+            "ties": self._ties,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        """Import parameters from a state dictionary.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+        """
+        self._initial_rating = parameters.get("initial_rating", self._anchor_rating)
+        self._beta = (self._initial_rating - self._anchor_rating) / self._scale
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        """Import current state variables from a state dictionary.
+
+        Note: opponent references cannot be restored from serialization, so the match graph is
+        reset; the rating and aggregate win/loss/tie counts are preserved.
+
+        Args:
+            state (dict): A dictionary containing state variables.
+        """
+        if "beta" in state:
+            self._beta = state["beta"]
+        elif "rating" in state:
+            self._beta = (state["rating"] - self._anchor_rating) / self._scale
+        self._wins = state.get("wins", 0)
+        self._losses = state.get("losses", 0)
+        self._ties = state.get("ties", 0)
+        self._opponents = {}
+        self._head_to_head = {}
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        """Create a new competitor instance from parameters.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Returns:
+            BradleyTerryCompetitor: A new competitor instance.
+        """
+        return cls(initial_rating=parameters.get("initial_rating", cls._anchor_rating))
+
+    def reset(self) -> None:
+        """Reset this competitor to its initial state."""
+        logger.info("Resetting BradleyTerryCompetitor %d to initial state.", self._id)
+        self._beta = (self._initial_rating - self._anchor_rating) / self._scale
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        self._opponents = {}
+        self._head_to_head = {}
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        """Configure class-level parameters for this rating system.
+
+        Overrides the base implementation to validate the regularization and iteration
+        parameters.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        if kwargs.get("reg", 0.0) < 0:
+            raise InvalidParameterException("reg must be non-negative")
+        if kwargs.get("max_iter", 1) < 1:
+            raise InvalidParameterException("max_iter must be at least 1")
+        if kwargs.get("scale", 1.0) <= 0:
+            raise InvalidParameterException("scale must be positive")
+        super().configure_class(**kwargs)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this competitor."""
+        return (
+            f"<BradleyTerryCompetitor: rating={self.rating:.3f}, "
+            f"W/L/T={self._wins}/{self._losses}/{self._ties}>"
+        )
+
+    def __str__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<BradleyTerryCompetitor: rating={self.rating:.3f}>"
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if two competitors are the same object (by unique ID)."""
+        if not isinstance(other, BradleyTerryCompetitor):
+            return NotImplemented
+        return self._id == other._id
+
+    def __hash__(self) -> int:
+        """Get a hash value for this competitor based on its unique ID."""
+        return hash(self._id)

--- a/tests/test_BradleyTerryCompetitor.py
+++ b/tests/test_BradleyTerryCompetitor.py
@@ -1,0 +1,144 @@
+import unittest
+
+from elote import BradleyTerryCompetitor, EloCompetitor
+from elote.competitors.base import (
+    BaseCompetitor,
+    MissMatchedCompetitorTypesException,
+    InvalidParameterException,
+)
+
+
+class TestBradleyTerryCompetitor(unittest.TestCase):
+    """Behavioral / interface tests for BradleyTerryCompetitor."""
+
+    def test_initial_rating(self):
+        player = BradleyTerryCompetitor()
+        self.assertAlmostEqual(player.rating, 1500.0)
+
+        player = BradleyTerryCompetitor(initial_rating=1600)
+        self.assertAlmostEqual(player.rating, 1600.0)
+
+    def test_rating_setter(self):
+        player = BradleyTerryCompetitor()
+        player.rating = 1700
+        self.assertAlmostEqual(player.rating, 1700.0)
+
+    def test_expected_score_symmetry(self):
+        a = BradleyTerryCompetitor(initial_rating=1600)
+        b = BradleyTerryCompetitor(initial_rating=1400)
+        self.assertAlmostEqual(a.expected_score(b) + b.expected_score(a), 1.0)
+
+        equal_a = BradleyTerryCompetitor()
+        equal_b = BradleyTerryCompetitor()
+        self.assertAlmostEqual(equal_a.expected_score(equal_b), 0.5)
+
+    def test_expected_score_matches_elo(self):
+        # Bradley-Terry with scale 400/ln(10) has the same expected-score form as Elo.
+        bt_a = BradleyTerryCompetitor(initial_rating=1650)
+        bt_b = BradleyTerryCompetitor(initial_rating=1480)
+        elo_a = EloCompetitor(initial_rating=1650)
+        elo_b = EloCompetitor(initial_rating=1480)
+        self.assertAlmostEqual(bt_a.expected_score(bt_b), elo_a.expected_score(elo_b))
+
+    def test_beat_updates_ratings(self):
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        old_a, old_b = a.rating, b.rating
+        a.beat(b)
+        # A global re-fit changes both ratings; the winner ends up ahead of the loser.
+        self.assertNotEqual(a.rating, old_a)
+        self.assertNotEqual(b.rating, old_b)
+        self.assertGreater(a.rating, b.rating)
+
+    def test_lost_to(self):
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        a.lost_to(b)
+        self.assertGreater(b.rating, a.rating)
+
+    def test_tied(self):
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        a.tied(b)
+        # Symmetric tie leaves the two competitors on equal footing.
+        self.assertAlmostEqual(a.rating, b.rating, places=5)
+        self.assertEqual(a._ties, 1)
+        self.assertEqual(b._ties, 1)
+
+    def test_win_loss_tie_counts(self):
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        a.beat(b)
+        b.beat(a)
+        a.tied(b)
+        self.assertEqual(a._wins, 1)
+        self.assertEqual(a._losses, 1)
+        self.assertEqual(a._ties, 1)
+        self.assertEqual(a.num_games, 3)
+
+    def test_undefeated_stays_finite(self):
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        c = BradleyTerryCompetitor()
+        a.beat(b)
+        a.beat(c)
+        a.beat(b)
+        self.assertTrue(abs(a.rating) < float("inf"))
+        self.assertGreater(a.rating, b.rating)
+        self.assertGreater(a.rating, c.rating)
+
+    def test_reset(self):
+        a = BradleyTerryCompetitor(initial_rating=1550)
+        b = BradleyTerryCompetitor()
+        a.beat(b)
+        a.reset()
+        self.assertAlmostEqual(a.rating, 1550.0)
+        self.assertEqual(a._wins, 0)
+        self.assertEqual(a._losses, 0)
+        self.assertEqual(a._opponents, {})
+
+    def test_comparison_operators(self):
+        a = BradleyTerryCompetitor(initial_rating=1400)
+        b = BradleyTerryCompetitor(initial_rating=1600)
+        self.assertTrue(a < b)
+        self.assertTrue(b > a)
+        self.assertFalse(a == b)
+
+    def test_serialization_roundtrip(self):
+        a = BradleyTerryCompetitor(initial_rating=1550)
+        b = BradleyTerryCompetitor()
+        a.beat(b)
+        a.beat(b)
+        b.beat(a)
+
+        state = a.export_state()
+        restored = BaseCompetitor.from_state(state)
+        self.assertIsInstance(restored, BradleyTerryCompetitor)
+        self.assertAlmostEqual(restored.rating, a.rating)
+        self.assertEqual(restored._wins, 2)
+        self.assertEqual(restored._losses, 1)
+
+    def test_json_roundtrip(self):
+        a = BradleyTerryCompetitor(initial_rating=1520)
+        json_str = a.to_json()
+        restored = BradleyTerryCompetitor.from_json(json_str)
+        self.assertAlmostEqual(restored.rating, a.rating)
+
+    def test_type_mismatch_raises(self):
+        a = BradleyTerryCompetitor()
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            a.expected_score(EloCompetitor())
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            a.beat(EloCompetitor())
+
+    def test_configure_class_validation(self):
+        with self.assertRaises(InvalidParameterException):
+            BradleyTerryCompetitor.configure_class(reg=-1)
+        with self.assertRaises(InvalidParameterException):
+            BradleyTerryCompetitor.configure_class(max_iter=0)
+        with self.assertRaises(InvalidParameterException):
+            BradleyTerryCompetitor.configure_class(scale=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_BradleyTerryCompetitor_known_values.py
+++ b/tests/test_BradleyTerryCompetitor_known_values.py
@@ -1,0 +1,67 @@
+import math
+import unittest
+
+from elote import BradleyTerryCompetitor, EloCompetitor
+
+
+class TestBradleyTerryKnownValues(unittest.TestCase):
+    """Tests for BradleyTerryCompetitor against hand-computed values."""
+
+    def test_initial_rating(self):
+        self.assertAlmostEqual(BradleyTerryCompetitor().rating, 1500.0)
+        self.assertAlmostEqual(BradleyTerryCompetitor(initial_rating=1234).rating, 1234.0)
+
+    def test_expected_score_known(self):
+        # Equal strengths -> 0.5.
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        self.assertAlmostEqual(a.expected_score(b), 0.5)
+
+        # 200-point gap on the Elo scale -> the classic Elo win probability.
+        a = BradleyTerryCompetitor(initial_rating=1600)
+        b = BradleyTerryCompetitor(initial_rating=1400)
+        expected = 1.0 / (1.0 + 10 ** (-200 / 400))
+        self.assertAlmostEqual(a.expected_score(b), expected)
+
+    def test_matches_elo_expected_score(self):
+        for ra, rb in [(1500, 1500), (1600, 1400), (1200, 1800), (1723, 1601)]:
+            bt = BradleyTerryCompetitor(initial_rating=ra).expected_score(
+                BradleyTerryCompetitor(initial_rating=rb)
+            )
+            elo = EloCompetitor(initial_rating=ra).expected_score(EloCompetitor(initial_rating=rb))
+            self.assertAlmostEqual(bt, elo)
+
+    def test_two_player_mle_ratio(self):
+        # A beats B twice, B beats A once. The unregularized MLE gives p_A / p_B = 2,
+        # i.e. beta_A - beta_B = ln(2). With light regularization the gap is very close.
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        a.beat(b)
+        a.beat(b)
+        b.beat(a)
+        beta_gap = a._beta - b._beta
+        self.assertAlmostEqual(beta_gap, math.log(2), places=1)
+        self.assertGreater(a.rating, b.rating)
+
+    def test_recentering(self):
+        # After a fit the mean log-strength of a component is zero, so equal records keep
+        # the two competitors centered on the anchor rating.
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        a.beat(b)
+        b.beat(a)
+        self.assertAlmostEqual((a.rating + b.rating) / 2, 1500.0, places=3)
+
+    def test_transitive_ordering(self):
+        # A beats B, B beats C -> A > B > C.
+        a = BradleyTerryCompetitor()
+        b = BradleyTerryCompetitor()
+        c = BradleyTerryCompetitor()
+        a.beat(b)
+        b.beat(c)
+        self.assertGreater(a.rating, b.rating)
+        self.assertGreater(b.rating, c.rating)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,6 +6,7 @@ from elote import (
     GlickoCompetitor,
     BlendedCompetitor,
     ColleyMatrixCompetitor,
+    BradleyTerryCompetitor,
 )
 from elote.competitors.base import BaseCompetitor, InvalidStateException
 
@@ -164,6 +165,42 @@ class TestStandardizedSerialization(unittest.TestCase):
         self.assertEqual(new_competitor._wins, 2)
         self.assertEqual(new_competitor._losses, 1)
         self.assertEqual(new_competitor._ties, 0)
+
+        # Note: We can't verify _opponents because that can't be exported/imported
+
+    def test_bradley_terry_serialization(self):
+        """Test serialization and deserialization of BradleyTerryCompetitor."""
+        competitor = BradleyTerryCompetitor(initial_rating=1550)
+
+        opponent = BradleyTerryCompetitor(initial_rating=1500)
+        competitor.beat(opponent)
+        competitor.beat(opponent)
+        opponent.beat(competitor)
+
+        state = competitor.export_state()
+
+        self.assertIn("type", state)
+        self.assertIn("version", state)
+        self.assertIn("parameters", state)
+        self.assertIn("state", state)
+        self.assertEqual(state["type"], "BradleyTerryCompetitor")
+        self.assertEqual(state["version"], 1)
+
+        self.assertIn("initial_rating", state["parameters"])
+        self.assertEqual(state["parameters"]["initial_rating"], 1550)
+
+        self.assertIn("rating", state["state"])
+        self.assertAlmostEqual(state["state"]["rating"], competitor.rating)
+        self.assertEqual(state["state"]["wins"], 2)
+        self.assertEqual(state["state"]["losses"], 1)
+        self.assertEqual(state["state"]["ties"], 0)
+
+        new_competitor = BaseCompetitor.from_state(state)
+        self.assertIsInstance(new_competitor, BradleyTerryCompetitor)
+        self.assertEqual(new_competitor._initial_rating, 1550)
+        self.assertAlmostEqual(new_competitor.rating, competitor.rating)
+        self.assertEqual(new_competitor._wins, 2)
+        self.assertEqual(new_competitor._losses, 1)
 
         # Note: We can't verify _opponents because that can't be exported/imported
 

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -6,6 +6,7 @@ from elote import (
     DWZCompetitor,
     BlendedCompetitor,
     ColleyMatrixCompetitor,
+    BradleyTerryCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -301,6 +302,51 @@ class TestUnifiedInterface(unittest.TestCase):
         with self.assertRaises(InvalidRatingValueException):
             ColleyMatrixCompetitor(initial_rating=-0.1)
 
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor1.expected_score(EloCompetitor())
+
+    def test_base_methods_bradley_terry(self):
+        """Test that the Bradley-Terry competitor implements all required methods."""
+        competitor = BradleyTerryCompetitor(initial_rating=1500)
+        self.assertAlmostEqual(competitor.rating, 1500)
+
+        # Test export/import
+        state = competitor.export_state()
+        self.assertIn("initial_rating", state)
+
+        new_competitor = BradleyTerryCompetitor.from_state(state)
+        self.assertAlmostEqual(new_competitor.rating, 1500)
+
+        # Test reset
+        competitor.rating = 1600
+        self.assertAlmostEqual(competitor.rating, 1600)
+        competitor.reset()
+        self.assertAlmostEqual(competitor.rating, 1500)
+
+        # Test comparison operators
+        competitor1 = BradleyTerryCompetitor(initial_rating=1400)
+        competitor2 = BradleyTerryCompetitor(initial_rating=1600)
+        self.assertTrue(competitor1 < competitor2)
+        self.assertTrue(competitor2 > competitor1)
+        self.assertFalse(competitor1 == competitor2)
+
+        # Test expected score
+        score = competitor1.expected_score(competitor2)
+        self.assertTrue(0 < score < 1)
+
+        # Test match outcomes. Bradley-Terry re-fits the whole component on each result,
+        # so we assert that ratings changed (as with Colley) rather than a fixed magnitude.
+        comp_a = BradleyTerryCompetitor()
+        comp_b = BradleyTerryCompetitor()
+        old_rating_a = comp_a.rating
+        old_rating_b = comp_b.rating
+        for _ in range(3):
+            comp_a.beat(comp_b)
+        self.assertNotEqual(comp_a.rating, old_rating_a)
+        self.assertNotEqual(comp_b.rating, old_rating_b)
+        self.assertGreater(comp_a.rating, comp_b.rating)
+
+        # Test type mismatch
         with self.assertRaises(MissMatchedCompetitorTypesException):
             competitor1.expected_score(EloCompetitor())
 


### PR DESCRIPTION
## Summary

Adds `BradleyTerryCompetitor`, a maximum-likelihood paired-comparison rating system, to elote's competitor lineup.

The Bradley-Terry model assigns each competitor a latent strength and models `P(i beats j) = p_i / (p_i + p_j)`. In log form `p_i = e^β` this is `sigmoid(β_i − β_j)` — the same functional form as the Elo expected score. The distinctive part is that strengths are obtained by **maximum likelihood over all observed comparisons**, not by an incremental per-game nudge.

### Approach

This follows the existing `ColleyMatrixCompetitor` pattern (the library's other global-fit system): each competitor accumulates its match history, and after every result the strengths of the whole connected component are re-fit. The fit uses the iterative MM update of Newman (2023) with geometric-mean normalization.

Key design points:
- **Elo-compatible scale.** Ratings are reported as `rating = 1500 + (400/ln 10)·β`, which makes `expected_score` *numerically identical* to Elo's, so ratings are directly comparable.
- **Regularization for existence.** A light phantom-opponent term guarantees a unique, finite MLE even when a competitor is undefeated or winless within its component (where the raw estimate diverges to ±∞).
- **Robust fitting.** The fit seeds from a flat starting point each time; because the BT log-likelihood is concave with a unique maximum, warm-starting buys nothing and hurts conditioning.
- **Ties** count as half a win per side.

No new dependencies (numpy/scipy already required); no arena changes — `LambdaArena(func, base_competitor=BradleyTerryCompetitor)` works out of the box.

### What's included
- `elote/competitors/bradley_terry.py`, exported from the top-level package
- `tests/test_BradleyTerryCompetitor.py` and `tests/test_BradleyTerryCompetitor_known_values.py`
- Entries in the shared `test_unified_interface.py` and `test_serialization.py`
- Narrative docs page `docs/source/rating_systems/bradley_terry.rst`, wired into the toctree

### Notes / limitations
- Like Colley, every result re-fits the whole connected component — heavier than Elo's constant-time update for very large populations.
- Like Colley, opponent references can't be serialized; a restored competitor keeps its rating and aggregate W/L/T but not the live match graph.

### Testing
- `223 passed, 6 skipped` on the full suite; new BT files, unified-interface, and serialization suites all green.
- `ruff` and `mypy` clean on the new module.
- Verified end-to-end through `LambdaArena`: a 6-competitor tournament with known latent strengths produces a perfectly monotonic leaderboard.