### PR TITLE
Include draws in History confusion metrics

### DIFF
--- a/elote/arenas/base.py
+++ b/elote/arenas/base.py
@@ -150,7 +150,7 @@ class History:
 
         for bout in self.bouts:
             # Extract the actual winner and predicted probability
-            actual_winner = bout.actual_winner()
+            actual_winner = bout._normalized_outcome()
             predicted_prob = bout.predicted_outcome
 
             # Skip if we don't have both actual and predicted values
@@ -180,33 +180,6 @@ class History:
                 predicted_winner = "b"
             else:
                 predicted_winner = "draw"
-
-            # Normalize actual winner to 'a', 'b', or 'draw'
-            if isinstance(actual_winner, str):
-                actual_winner = actual_winner.lower()
-                if actual_winner in ["a", "win", "true", "1"]:
-                    actual_winner = "a"
-                elif actual_winner in ["b", "loss", "false", "0"]:
-                    actual_winner = "b"
-                else:
-                    actual_winner = "draw"
-            elif isinstance(actual_winner, (int, float)):
-                if actual_winner == 1:
-                    actual_winner = "a"
-                elif actual_winner == 0:
-                    actual_winner = "b"
-                elif actual_winner == 0.5:
-                    actual_winner = "draw"
-                else:
-                    # Skip if actual winner is not a recognized value
-                    logger.debug("Unrecognized actual_winner value: %s, skipping bout.", bout.outcome)
-                    skipped_bouts += 1
-                    continue
-            else:
-                # Skip if actual winner is not a recognized type
-                logger.debug("Unrecognized actual_winner type: %s, skipping bout.", type(bout.outcome))
-                skipped_bouts += 1
-                continue
 
             # Update confusion matrix
             if predicted_winner == "draw":
@@ -497,8 +470,10 @@ class History:
         )
 
         for bout in self.bouts:
+            actual = bout._normalized_outcome()
+
             # Skip if we don't have both actual and predicted values
-            if bout.actual_winner() is None or bout.predicted_outcome is None:
+            if actual is None or bout.predicted_outcome is None:
                 skipped_bouts += 1
                 continue
 
@@ -511,24 +486,6 @@ class History:
                 predicted = "b"
             else:
                 predicted = "draw"
-
-            # Determine actual outcome
-            actual = bout.actual_winner()
-            if isinstance(actual, (int, float)):
-                if actual == 1:
-                    actual = "a"
-                elif actual == 0:
-                    actual = "b"
-                elif actual == 0.5:
-                    actual = "draw"
-            elif isinstance(actual, str):
-                actual = actual.lower()
-                if actual in ["a", "win", "true", "1"]:
-                    actual = "a"
-                elif actual in ["b", "loss", "false", "0"]:
-                    actual = "b"
-                else:
-                    actual = "draw"
 
             # Count correct predictions
             if predicted == actual:
@@ -750,6 +707,25 @@ class Bout:
         self.outcome = outcome
         self.attributes = attributes or {}
 
+    def _normalized_outcome(self) -> Optional[str]:
+        if isinstance(self.outcome, str):
+            outcome = self.outcome.lower()
+            if outcome in ["win", "won", "1", "a", "true", "t", "yes", "y"]:
+                return "a"
+            if outcome in ["loss", "lost", "0", "b", "false", "f", "no", "n"]:
+                return "b"
+            if outcome in ["draw", "tie", "tied", "0.5", "d", "equal", "eq"]:
+                return "draw"
+        elif isinstance(self.outcome, (int, float)):
+            if self.outcome == 1:
+                return "a"
+            if self.outcome == 0:
+                return "b"
+            if self.outcome == 0.5:
+                return "draw"
+
+        return None
+
     def actual_winner(self) -> Optional[str]:
         """
         Return the actual winner of the bout based on the outcome.
@@ -757,23 +733,8 @@ class Bout:
         Returns:
             str or None: 'a' if a won, 'b' if b won, None if it was a draw or unclear
         """
-        if isinstance(self.outcome, str):
-            outcome_lower = self.outcome.lower()
-            if outcome_lower in ["win", "won", "1", "a", "true", "t", "yes", "y"]:
-                return "a"
-            elif outcome_lower in ["loss", "lost", "0", "b", "false", "f", "no", "n"]:
-                return "b"
-            elif outcome_lower in ["draw", "tie", "tied", "draw", "0.5", "d", "equal", "eq"]:
-                return None
-        elif isinstance(self.outcome, (int, float)):
-            if self.outcome == 1:
-                return "a"
-            elif self.outcome == 0:
-                return "b"
-            elif self.outcome == 0.5:
-                return None
-
-        return None
+        outcome = self._normalized_outcome()
+        return outcome if outcome in ["a", "b"] else None
 
     def true_positive(self, threshold: float = 0.5) -> bool:
         """Check if this bout is a true positive prediction.

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -116,6 +116,42 @@ class TestHistoryMetrics(unittest.TestCase):
             places=5,
         )
 
+    def test_calculate_metrics_includes_draws(self):
+        history = History()
+        history.bouts = [
+            Bout("a", "b", 0.8, "win"),
+            Bout("a", "b", 0.5, 0.5),
+            Bout("a", "b", 0.5, "tie"),
+            Bout("a", "b", 0.5, "draw"),
+            Bout("a", "b", 0.8, "loss"),
+            Bout("a", "b", 0.5, "win"),
+            Bout("a", "b", 0.2, "loss"),
+            Bout("a", "b", 0.2, "win"),
+            Bout("a", "b", 0.8, 0.5),
+            Bout("a", "b", 0.2, "tie"),
+            Bout("a", "b", 0.8, "draw"),
+            Bout("a", "b", None, "draw"),
+            Bout("a", "b", 0.5, None),
+            Bout("a", "b", 0.5, "unknown"),
+        ]
+
+        metrics = history.calculate_metrics(lower_threshold=0.4, upper_threshold=0.6)
+
+        self.assertEqual(metrics["confusion_matrix"], {"tp": 4, "fp": 2, "tn": 1, "fn": 4})
+        self.assertAlmostEqual(metrics["accuracy"], 5 / 11)
+        self.assertAlmostEqual(metrics["precision"], 2 / 3)
+        self.assertAlmostEqual(metrics["recall"], 1 / 2)
+        self.assertAlmostEqual(metrics["f1"], 4 / 7)
+
+    def test_optimize_thresholds_evaluates_draws(self):
+        history = History()
+        history.add_bout(Bout("a", "b", 0.5, "draw"))
+
+        accuracy, thresholds = history.optimize_thresholds(initial_thresholds=(0.5, 0.5))
+
+        self.assertEqual(accuracy, 1.0)
+        self.assertEqual(thresholds, [0.5, 0.5])
+
     def test_calculate_metrics_edge_cases(self):
         """Test that calculate_metrics handles edge cases correctly."""
         # Create a new empty history


### PR DESCRIPTION
Closes #75

## Summary

- normalize recognized bout outcomes separately from `actual_winner()` so draws remain distinguishable from missing or unknown results
- include correct draws, missed draws, and false draw predictions in the existing four confusion-matrix buckets
- cover exact draw-aware confusion counts, metric values, missing data, and threshold optimization

## Verification

- `uv run pytest -q` — 235 passed, 6 skipped, 21 subtests passed
- `uv run ruff check .` — passed
- `uv run mypy --python-version 3.12 elote` — passed
- `uv tool run --with 'tox==4.24.1' --with 'tox-uv==1.25.0' tox` — Python 3.10, 3.11, and 3.12 environments passed (241 tests each)
- mutation check: restored the early `actual_winner() is None` draw skip and confirmed both the exact-value metrics regression and threshold-optimization regression failed; restored the fix and reran the focused tests successfully
