### PR TITLE
Fix TrueSkill two-player expected-score variance term

### DIFF
--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -448,10 +448,11 @@ class TrueSkillCompetitor(BaseCompetitor):
         # Calculate the skill difference
         mu_diff = self._mu - competitor_ts._mu
 
-        # Calculate the total variance
+        # Calculate the total variance. Canonical two-player TrueSkill has
+        # independent performance noise for both players, so beta is counted twice.
         beta_squared = self._beta**2
         sigma_squared_sum = self._sigma**2 + competitor_ts._sigma**2
-        v = math.sqrt(beta_squared + sigma_squared_sum)
+        v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
         # Calculate the win probability
         t = mu_diff / v

--- a/tests/test_TrueSkillCompetitor.py
+++ b/tests/test_TrueSkillCompetitor.py
@@ -86,7 +86,9 @@ class TestTrueSkill(unittest.TestCase):
         # Test with equal ratings
         player1 = TrueSkillCompetitor(initial_mu=25, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25, initial_sigma=8.333)
-        self.assertAlmostEqual(player1.expected_score(player2), 0.335, places=3)  # Updated expected value
+        # Externally derived from sqrt(2*beta^2 + sigma_i^2 + sigma_j^2); the
+        # single-noise form gives ~0.335.
+        self.assertAlmostEqual(player1.expected_score(player2), 0.342657, places=5)
 
         # Test with different ratings
         player1 = TrueSkillCompetitor(initial_mu=30, initial_sigma=8.333)

--- a/tests/test_TrueSkillCompetitor_known_values.py
+++ b/tests/test_TrueSkillCompetitor_known_values.py
@@ -79,25 +79,41 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertAlmostEqual(draw_margin, expected_margin, places=3)
 
     def test_expected_score(self):
-        """Test expected_score with known values."""
-        # Test with equal ratings
+        """Test expected_score against externally derived reference probabilities.
+
+        Reference values are computed independently of ``expected_score`` from the
+        canonical two-player TrueSkill formula
+        ``win_prob = Phi(mu_diff / v) - draw_prob / 2`` where
+        ``v = sqrt(2*beta^2 + sigma_i^2 + sigma_j^2)`` (beta=4.166,
+        draw_probability=0.10). None of these assertions call the method under
+        test to derive its own expectation, and each fails if the beta^2 term is
+        mutated back to the single-noise ``sqrt(beta^2 + ...)`` form.
+        """
+        # Equal ratings: symmetric matchup. mu_diff=0 so win_prob=0.5, and the
+        # draw correction depends on v, so the missing beta^2 term still shifts
+        # the result (single-noise form gives ~0.335).
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
-        self.assertAlmostEqual(player1.expected_score(player2), 0.335, places=3)  # Updated expected value
+        self.assertAlmostEqual(player1.expected_score(player2), 0.342657, places=5)
 
-        # Test with different ratings
+        # Unequal means, equal sigmas: the corrected variance term materially
+        # softens the prediction (single-noise form gives ~0.761).
         player1 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
         player2 = TrueSkillCompetitor(initial_mu=20.0, initial_sigma=5.0)
-        expected_score = player1.expected_score(player2)  # Use actual value
-        self.assertAlmostEqual(player1.expected_score(player2), expected_score, places=3)
+        self.assertAlmostEqual(player1.expected_score(player2), 0.732131, places=5)
 
-        # Test with different sigmas
+        # Same matchup reversed: the weaker player. Probabilities are not required
+        # to sum to 1 because of the draw correction.
+        self.assertAlmostEqual(player2.expected_score(player1), 0.009389, places=5)
+
+        # Equal means, different sigmas (single-noise form gives ~0.287).
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=3.0)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.0)
         expected_score = player1.expected_score(player2)
-        # The expected score might be less than 0.3 in some implementations
-        self.assertGreaterEqual(expected_score, 0.25)
-        self.assertLess(expected_score, 0.4)
+        self.assertAlmostEqual(expected_score, 0.303476, places=5)
+        # Probability bounds remain covered.
+        self.assertGreaterEqual(expected_score, 0.0)
+        self.assertLessEqual(expected_score, 1.0)
 
     def test_beat_with_known_values(self):
         """Test beat method with known values."""


### PR DESCRIPTION
Closes #74

## What changed
`TrueSkillCompetitor.expected_score` computed the performance-difference standard deviation as `sqrt(beta² + sigma_i² + sigma_j²)`. Canonical two-player TrueSkill has **independent** performance noise for both players, so this term is `sqrt(2*beta² + sigma_i² + sigma_j²)` — the form `match_quality` already used. The single-noise version made the two prediction paths internally inconsistent and produced win probabilities that were too sharp.

- `elote/competitors/trueskill.py`: `expected_score` now uses `sqrt(2*beta² + sigma_i² + sigma_j²)`. The `beat`/`tied` update equations are intentionally left untouched (out of scope per the issue).
- `tests/test_TrueSkillCompetitor_known_values.py::test_expected_score`: replaced the self-referential assertions (which compared the method to its own output) with **fixed, externally derived** reference probabilities, added an unequal-mean case where old and corrected formulas differ materially (~0.761 → 0.732), added the reversed matchup, and kept symmetry + probability-bounds coverage.
- `tests/test_TrueSkillCompetitor.py::test_expected_score_calculation`: the equal-player assertion was frozen at the old-formula value `0.335`; updated to the corrected `0.342657`.

Reference values were derived independently of the method under test from `Phi(mu_diff / v) - draw_prob/2` with `v = sqrt(2*beta² + sigma_i² + sigma_j²)`, `beta=4.166`, `draw_probability=0.10`, then confirmed to match the implementation.

## Verification
- `uv run --extra dev pytest tests/test_TrueSkillCompetitor.py tests/test_TrueSkillCompetitor_known_values.py -q` → 23 passed.
- **Mutation check** (acceptance criterion): reverting the variance term to `sqrt(beta² + ...)` fails both `test_expected_score` and `test_expected_score_calculation`; restored the fix and re-ran green.
- Full suite: `uv run --extra dev pytest -q` → 233 passed, 6 skipped.
- Lint: `uv run --extra dev ruff check elote tests` → All checks passed; `ruff format --check` → already formatted.
