### PR TITLE
Fix Glicko double-squared RD collapsing expected_score to ~0.5

### DIFF
--- a/elote/competitors/glicko.py
+++ b/elote/competitors/glicko.py
@@ -303,7 +303,7 @@ class GlickoCompetitor(BaseCompetitor):
         self.verify_competitor_types(competitor)
         logger.debug("Calculating expected score between %s and %s", self, competitor)
 
-        g_term = self._g(self.rd**2)
+        g_term = self._g(competitor.rd)
         E = 1 / (1 + 10 ** ((-1 * g_term * (self._rating - competitor.rating)) / 400))
         return E
 
@@ -401,7 +401,7 @@ class GlickoCompetitor(BaseCompetitor):
             tuple: A tuple containing the new rating and RD.
         """
         E_term = self.expected_score(competitor)
-        g = self._g(competitor.rd**2)
+        g = self._g(competitor.rd)
         logger.debug("Calculating rating update for %s: E=%.4f, g=%.4f", self, E_term, g)
         d_squared = (self._q**2 * (g**2 * E_term * (1 - E_term))) ** -1
 

--- a/tests/test_GlickoCompetitor.py
+++ b/tests/test_GlickoCompetitor.py
@@ -85,8 +85,8 @@ class TestGlicko(unittest.TestCase):
 
     def test_expected_score_calculation(self):
         """Test that the expected score is calculated correctly."""
-        # The expected score is calculated as:
-        # E = 1 / (1 + 10^(-g(RD_i^2) * (R_i - R_j) / 400))
+        # The expected score is calculated per Glickman's formula:
+        # E = 1 / (1 + 10^(-g(RD_j) * (R_i - R_j) / 400)), where RD_j is the opponent's RD.
 
         # Test with equal ratings
         player1 = GlickoCompetitor(initial_rating=1500, initial_rd=350)
@@ -98,7 +98,7 @@ class TestGlicko(unittest.TestCase):
         player2 = GlickoCompetitor(initial_rating=1500, initial_rd=350)
 
         # Calculate the expected score manually
-        g_term = GlickoCompetitor._g(player1.rd**2)
+        g_term = GlickoCompetitor._g(player2.rd)
         expected_score = 1 / (1 + 10 ** ((-1 * g_term * (player1.rating - player2.rating)) / 400))
 
         self.assertAlmostEqual(player1.expected_score(player2), expected_score, places=5)

--- a/tests/test_GlickoCompetitor_known_values.py
+++ b/tests/test_GlickoCompetitor_known_values.py
@@ -35,10 +35,33 @@ class TestGlickoKnownValues(unittest.TestCase):
         player1 = GlickoCompetitor(initial_rating=1500, initial_rd=300)
         player2 = GlickoCompetitor(initial_rating=1700, initial_rd=300)
 
-        # Calculate expected score manually
-        g = player1._g(300**2)  # Use rd squared as per the implementation
+        # Calculate expected score manually per Glickman's formula:
+        # E = 1 / (1 + 10^(-g(RD_j)(r_i - r_j)/400)), where RD_j is the opponent's RD.
+        g = player2._g(player2.rd)
         E = 1 / (1 + 10 ** ((-g * (1500 - 1700)) / 400))
         self.assertAlmostEqual(player1.expected_score(player2), E)
+
+    def test_expected_score_large_gap(self):
+        """A large positive rating gap should give an expected score near 1 (and its mirror near 0)."""
+        strong = GlickoCompetitor(initial_rating=2500, initial_rd=350)
+        weak = GlickoCompetitor(initial_rating=1500, initial_rd=350)
+
+        self.assertGreater(strong.expected_score(weak), 0.9)
+        self.assertLess(weak.expected_score(strong), 0.1)
+
+    def test_expected_score_symmetric(self):
+        """Equal ratings and RD should give an expected score of exactly 0.5."""
+        player1 = GlickoCompetitor(initial_rating=1500, initial_rd=200)
+        player2 = GlickoCompetitor(initial_rating=1500, initial_rd=200)
+        self.assertAlmostEqual(player1.expected_score(player2), 0.5)
+
+    def test_expected_score_monotonic_in_gap(self):
+        """Expected score should increase monotonically with the rating gap."""
+        base = GlickoCompetitor(initial_rating=1500, initial_rd=200)
+        opponents = [GlickoCompetitor(initial_rating=r, initial_rd=200) for r in (1200, 1400, 1500, 1600, 1800)]
+        scores = [base.expected_score(o) for o in opponents]
+        for earlier, later in zip(scores, scores[1:], strict=False):
+            self.assertGreater(earlier, later)
 
     def test_beat_with_known_values(self):
         """Test beat method with known values."""


### PR DESCRIPTION
Closes #71

## Problem
`GlickoCompetitor._g(x)` squares its argument internally, but `expected_score`
and the rating-update path passed **RD²** to it, so the g-function was evaluated
at **RD⁴**. The result: Glicko win probabilities collapsed to ≈0.5 regardless of
the rating gap — a 2500-vs-1500 pair returned `0.504` instead of ~0.98.

A second, smaller defect: `expected_score` used `self.rd`, but Glickman's Glicko-1
formula uses the *opponent's* deviation `g(RD_j)`.

The known-value test masked both — `tests/test_GlickoCompetitor_known_values.py`
computed its reference with `_g(300**2)  # Use rd squared as per the implementation`,
frozen to match the bug.

## Change (`elote/competitors/glicko.py`)
- `expected_score`: `self._g(self.rd**2)` → `self._g(competitor.rd)` — pass the
  opponent's RD directly, per `E = 1/(1 + 10^(-g(RD_j)(r_i − r_j)/400))`.
- `update_competitor_rating`: `self._g(competitor.rd**2)` → `self._g(competitor.rd)`
  (drop the extra square; already used the opponent's RD).

Tests:
- Recomputed both Glicko `expected_score` references with `_g(<opponent rd>)`
  instead of the `rd**2` workaround (`test_GlickoCompetitor_known_values.py`,
  `test_GlickoCompetitor.py`).
- Added gap-based regression assertions: large-gap magnitude (near 1 / near 0),
  symmetric pair equals 0.5, and monotonicity in the rating gap.

## Verification
- `GlickoCompetitor(2500).expected_score(GlickoCompetitor(1500))` → **0.979**
  (was 0.504); the symmetric call → **0.021**; equal ratings → **0.5**. `_g` is
  called with an RD value, never `rd**2`, at both sites.
- `make test` → **233 passed, 6 skipped**. The directional `beat`/`tied` and
  `rd_effect` invariants (winner up, loser down, RD shrinks) still hold.
- `make lint` (`ruff check .`) → **All checks passed!**
- `make typecheck` → `mypy elote` is clean (`Success: no issues found`) when run
  past a **pre-existing, environment-level** blocker: the installed `scipy-stubs`
  uses a PEP 695 `type` statement that mypy rejects under the repo's
  `python_version = "3.10"` target. This fails identically on the unmodified base
  tree (confirmed via `git stash`) and is unrelated to this diff — it touches no
  file this PR changes.
- Mutation check: reintroducing `_g(self.rd**2)` makes the new large-gap test and
  the corrected reference test fail (`0.5037 not > 0.9`); restoring the fix leaves
  the diff test-only.
