### PR TITLE
ci: efficiency + hygiene tuning

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,10 +11,10 @@ jobs:
       id-token: write
     steps:
       - name: Clone
-        uses: actions/checkout@v3
-      
+        uses: actions/checkout@v5
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,23 +9,27 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
-      
+      uses: actions/checkout@v5
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    
+
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
CI efficiency + hygiene tuning for GitHub Actions workflows.

- Bump `actions/checkout@v3 → v5` and `actions/setup-python@v4 → v5` in `pypi-publish.yml` and `test-suite.yml`
- Replace the `curl … astral.sh/uv/install.sh` uv bootstrap with `astral-sh/setup-uv@v5` (`enable-cache: true`) in `test-suite.yml` (Python version pin kept)
- Add `concurrency: cancel-in-progress` to `test-suite.yml` so superseded PR runs are cancelled (intentionally NOT added to the release-triggered `pypi-publish.yml`)
