### PR TITLE
Correct TrueSkill win and draw update equations

### DIFF
--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -411,7 +411,7 @@ class TrueSkillCompetitor(BaseCompetitor):
         cdf_1 = self._gaussian_cdf(t - epsilon)
         cdf_2 = self._gaussian_cdf(t + epsilon)
         denominator = cdf_2 - cdf_1
-        return v**2 + ((t - epsilon) * pdf_1 - (t + epsilon) * pdf_2) / denominator if denominator > 0 else 0
+        return v**2 + ((epsilon - t) * pdf_1 + (epsilon + t) * pdf_2) / denominator if denominator > 0 else 0
 
     @staticmethod
     def _calculate_draw_margin(beta: float, draw_probability: float) -> float:
@@ -491,35 +491,34 @@ class TrueSkillCompetitor(BaseCompetitor):
         # Calculate the skill difference
         mu_diff = self._mu - competitor_ts._mu
 
-        # Calculate the total variance
+        # Apply the dynamic factor before incorporating the match result.
+        sigma_squared_1 = self._sigma**2 + self._tau**2
+        sigma_squared_2 = competitor_ts._sigma**2 + competitor_ts._tau**2
+
+        # Calculate the total performance-difference variance
         beta_squared = self._beta**2
-        sigma_squared_1 = self._sigma**2
-        sigma_squared_2 = competitor_ts._sigma**2
         sigma_squared_sum = sigma_squared_1 + sigma_squared_2
-        v = math.sqrt(beta_squared + sigma_squared_sum)
+        v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
         # Calculate the performance update
-        t = mu_diff / v
+        draw_margin = math.sqrt(2) * self._beta * special.ndtri((self._draw_probability + 1) / 2)
+        t = (mu_diff - draw_margin) / v
         v_win_value = self._v_win(t)
         w_win_value = self._w_win(t)
 
         # Update the winner's mu and sigma
         sigma_squared_to_v_squared = sigma_squared_1 / v**2
-        self._mu = self._mu + sigma_squared_to_v_squared * v_win_value
+        self._mu = self._mu + sigma_squared_1 / v * v_win_value
         self._sigma = math.sqrt(sigma_squared_1 * (1 - sigma_squared_to_v_squared * w_win_value))
 
         logger.debug("Winner update: new_mu=%.2f, new_sigma=%.2f", self._mu, self._sigma)
         # Update the loser's mu and sigma
         sigma_squared_to_v_squared = sigma_squared_2 / v**2
-        competitor_ts._mu = competitor_ts._mu - sigma_squared_to_v_squared * v_win_value
+        competitor_ts._mu = competitor_ts._mu - sigma_squared_2 / v * v_win_value
         competitor_ts._sigma = math.sqrt(sigma_squared_2 * (1 - sigma_squared_to_v_squared * w_win_value))
         logger.debug(
             "Loser update (%s): new_mu=%.2f, new_sigma=%.2f", competitor_ts, competitor_ts._mu, competitor_ts._sigma
         )
-
-        # Apply the dynamic factor to increase uncertainty over time
-        self._sigma = math.sqrt(self._sigma**2 + self._tau**2)
-        competitor_ts._sigma = math.sqrt(competitor_ts._sigma**2 + self._tau**2)
 
     def tied(self, competitor: BaseCompetitor) -> None:
         """Update ratings after this competitor has tied with the given competitor.
@@ -537,15 +536,17 @@ class TrueSkillCompetitor(BaseCompetitor):
         # Calculate the skill difference
         mu_diff = self._mu - competitor_ts._mu
 
-        # Calculate the total variance
+        # Apply the dynamic factor before incorporating the match result.
+        sigma_squared_1 = self._sigma**2 + self._tau**2
+        sigma_squared_2 = competitor_ts._sigma**2 + competitor_ts._tau**2
+
+        # Calculate the total performance-difference variance
         beta_squared = self._beta**2
-        sigma_squared_1 = self._sigma**2
-        sigma_squared_2 = competitor_ts._sigma**2
         sigma_squared_sum = sigma_squared_1 + sigma_squared_2
-        v = math.sqrt(beta_squared + sigma_squared_sum)
+        v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
         # Calculate the draw margin
-        draw_margin = self._calculate_draw_margin(self._beta, self._draw_probability)
+        draw_margin = math.sqrt(2) * self._beta * special.ndtri((self._draw_probability + 1) / 2)
 
         # Calculate the performance update for a draw
         t = mu_diff / v
@@ -554,13 +555,13 @@ class TrueSkillCompetitor(BaseCompetitor):
 
         # Update the first player's mu and sigma
         sigma_squared_to_v_squared = sigma_squared_1 / v**2
-        self._mu = self._mu + sigma_squared_to_v_squared * v_draw_value
+        self._mu = self._mu - sigma_squared_1 / v * v_draw_value
         self._sigma = math.sqrt(sigma_squared_1 * (1 - sigma_squared_to_v_squared * w_draw_value))
 
         logger.debug("Player 1 tie update: new_mu=%.2f, new_sigma=%.2f", self._mu, self._sigma)
         # Update the second player's mu and sigma
         sigma_squared_to_v_squared = sigma_squared_2 / v**2
-        competitor_ts._mu = competitor_ts._mu - sigma_squared_to_v_squared * v_draw_value
+        competitor_ts._mu = competitor_ts._mu + sigma_squared_2 / v * v_draw_value
         competitor_ts._sigma = math.sqrt(sigma_squared_2 * (1 - sigma_squared_to_v_squared * w_draw_value))
         logger.debug(
             "Player 2 tie update (%s): new_mu=%.2f, new_sigma=%.2f",
@@ -568,10 +569,6 @@ class TrueSkillCompetitor(BaseCompetitor):
             competitor_ts._mu,
             competitor_ts._sigma,
         )
-
-        # Apply the dynamic factor to increase uncertainty over time
-        self._sigma = math.sqrt(self._sigma**2 + self._tau**2)
-        competitor_ts._sigma = math.sqrt(competitor_ts._sigma**2 + self._tau**2)
 
     @classmethod
     def match_quality(cls, player1: "TrueSkillCompetitor", player2: "TrueSkillCompetitor") -> float:

--- a/tests/test_TrueSkillCompetitor.py
+++ b/tests/test_TrueSkillCompetitor.py
@@ -109,10 +109,8 @@ class TestTrueSkill(unittest.TestCase):
         player1.tied(player2)
 
         # The higher-rated player should lose rating, and the lower-rated player should gain rating
-        self.assertGreater(player1.mu, initial_mu1 - 1)  # Allow for small changes
-        self.assertLess(player1.mu, initial_mu1 + 1)
-        self.assertGreater(player2.mu, initial_mu2 - 1)
-        self.assertLess(player2.mu, initial_mu2 + 1)
+        self.assertLess(player1.mu, initial_mu1)
+        self.assertGreater(player2.mu, initial_mu2)
 
     def test_reset(self):
         """Test that reset returns the competitor to its initial state."""

--- a/tests/test_TrueSkillCompetitor_known_values.py
+++ b/tests/test_TrueSkillCompetitor_known_values.py
@@ -116,7 +116,7 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertLessEqual(expected_score, 1.0)
 
     def test_beat_with_known_values(self):
-        """Test beat method with known values."""
+        """Test beat against values from the trueskill 0.4.5 reference implementation."""
         # Create players with specific ratings
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
@@ -129,6 +129,11 @@ class TestTrueSkillKnownValues(unittest.TestCase):
 
         # Player1 beats player2
         player1.beat(player2)
+
+        self.assertAlmostEqual(player1.mu, 29.395741, places=5)
+        self.assertAlmostEqual(player1.sigma, 7.171128, places=5)
+        self.assertAlmostEqual(player2.mu, 20.604259, places=5)
+        self.assertAlmostEqual(player2.sigma, 7.171128, places=5)
 
         # Player1's mu should increase
         self.assertGreater(player1.mu, initial_mu1)
@@ -162,7 +167,7 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertGreater(mu_change, 0.5)  # Updated to a more realistic value
 
     def test_tied_with_known_values(self):
-        """Test tied method with known values."""
+        """Test tied against values from the trueskill 0.4.5 reference implementation."""
         # Create players with equal ratings
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
@@ -195,11 +200,14 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         # Players tie
         player1.tied(player2)
 
+        self.assertAlmostEqual(player1.mu, 27.054816, places=5)
+        self.assertAlmostEqual(player1.sigma, 4.200224, places=5)
+        self.assertAlmostEqual(player2.mu, 22.945184, places=5)
+        self.assertAlmostEqual(player2.sigma, 4.200224, places=5)
+
         # Check that mu values change in the expected direction
-        # Note: In some implementations, the higher-rated player's mu might increase slightly
-        # and the lower-rated player's mu might decrease
-        self.assertNotEqual(player1.mu, initial_mu1)
-        self.assertNotEqual(player2.mu, initial_mu2)
+        self.assertLess(player1.mu, initial_mu1)
+        self.assertGreater(player2.mu, initial_mu2)
 
     def test_match_quality(self):
         """Test match quality calculation with known values."""


### PR DESCRIPTION
Closes #79

## Summary

- correct two-player TrueSkill win and draw updates to use both performance-noise terms and canonical mean/variance scaling
- apply dynamic uncertainty before the factor update and condition results on the canonical draw margin
- add fixed mu/sigma regressions against trueskill 0.4.5 for an equal-player win and an unequal-player draw
- replace the broad draw assertions frozen around the reversed update with toward-each-other checks

## Verification

- `make test` — 235 passed, 6 skipped
- `make test-all` — 241 passed on each of Python 3.10, 3.11, and 3.12
- `make lint` — passed
- `make typecheck` — passed (24 source files)
- `git diff --check` — passed
- Mutation check: changing the winner mean multiplier back from `sigma²/c` to `sigma²/c²` failed `test_beat_with_known_values` (25.333621 vs 29.395741).
- Mutation check: reversing the higher-rated player draw correction failed `test_tied_with_known_values` (32.945184 vs 27.054816).
