### PR TITLE
Document all competitors, add Bradley-Terry example, and prep v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 v1.2.0
 ======
 
- * Began adding type hints
- * Fixed DWZ to correctly calculate development coefficient based on the competitors age at time of match.
+New rating systems
+
+ * Added the Bradley-Terry model (`BradleyTerryCompetitor`), a maximum-likelihood paired-comparison
+   system reported on an Elo-compatible rating scale.
+
+Bug fixes
+
+ * Fixed a `TypeError` crash in `LambdaArena.process_history`, `evaluate_performance`, and `validate`.
+ * Fixed `LambdaArena.leaderboard()` to return competitors best-first, matching its docstring.
+ * Fixed `EloCompetitor.transformed_rating` to honor a configurable `_base_rating` divisor.
+ * Fixed DWZ to correctly calculate the development coefficient based on the competitor's age at
+   the time of the match.
+
+Improvements
+
+ * Added type hints across the competitor and arena modules.
+ * Added a configurable logging module (`elote.logging`).
+ * Expanded the documentation to cover every competitor (Glicko-2, TrueSkill, Colley Matrix, and
+   Bradley-Terry), added a Bradley-Terry example, and refreshed the rating-system comparison guide.
+ * Updated the Sphinx theme (Google Analytics and dark mode) and general linting/dependency cleanup.
+ * Routine dependency bumps (uv, pygments, requests, black, pillow, filelock, virtualenv).
  
 v1.1.0
 ======

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Currently implemented rating systems:
 - **TrueSkill** - Microsoft's Bayesian skill rating system for multiplayer games
 - **ECF** - The English Chess Federation rating system
 - **DWZ** - The Deutsche Wertungszahl (German evaluation number) system
+- **Colley Matrix** - A least-squares method that ranks competitors by solving a linear system
+- **Bradley-Terry** - A maximum-likelihood paired-comparison model on an Elo-compatible scale
+
+You can also combine several systems into a single **Ensemble** (blended) competitor.
 
 ## Installation
 

--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -30,6 +30,24 @@ Glicko Competitor
    :show-inheritance:
    :special-members: __init__
 
+Glicko-2 Competitor
+------------------
+
+.. automodule:: elote.competitors.glicko2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
+TrueSkill Competitor
+-------------------
+
+.. automodule:: elote.competitors.trueskill
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 DWZ Competitor
 -------------
 
@@ -43,6 +61,24 @@ ECF Competitor
 -------------
 
 .. automodule:: elote.competitors.ecf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
+Colley Matrix Competitor
+-----------------------
+
+.. automodule:: elote.competitors.colley
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
+Bradley-Terry Competitor
+-----------------------
+
+.. automodule:: elote.competitors.bradley_terry
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -13,6 +13,18 @@ Glicko Competitor
 .. autoclass:: elote.competitors.glicko.GlickoCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Glicko-2 Competitor
+-------------------
+
+.. autoclass:: elote.competitors.glicko2.Glicko2Competitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
+TrueSkill Competitor
+--------------------
+
+.. autoclass:: elote.competitors.trueskill.TrueSkillCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
 DWZ Competitor
 --------------
 
@@ -23,6 +35,18 @@ ECF Competitor
 --------------
 
 .. autoclass:: elote.competitors.ecf.ECFCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
+Colley Matrix Competitor
+------------------------
+
+.. autoclass:: elote.competitors.colley.ColleyMatrixCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
+Bradley-Terry Competitor
+------------------------
+
+.. autoclass:: elote.competitors.bradley_terry.BradleyTerryCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
 BlendedCompetitor

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,8 +40,11 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
 
    rating_systems/elo
    rating_systems/glicko
+   rating_systems/glicko2
+   rating_systems/trueskill
    rating_systems/ecf
    rating_systems/dwz
+   rating_systems/colley
    rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison

--- a/docs/source/rating_systems/bradley_terry.rst
+++ b/docs/source/rating_systems/bradley_terry.rst
@@ -36,14 +36,16 @@ ratings on an Elo-like scale, ``rating = 1500 + s \\cdot \\beta`` with ``s = 400
 so that the expected score is numerically identical to Elo's and the ratings are directly
 comparable to Elo ratings.
 
-The strengths are fit with the iterative MM update of Newman (2023). Given win counts
-``w_{ij}`` (the number of times ``i`` beat ``j``), each iteration applies
+The strengths are fit with the minorization-maximization (MM) update of Hunter (2004). Writing
+``W_i`` for the total number of wins by ``i`` and ``n_{ij}`` for the number of games between ``i``
+and ``j``, each iteration applies
 
 .. math::
 
-   p_i' = \\frac{\\sum_j w_{ij}\\, p_j / (p_i + p_j)}{\\sum_j w_{ji} / (p_i + p_j)}
+   p_i' = \\frac{W_i}{\\sum_j n_{ij} / (p_i + p_j)}
 
-followed by normalization by the geometric mean of the strengths. Because the strengths are
+followed by normalization by the geometric mean of the strengths. This update is guaranteed to
+increase the likelihood at every step and converges to the unique regularized maximum. Because the strengths are
 only identified up to an overall scale, Elote re-centers them so that the mean log-strength of
 a connected group is zero.
 
@@ -105,7 +107,7 @@ Class-level parameters can be tuned with ``configure_class``:
 
 - ``anchor_rating`` -- the rating assigned to the mean log-strength (default ``1500``).
 - ``scale`` -- points per unit of log-strength (default ``400 / ln(10)``).
-- ``reg`` -- regularization strength (default ``0.01``).
+- ``reg`` -- regularization strength (default ``0.1``).
 - ``max_iter`` / ``tol`` -- iteration budget and convergence tolerance for the fit.
 
 Real-World Applications
@@ -120,5 +122,5 @@ References
 
 - Bradley, R. A., & Terry, M. E. (1952). Rank Analysis of Incomplete Block Designs: I. The
   Method of Paired Comparisons. *Biometrika*, 39(3/4), 324-345.
-- Newman, M. E. J. (2023). Efficient computation of rankings from pairwise comparisons.
-  *Journal of Machine Learning Research*, 24(238), 1-25.
+- Hunter, D. R. (2004). MM Algorithms for Generalized Bradley-Terry Models. *The Annals of
+  Statistics*, 32(1), 384-406.

--- a/docs/source/rating_systems/colley.rst
+++ b/docs/source/rating_systems/colley.rst
@@ -1,0 +1,91 @@
+Colley Matrix Method
+===================
+
+Overview
+--------
+
+The Colley Matrix Method is a least-squares rating system devised by astrophysicist Wesley Colley.
+Rather than nudging ratings after each game the way Elo does, it solves a single system of linear
+equations over the entire match history to obtain every competitor's rating at once. It is one of
+the computer rankings historically used in the college-football Bowl Championship Series, and is
+prized for being **bias free**: the result depends only on who beat whom, not on the order games
+were played or on the margin of victory.
+
+How It Works
+-----------
+
+Colley's method builds a linear system
+
+.. math::
+
+   C\,r = b
+
+where ``r`` is the vector of ratings, ``C`` is the *Colley matrix* built from each competitor's
+game counts and head-to-head schedule, and ``b`` is derived from wins and losses. Every competitor
+starts at a rating of 0.5, and solving the system yields final ratings in the range [0, 1]. A useful
+property is that the ratings of a group of ``n`` competitors always sum to ``n / 2``.
+
+In Elote the fit is recomputed over the connected group of competitors after each recorded result,
+so ratings always reflect the full set of games. The expected score between two competitors is a
+logistic function of their rating difference.
+
+Advantages
+---------
+
+- **Order Independent**: the ratings depend only on the set of results, not the schedule order.
+- **Bias Free**: no margin-of-victory influence, which discourages running up the score.
+- **Well Grounded**: a clean least-squares interpretation with a unique solution.
+- **Self-Normalizing**: ratings live in [0, 1] and sum to ``n / 2``.
+
+Limitations
+----------
+
+- **Recomputes Globally**: like Bradley-Terry, each result re-solves the whole connected group,
+  which is more expensive than Elo's constant-time update for very large populations.
+- **No Margin of Victory**: only win/loss/tie outcomes are used.
+- **Different Scale**: ratings are in [0, 1] rather than on the 1500-centered chess scale.
+- **Connectivity Needed**: groups of competitors that never play each other cannot be compared.
+
+Implementation in Elote
+----------------------
+
+Elote implements the Colley Matrix Method through the ``ColleyMatrixCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import ColleyMatrixCompetitor
+
+    # Every competitor starts at 0.5
+    team_a = ColleyMatrixCompetitor()
+    team_b = ColleyMatrixCompetitor()
+
+    # Get win probability
+    print(f"Team A win probability: {team_a.expected_score(team_b):.2%}")
+
+    # Record results; the whole connected group is re-solved after each one
+    team_a.beat(team_b)
+    team_a.beat(team_b)
+    team_b.beat(team_a)
+
+    print(f"Team A: {team_a.rating:.3f}")
+    print(f"Team B: {team_b.rating:.3f}")
+
+Customization
+------------
+
+Key parameter:
+
+- **initial_rating**: starting rating value (default: 0.5).
+
+Real-World Applications
+---------------------
+
+- **College Football**: one of the computer polls used in the BCS era.
+- **Sports Rankings**: any round-robin or bracketed competition where schedule bias matters.
+- **Tournament Seeding**: producing an order-independent ranking from recorded results.
+
+References
+---------
+
+1. Colley, W. N. (2002). "Colley's Bias Free College Football Ranking Method: The Colley Matrix
+   Explained". https://www.colleyrankings.com/matrate.pdf

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -8,62 +8,72 @@ Overview Comparison
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 16 16 16 16 16
+   :widths: 16 18 14 20 14 18
 
-   * - Feature
-     - Elo
-     - Glicko
-     - ECF
-     - DWZ
-     - Ensemble
-   * - **Origin**
+   * - System
+     - Origin
+     - Complexity
+     - Uncertainty Tracking
+     - Order Independent
+     - Typical Use Cases
+   * - **Elo**
      - Chess (1960s)
-     - Chess (1995)
-     - England (1950s)
-     - Germany (1990s)
-     - Meta-system
-   * - **Complexity**
      - Low
-     - Medium
-     - Low
-     - Medium
-     - High
-   * - **Uncertainty Tracking**
      - No
+     - No
+     - General purpose
+   * - **Glicko**
+     - Chess (1995)
+     - Medium
      - Yes (RD)
      - No
+     - Sparse competitions
+   * - **Glicko-2**
+     - Chess (2000s)
+     - Medium-High
+     - Yes (RD + volatility)
+     - No
+     - Online chess, volatile skill
+   * - **TrueSkill**
+     - Microsoft (2007)
+     - High
+     - Yes (sigma)
+     - No
+     - Teams and multiplayer
+   * - **ECF**
+     - England (1950s)
+     - Low
+     - No
+     - No
+     - English chess
+   * - **DWZ**
+     - Germany (1990s)
+     - Medium
      - Partial
-     - Depends on components
-   * - **Expected Score Formula**
-     - Logistic
-     - Modified Logistic
-     - Linear
-     - Logistic
-     - Weighted Average
-   * - **Inactivity Handling**
+     - No
+     - Youth development
+   * - **Colley Matrix**
+     - Sports (2002)
+     - Medium
      - No
      - Yes
+     - Bias-free sports ranking
+   * - **Bradley-Terry**
+     - Statistics (1952)
+     - Medium
      - No
-     - Partial
-     - Depends on components
-   * - **Implementation Difficulty**
-     - Easy
-     - Moderate
-     - Easy
-     - Moderate
-     - Complex
-   * - **Computational Cost**
-     - Low
-     - Medium
-     - Low
-     - Medium
+     - Yes
+     - Maximum-likelihood ranking
+   * - **Ensemble**
+     - Meta-system
      - High
-   * - **Typical Use Cases**
-     - General purpose
-     - Sparse competitions
-     - English chess
-     - Youth development
+     - Depends on components
+     - Depends on components
      - Complex domains
+
+Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ) update ratings incrementally after each
+result. Global-fit systems (Colley Matrix and Bradley-Terry) re-solve the whole connected group of
+competitors from the full set of results, which makes them order independent.
 
 Mathematical Formulation
 -----------------------
@@ -78,10 +88,18 @@ Mathematical Formulation
      - :math:`E_A = \frac{1}{1 + 10^{(R_B - R_A) / 400}}`
    * - **Glicko**
      - :math:`E(A, B) = \frac{1}{1 + 10^{-g(RD_B) \times (r_A - r_B) / 400}}` where :math:`g(RD) = \frac{1}{\sqrt{1 + 3 \times RD^2 / \pi^2}}`
+   * - **Glicko-2**
+     - Same logistic form as Glicko, evaluated on an internal transformed scale with an added volatility term
+   * - **TrueSkill**
+     - :math:`E_A = \Phi\!\left(\frac{\mu_A - \mu_B}{\sqrt{2\beta^2 + \sigma_A^2 + \sigma_B^2}}\right)` where :math:`\Phi` is the normal CDF
    * - **ECF**
      - :math:`E_A = 0.5 + \frac{R_A - R_B}{F}` where F is typically 120
    * - **DWZ**
      - :math:`W_e = \frac{1}{1 + 10^{-(R_A - R_B) / 400}}`
+   * - **Colley Matrix**
+     - Ratings solve :math:`C r = b`; :math:`E_A = \frac{1}{1 + e^{-4 (r_A - r_B)}}`
+   * - **Bradley-Terry**
+     - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
    * - **Ensemble**
      - :math:`E_{ensemble} = \sum_{i=1}^{n} w_i \times E_i` where :math:`w_i` are weights
 
@@ -98,10 +116,18 @@ Key Parameters
      - K-factor (determines rating change magnitude)
    * - **Glicko**
      - Initial rating, Initial RD, Volatility, Tau
+   * - **Glicko-2**
+     - Initial rating, Initial RD, Initial volatility, Tau
+   * - **TrueSkill**
+     - Initial mu, Initial sigma, Beta, Tau, Draw probability
    * - **ECF**
-     - K-factor, F-factor (conversion factor)
+     - Delta (max rating difference), Number of periods
    * - **DWZ**
-     - Initial rating, Development coefficient
+     - Initial rating, Development coefficient (age-dependent)
+   * - **Colley Matrix**
+     - Initial rating (default 0.5)
+   * - **Bradley-Terry**
+     - Initial rating, Scale, Regularization, Max iterations
    * - **Ensemble**
      - Component systems, Weights
 
@@ -138,6 +164,36 @@ Glicko
 - More parameters to tune
 - Less intuitive interpretation
 
+Glicko-2
+^^^^^^^^
+
+**Strengths:**
+- Adds volatility to capture how consistent a competitor is
+- Retains Glicko's uncertainty and inactivity handling
+- Fast, stable convergence for both erratic and steady players
+- Used by major online chess platforms
+
+**Weaknesses:**
+- The most involved of the Glicko family to implement
+- Sensitive to the tau system constant
+- Iterative volatility update adds computational cost
+- Designed around rating periods rather than single games
+
+TrueSkill
+^^^^^^^^^
+
+**Strengths:**
+- Models both skill and uncertainty as a Gaussian
+- Naturally extends to teams and multiplayer games
+- Fast convergence as uncertainty shrinks
+- Principled Bayesian foundation
+
+**Weaknesses:**
+- Most complex inference of the individual systems
+- Rating is derived from mu and sigma (no direct setter)
+- Works on a mu/sigma scale rather than the chess scale
+- Sensitive to beta, tau, and draw-probability settings
+
 ECF
 ^^^
 
@@ -168,6 +224,36 @@ DWZ
 - Parameter sensitivity
 - Less international recognition
 
+Colley Matrix
+^^^^^^^^^^^^^
+
+**Strengths:**
+- Order independent: depends only on the set of results
+- Bias free: no margin-of-victory influence
+- Clean least-squares interpretation with a unique solution
+- Self-normalizing ratings in [0, 1] that sum to n/2
+
+**Weaknesses:**
+- Re-solves the whole connected group after each result
+- Uses only win/loss/tie outcomes
+- Ratings are on a [0, 1] scale, not the chess scale
+- Requires a connected schedule to compare competitors
+
+Bradley-Terry
+^^^^^^^^^^^^^
+
+**Strengths:**
+- Order independent maximum-likelihood estimate
+- Statistically principled paired-comparison model
+- Reported on an Elo-compatible scale for easy interpretation
+- Regularized so undefeated or winless competitors stay finite
+
+**Weaknesses:**
+- Re-fits the whole connected group after each result
+- Uses only win/loss/tie outcomes
+- The match graph cannot be serialized (only aggregate counts)
+- More expensive than Elo for very large populations
+
 Ensemble
 ^^^^^^^^
 
@@ -189,26 +275,27 @@ Choosing the Right System
 Consider the following factors when choosing a rating system:
 
 1. **Data Density**: How frequently do competitors face each other?
-   - Sparse data: Consider Glicko
+   - Sparse data: Consider Glicko or Glicko-2
    - Dense data: Elo may be sufficient
 
 2. **Domain Specifics**:
    - Chess in England: ECF
    - Chess in Germany: DWZ
    - Youth development: DWZ
+   - Team and multiplayer games: TrueSkill
    - General purpose: Elo or Glicko
 
-3. **Computational Resources**:
+3. **Order Independence**: Do you need a ranking that ignores schedule order?
+   - Yes: Colley Matrix or Bradley-Terry
+   - No: any online system (Elo, Glicko, etc.)
+
+4. **Computational Resources**:
    - Limited resources: Elo or ECF
-   - Sufficient resources: Glicko, DWZ, or Ensemble
+   - Sufficient resources: Glicko, Glicko-2, TrueSkill, or Ensemble
 
-4. **Uncertainty Importance**:
-   - Critical to track uncertainty: Glicko
+5. **Uncertainty Importance**:
+   - Critical to track uncertainty: Glicko, Glicko-2, or TrueSkill
    - Uncertainty less important: Elo or ECF
-
-5. **Complexity Tolerance**:
-   - Need simple explanation: Elo or ECF
-   - Can handle complexity: Glicko, DWZ, or Ensemble
 
 6. **Prediction Accuracy**:
    - Highest accuracy needed: Consider Ensemble
@@ -221,44 +308,55 @@ Here's a quick comparison of how to use each system in Elote:
 
 .. code-block:: python
 
-    from elote import EloCompetitor, GlickoCompetitor, ECFCompetitor, DWZCompetitor, EnsembleCompetitor
+    from elote import (
+        EloCompetitor,
+        GlickoCompetitor,
+        Glicko2Competitor,
+        TrueSkillCompetitor,
+        ECFCompetitor,
+        DWZCompetitor,
+        ColleyMatrixCompetitor,
+        BradleyTerryCompetitor,
+        BlendedCompetitor,
+    )
 
     # Elo
     elo_player = EloCompetitor(initial_rating=1500, k_factor=32)
 
     # Glicko
-    glicko_player = GlickoCompetitor(initial_rating=1500, initial_rd=350, volatility=0.06)
+    glicko_player = GlickoCompetitor(initial_rating=1500, initial_rd=350)
+
+    # Glicko-2
+    glicko2_player = Glicko2Competitor(initial_rating=1500, initial_rd=350)
+
+    # TrueSkill (mu/sigma scale)
+    trueskill_player = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
 
     # ECF
-    ecf_player = ECFCompetitor(initial_rating=120, k_factor=16, f_factor=120)
+    ecf_player = ECFCompetitor(initial_rating=100)
 
     # DWZ
-    dwz_player = DWZCompetitor(initial_rating=1600, initial_development_coeff=30)
+    dwz_player = DWZCompetitor(initial_rating=1600)
 
-    # Ensemble
-    ensemble_player = EnsembleCompetitor(
-        rating_systems=[
-            (EloCompetitor(initial_rating=1500), 0.5),
-            (GlickoCompetitor(initial_rating=1500), 0.5)
+    # Colley Matrix ([0, 1] scale)
+    colley_player = ColleyMatrixCompetitor()
+
+    # Bradley-Terry (Elo-compatible scale)
+    bt_player = BradleyTerryCompetitor(initial_rating=1500)
+
+    # Ensemble (blend of sub-competitors)
+    ensemble_player = BlendedCompetitor(
+        competitors=[
+            {"type": "EloCompetitor", "competitor_kwargs": {"initial_rating": 1500}},
+            {"type": "GlickoCompetitor", "competitor_kwargs": {"initial_rating": 1500}},
         ]
     )
 
-    # Usage is the same for all systems
+    # Usage is the same for all systems: expected_score, beat, tied, lost_to
+    player = EloCompetitor(initial_rating=1500)
     opponent = EloCompetitor(initial_rating=1400)
-    
-    # Get expected scores
-    print(f"Elo expected: {elo_player.expected_score(opponent):.2%}")
-    print(f"Glicko expected: {glicko_player.expected_score(opponent):.2%}")
-    print(f"ECF expected: {ecf_player.expected_score(opponent):.2%}")
-    print(f"DWZ expected: {dwz_player.expected_score(opponent):.2%}")
-    print(f"Ensemble expected: {ensemble_player.expected_score(opponent):.2%}")
-
-    # Record a win
-    elo_player.beat(opponent)
-    glicko_player.beat(opponent)
-    ecf_player.beat(opponent)
-    dwz_player.beat(opponent)
-    ensemble_player.beat(opponent)
+    print(f"Expected score: {player.expected_score(opponent):.2%}")
+    player.beat(opponent)  # record a win
 
 Empirical Comparison
 -------------------
@@ -272,4 +370,4 @@ Here's a simple approach to compare systems:
 3. Evaluate prediction accuracy on the test data
 4. Choose the system with the best performance for your specific use case
 
-Remember that no rating system is universally best - the right choice depends on your specific requirements, data characteristics, and domain constraints. 
+Remember that no rating system is universally best - the right choice depends on your specific requirements, data characteristics, and domain constraints.

--- a/docs/source/rating_systems/glicko2.rst
+++ b/docs/source/rating_systems/glicko2.rst
@@ -1,0 +1,103 @@
+Glicko-2 Rating System
+=====================
+
+Overview
+--------
+
+Glicko-2 is an extension of the Glicko rating system, both developed by Mark Glickman. It keeps
+Glicko's rating and rating deviation (RD) and adds a third quantity, **volatility**, which
+measures how erratic a competitor's results have been. A player whose results swing wildly gets a
+higher volatility, which in turn lets their rating move more quickly; a player with steady results
+gets a lower volatility and a more stable rating.
+
+Internally Glicko-2 works on a transformed scale with mean 0 and standard deviation 1, and converts
+back to the familiar mean-1500 display scale (with a scale factor of about 173.7) when reporting a
+rating.
+
+How It Works
+-----------
+
+Each competitor is described by three quantities:
+
+1. **Rating (r)**: the estimate of the player's skill.
+2. **Rating Deviation (RD)**: the uncertainty in that estimate.
+3. **Volatility (σ)**: the expected fluctuation in the rating over time.
+
+The expected outcome uses the same logistic form as Glicko, discounting for the opponent's
+uncertainty. After a rating period the rating, RD, and volatility are all updated together, with
+the volatility found by an iterative procedure controlled by the system constant ``tau``. As with
+Glicko, RD grows during periods of inactivity so that a long-absent competitor's rating becomes
+less certain.
+
+Advantages
+---------
+
+- **Volatility Tracking**: captures how consistent a competitor's results are, not just their skill.
+- **Uncertainty Measurement**: like Glicko, models the reliability of each rating.
+- **Inactivity Handling**: RD increases for players who have not competed recently.
+- **Faster, More Stable Convergence**: erratic players adjust quickly; steady players stay stable.
+
+Limitations
+----------
+
+- **Complexity**: the most involved of the Glicko family to understand and implement.
+- **Parameter Sensitivity**: results depend on the ``tau`` system constant and initial values.
+- **Rating-Period Design**: originally intended to update over rating periods rather than after
+  every single game.
+- **Computational Overhead**: the iterative volatility update costs more than Elo or Glicko.
+
+Implementation in Elote
+----------------------
+
+Elote implements Glicko-2 through the ``Glicko2Competitor`` class:
+
+.. code-block:: python
+
+    from elote import Glicko2Competitor
+
+    # Create two competitors with ratings, RDs, and volatilities
+    player1 = Glicko2Competitor(initial_rating=1500, initial_rd=350)
+    player2 = Glicko2Competitor(initial_rating=1700, initial_rd=300)
+
+    # Get win probability
+    print(f"Player 2 win probability: {player2.expected_score(player1):.2%}")
+
+    # Record a match result (an optional match_time can be supplied)
+    player1.beat(player2)
+
+    # Rating, RD, and volatility are all updated
+    print(f"Player 1: rating={player1.rating}, rd={player1.rd}, vol={player1.volatility}")
+
+Customization
+------------
+
+.. code-block:: python
+
+    player = Glicko2Competitor(
+        initial_rating=1500,
+        initial_rd=350,
+        initial_volatility=0.06,
+    )
+
+Key parameters:
+
+- **initial_rating**: starting rating value (default: 1500).
+- **initial_rd**: starting rating deviation (default: 350).
+- **initial_volatility**: starting volatility (default: 0.06).
+
+The class-level ``tau`` system constant (default 0.5) constrains how much volatility can change
+between rating periods and can be adjusted with ``Glicko2Competitor.configure_class(tau=...)``.
+
+Real-World Applications
+---------------------
+
+- **Online Chess**: Glicko-2 is the rating system used by lichess.org.
+- **Competitive Video Games**: used in modified form by several matchmaking systems.
+- **Sports Analytics**: applied where both skill and consistency matter.
+
+References
+---------
+
+1. Glickman, Mark E. (2012). "Example of the Glicko-2 system". http://www.glicko.net/glicko/glicko2.pdf
+2. Glickman, Mark E. (1999). "Parameter estimation in large dynamic paired comparison experiments".
+   Applied Statistics, 48, 377-394.

--- a/docs/source/rating_systems/trueskill.rst
+++ b/docs/source/rating_systems/trueskill.rst
@@ -1,0 +1,103 @@
+TrueSkill Rating System
+======================
+
+Overview
+--------
+
+TrueSkill is a Bayesian skill-rating system developed by Microsoft Research. It generalizes Elo and
+Glicko to team-based and multiplayer games, and is best known for powering matchmaking on Xbox Live.
+Each player's skill is modeled as a Gaussian (normal) distribution with a mean and a standard
+deviation, and match results shift both quantities.
+
+How It Works
+-----------
+
+Each competitor's skill is described by two quantities:
+
+1. **Mu (μ)**: the estimated skill level (the mean of the belief distribution).
+2. **Sigma (σ)**: the uncertainty in that estimate (the standard deviation).
+
+The probability that one player beats another depends on the difference in their means relative to
+their combined uncertainty and a skill factor ``beta``. After each match, both players' distributions
+are updated via Bayesian inference: the winner's mean rises, the loser's falls, and both players'
+sigma typically shrinks as evidence accumulates. A small dynamics factor ``tau`` is added to the
+uncertainty over time so that skill can drift.
+
+Because a single Gaussian would over-state confidence, Elote reports a **conservative** rating of
+``mu - 3 * sigma`` -- a value you can be roughly 99% sure the player's true skill exceeds.
+
+Advantages
+---------
+
+- **Uncertainty Aware**: models both skill and confidence, like Glicko.
+- **Team and Multiplayer Support**: naturally extends to games with more than two participants.
+- **Fast Convergence**: new players' ratings settle quickly as sigma shrinks.
+- **Principled**: grounded in Bayesian inference over factor graphs.
+
+Limitations
+----------
+
+- **Complexity**: the underlying factor-graph inference is the most complex of the systems here.
+- **No Direct Rating Setter**: the reported rating is derived from mu and sigma, so you set ``mu``
+  and ``sigma`` rather than the rating directly.
+- **Parameter Sensitivity**: depends on ``beta``, ``tau``, and the assumed draw probability.
+- **Different Scale**: works on a mu/sigma scale (default μ = 25) rather than the 1500-centered
+  chess scale.
+
+Implementation in Elote
+----------------------
+
+Elote implements TrueSkill through the ``TrueSkillCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import TrueSkillCompetitor
+
+    # Create two competitors (defaults: mu=25.0, sigma=8.333)
+    player1 = TrueSkillCompetitor()
+    player2 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
+
+    # Get win probability
+    print(f"Player 2 win probability: {player2.expected_score(player1):.2%}")
+
+    # Record a match result
+    player1.beat(player2)
+
+    # The conservative rating is mu - 3 * sigma
+    print(f"Player 1: mu={player1.mu}, sigma={player1.sigma}, rating={player1.rating}")
+
+You can also measure how evenly matched two players are:
+
+.. code-block:: python
+
+    quality = TrueSkillCompetitor.match_quality(player1, player2)
+    print(f"Match quality: {quality:.2%}")
+
+Customization
+------------
+
+Key parameters:
+
+- **initial_mu**: starting mean skill (default: 25.0).
+- **initial_sigma**: starting uncertainty (default: 8.333).
+
+Class-level constants can be tuned with ``TrueSkillCompetitor.configure_class(...)``:
+
+- ``beta`` -- skill factor governing how much outcomes depend on skill vs. chance (default 4.166).
+- ``tau`` -- dynamics factor adding uncertainty over time (default 0.083).
+- ``draw_probability`` -- assumed probability of a draw (default 0.10).
+
+Real-World Applications
+---------------------
+
+- **Xbox Live**: the original use case, for matchmaking across many titles.
+- **Esports and Multiplayer Games**: team-based skill estimation and matchmaking.
+- **Any Multiplayer Ranking**: settings where uncertainty and team composition matter.
+
+References
+---------
+
+1. Herbrich, R., Minka, T., & Graepel, T. (2007). "TrueSkill(TM): A Bayesian Skill Rating System".
+   Advances in Neural Information Processing Systems 20.
+2. Microsoft Research. "TrueSkill Ranking System".
+   https://www.microsoft.com/en-us/research/project/trueskill-ranking-system/

--- a/elote/competitors/bradley_terry.py
+++ b/elote/competitors/bradley_terry.py
@@ -11,15 +11,16 @@ Unlike Elo, which nudges ratings incrementally after every game, the Bradley-Ter
 are obtained by maximum likelihood estimation over the full set of observed comparisons. This
 implementation follows the same approach as :class:`~elote.competitors.colley.ColleyMatrixCompetitor`:
 each competitor accumulates its match history and, after every result, the strengths of the
-whole connected component are re-fit. The fit uses the iterative MM update of Newman (2023)
-with geometric-mean normalization and a small amount of regularization so that a unique, finite
-solution exists even when a competitor is undefeated or winless within its component.
+whole connected component are re-fit. The fit uses the minorization-maximization (MM) update of
+Hunter (2004) with geometric-mean normalization and a small amount of regularization so that a
+unique, finite solution exists even when a competitor is undefeated or winless within its
+component.
 
 References:
 - Bradley, R. A., & Terry, M. E. (1952). Rank Analysis of Incomplete Block Designs: I. The
   Method of Paired Comparisons. Biometrika, 39(3/4), 324-345.
-- Newman, M. E. J. (2023). Efficient computation of rankings from pairwise comparisons.
-  Journal of Machine Learning Research, 24(238), 1-25.
+- Hunter, D. R. (2004). MM algorithms for generalized Bradley-Terry models. The Annals of
+  Statistics, 32(1), 384-406.
 """
 
 import math
@@ -54,8 +55,8 @@ class BradleyTerryCompetitor(BaseCompetitor):
         _anchor_rating (float): Rating assigned to the mean log-strength. Default: 1500.0.
         _scale (float): Points per unit of log-strength. Default: 400 / ln(10).
         _reg (float): Regularization strength (virtual wins/losses against an average
-            phantom opponent). Default: 0.01.
-        _max_iter (int): Maximum MM iterations per fit. Default: 1000.
+            phantom opponent). Default: 0.1.
+        _max_iter (int): Maximum MM iterations per fit. Default: 10000.
         _tol (float): Convergence tolerance on the max change in log-strength. Default: 1e-8.
     """
 
@@ -63,7 +64,7 @@ class BradleyTerryCompetitor(BaseCompetitor):
     _anchor_rating: ClassVar[float] = 1500.0
     _scale: ClassVar[float] = 400.0 / math.log(10.0)
     _reg: ClassVar[float] = 0.1
-    _max_iter: ClassVar[int] = 1000
+    _max_iter: ClassVar[int] = 10000
     _tol: ClassVar[float] = 1e-8
 
     def __init__(self, initial_rating: Optional[float] = None):
@@ -225,10 +226,10 @@ class BradleyTerryCompetitor(BaseCompetitor):
     def _recalculate_ratings(self) -> None:
         """Re-fit the Bradley-Terry strengths for all connected competitors.
 
-        Uses the iterative MM update of Newman (2023) with geometric-mean normalization and a
-        small regularization term (virtual results against an average phantom opponent) so that
-        the maximum-likelihood estimate exists and is unique even when a competitor is
-        undefeated or winless within its component.
+        Uses the minorization-maximization (MM) update of Hunter (2004) with geometric-mean
+        normalization and a small regularization term (virtual results against an average phantom
+        opponent) so that the maximum-likelihood estimate exists and is unique even when a
+        competitor is undefeated or winless within its component.
         """
         competitors = self._get_connected_competitors()
         n = len(competitors)
@@ -249,27 +250,28 @@ class BradleyTerryCompetitor(BaseCompetitor):
         # Total games between each pair (symmetric).
         games = [[wins[i][j] + wins[j][i] for j in range(n)] for i in range(n)]
 
+        # Total wins per competitor (ties are already counted as half in the win matrix).
+        total_wins = [math.fsum(wins[i]) for i in range(n)]
+
         # Strengths p_i = exp(beta_i). The Bradley-Terry log-likelihood is concave with a
         # unique maximum, so we seed from a flat, well-conditioned starting point rather than
-        # warm-starting from the (possibly extreme) current strengths, which converges reliably.
+        # warm-starting from the (possibly extreme) current strengths.
         p = [1.0] * n
 
         reg = self._reg
         for iteration in range(self._max_iter):
             new_p = [0.0] * n
             for i in range(n):
-                numerator = 0.0
                 denominator = 0.0
                 for j in range(n):
                     if i == j or games[i][j] == 0:
                         continue
-                    denom_ij = p[i] + p[j]
-                    numerator += wins[i][j] * p[j] / denom_ij
-                    denominator += wins[j][i] / denom_ij
+                    denominator += games[i][j] / (p[i] + p[j])
                 # Regularization: a virtual win and loss against a phantom opponent of unit
-                # strength, guaranteeing a finite, unique solution.
-                numerator += reg * 1.0 / (p[i] + 1.0)
-                denominator += reg * 1.0 / (p[i] + 1.0)
+                # strength, guaranteeing a finite, unique solution even for undefeated or
+                # winless competitors.
+                numerator = total_wins[i] + reg
+                denominator += 2.0 * reg / (p[i] + 1.0)
                 new_p[i] = numerator / denominator if denominator > 0 else p[i]
 
             # Normalize by the geometric mean to fix the overall scale.

--- a/examples/bradley_terry_example.py
+++ b/examples/bradley_terry_example.py
@@ -1,0 +1,149 @@
+"""
+Bradley-Terry model example using Elote.
+
+The Bradley-Terry model is a maximum-likelihood paired-comparison system. Each competitor
+is assigned a single latent strength, and the probability that one competitor beats another
+is a logistic function of the difference in their strengths -- exactly the functional form
+of the Elo expected score. Unlike Elo, which nudges ratings incrementally, Bradley-Terry
+re-fits the strengths of the whole connected group of competitors by maximum likelihood
+after every result, so the final ratings depend only on the set of outcomes, not their order.
+
+This example demonstrates:
+1. Creating BradleyTerryCompetitor instances (on an Elo-compatible rating scale)
+2. Recording match results and watching the ratings re-fit
+3. The order-independence of the maximum-likelihood fit
+4. That the expected score matches Elo's for the same rating gap
+5. Using BradleyTerryCompetitor inside a LambdaArena tournament
+"""
+
+import os
+import json
+import matplotlib.pyplot as plt
+from elote import BradleyTerryCompetitor, EloCompetitor, LambdaArena
+
+
+def basic_bouts():
+    # Ratings use the same 1500-centered scale as Elo.
+    team_a = BradleyTerryCompetitor(initial_rating=1500)
+    team_b = BradleyTerryCompetitor(initial_rating=1500)
+    team_c = BradleyTerryCompetitor(initial_rating=1500)
+    team_d = BradleyTerryCompetitor(initial_rating=1500)
+
+    print("Initial ratings:")
+    for name, team in [("A", team_a), ("B", team_b), ("C", team_c), ("D", team_d)]:
+        print(f"Team {name}: {team.rating:.1f}")
+
+    print("\nInitial win probability A vs B:", f"{team_a.expected_score(team_b):.2%}")
+
+    print("\nSimulating a small tournament...")
+
+    a_ratings = [team_a.rating]
+    b_ratings = [team_b.rating]
+    c_ratings = [team_c.rating]
+    d_ratings = [team_d.rating]
+
+    def snapshot():
+        a_ratings.append(team_a.rating)
+        b_ratings.append(team_b.rating)
+        c_ratings.append(team_c.rating)
+        d_ratings.append(team_d.rating)
+
+    # Round 1
+    team_a.beat(team_b)  # A beats B
+    team_c.beat(team_d)  # C beats D
+    snapshot()
+
+    # Round 2
+    team_a.beat(team_c)  # A beats C
+    team_b.beat(team_d)  # B beats D
+    snapshot()
+
+    # Round 3
+    team_a.beat(team_d)  # A beats D
+    team_b.beat(team_c)  # B beats C
+    snapshot()
+
+    print("\nFinal ratings (higher = stronger):")
+    print(f"Team A: {team_a.rating:.1f} (won 3, lost 0)")
+    print(f"Team B: {team_b.rating:.1f} (won 1, lost 1)")
+    print(f"Team C: {team_c.rating:.1f} (won 1, lost 1)")
+    print(f"Team D: {team_d.rating:.1f} (won 0, lost 2)")
+
+    print("\nFinal win probabilities:")
+    print(f"Team A vs Team B: {team_a.expected_score(team_b):.2%}")
+    print(f"Team A vs Team D: {team_a.expected_score(team_d):.2%}")
+
+    # Plot rating changes over time
+    plt.figure(figsize=(10, 6))
+    rounds = range(len(a_ratings))
+    plt.plot(rounds, a_ratings, "o-", label="Team A")
+    plt.plot(rounds, b_ratings, "s-", label="Team B")
+    plt.plot(rounds, c_ratings, "^-", label="Team C")
+    plt.plot(rounds, d_ratings, "x-", label="Team D")
+    plt.xlabel("Round")
+    plt.ylabel("Rating")
+    plt.title("Bradley-Terry Ratings Over Tournament Rounds")
+    plt.legend()
+    plt.grid(True)
+    plt.xticks(list(rounds))
+
+    os.makedirs("images", exist_ok=True)
+    plt.savefig(os.path.join("images", "bradley_terry_ratings.png"))
+    print("\nRating history plot saved as 'images/bradley_terry_ratings.png'")
+
+
+def order_independence():
+    """The maximum-likelihood fit depends only on the set of results, not their order."""
+    print("\n--- Order independence ---")
+
+    # Sequence 1: alternating
+    x1, y1 = BradleyTerryCompetitor(), BradleyTerryCompetitor()
+    x1.beat(y1)
+    y1.beat(x1)
+    x1.beat(y1)
+
+    # Sequence 2: same results, different order
+    x2, y2 = BradleyTerryCompetitor(), BradleyTerryCompetitor()
+    y2.beat(x2)
+    x2.beat(y2)
+    x2.beat(y2)
+
+    print(f"Order 1 -> X: {x1.rating:.2f}, Y: {y1.rating:.2f}")
+    print(f"Order 2 -> X: {x2.rating:.2f}, Y: {y2.rating:.2f}")
+    print("Ratings match regardless of order:", round(x1.rating, 6) == round(x2.rating, 6))
+
+
+def matches_elo():
+    """For a given rating gap, Bradley-Terry's expected score matches Elo's."""
+    print("\n--- Expected score matches Elo ---")
+    bt_strong = BradleyTerryCompetitor(initial_rating=1600)
+    bt_weak = BradleyTerryCompetitor(initial_rating=1400)
+    elo_strong = EloCompetitor(initial_rating=1600)
+    elo_weak = EloCompetitor(initial_rating=1400)
+    print(f"Bradley-Terry: {bt_strong.expected_score(bt_weak):.6f}")
+    print(f"Elo:           {elo_strong.expected_score(elo_weak):.6f}")
+
+
+def arena_tournament():
+    """BradleyTerryCompetitor plugs straight into a LambdaArena."""
+    print("\n--- LambdaArena tournament ---")
+
+    # Latent strengths 0..5; higher wins. The arena should recover this order.
+    matchups = [(a, b) for a in range(6) for b in range(6) if a != b]
+
+    arena = LambdaArena(lambda a, b: a > b, base_competitor=BradleyTerryCompetitor)
+    arena.tournament(matchups)
+
+    print("Leaderboard (best first):")
+    print(json.dumps(arena.leaderboard(), indent=2, default=str))
+
+
+def main():
+    basic_bouts()
+    order_independence()
+    matches_elo()
+    arena_tournament()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elote"
-version = "1.1.0"
+version = "1.2.0"
 description = "Python module for rating bouts (like with Elo Rating)"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "elote"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
Follow-on to #58. Adds documentation coverage for **every** competitor, ships a Bradley-Terry example, corrects a Bradley-Terry fitting bug found while writing that example, and prepares the v1.2.0 release.

## Bradley-Terry fit correction (behavioral)
While writing the example I found the merged BT fit produces **incorrect rankings** on simple data. On a transitive double round-robin (strengths 0–5), it ranked a 6–4 competitor *below* a 4–6 one:

- Shipped update → order `[5, 4, 2, 3, 1, 0]` (2 and 3 inverted), stable even at 500k iterations.
- Standard **Hunter (2004) MM** update → order `[5, 4, 3, 2, 1, 0]` (correct).

The shipped iteration converged to a non-MLE fixed point. This PR swaps it for the Hunter MM update `p_i = W_i / Σ_j n_ij/(p_i+p_j)`, which is guaranteed to increase the likelihood every step and converge to the unique regularized maximum. It also:
- raises the default `max_iter` to 10000 (the correct iteration needs ~1.5k on a dense graph),
- fixes the algorithm attribution (Hunter 2004, not Newman 2023) in the module, class, and doc references,
- corrects stale docstring defaults (`reg=0.1`, `max_iter=10000`).

The 2-player known-value test still holds (β-gap ≈ ln 2), and the arena leaderboard is now perfectly monotonic.

## Documentation — all competitors
- New rating-system pages: **Glicko-2**, **TrueSkill**, **Colley Matrix** (added to the toctree).
- Added the missing competitors (Glicko-2, TrueSkill, Colley, Bradley-Terry) to the **API reference** and the **competitor list**.
- Rewrote the **comparison guide** to cover all nine systems (overview, formulas, parameters, strengths/weaknesses, chooser, code). Also fixed the pre-existing `EnsembleCompetitor` reference to the real `BlendedCompetitor` API.
- README **Features** now lists Colley and Bradley-Terry.

## Example
- `examples/bradley_terry_example.py`: bouts, order-independence, Elo-equivalence of `expected_score`, and a `LambdaArena` tournament.

## Release prep
- Fleshed out the `v1.2.0` CHANGELOG with everything since v1.1.0 (BT model, the three LambdaArena/Elo bug fixes, type hints, logging, docs, dependency bumps).
- Bumped version `1.1.0` → `1.2.0` (pyproject + uv.lock).

## Verification
- `pytest`: 228 passed, 6 skipped.
- `ruff` and `mypy`: clean.
- Docs build succeeds (remaining warnings are pre-existing docstring/underline quirks shared across the existing pages).