### PR TITLE
Fix ECF delta clamp symmetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+==========
+
+Bug fixes
+
+ * Fixed ECF rating updates to apply the rating-difference cap independently for each competitor.
+
 v1.2.0
 ======
 

--- a/elote/competitors/ecf.py
+++ b/elote/competitors/ecf.py
@@ -335,6 +335,9 @@ class ECFCompetitor(BaseCompetitor):
         their_transformed = competitor_ecf.transformed_elo_rating
         return my_transformed / (their_transformed + my_transformed)
 
+    def _clamp_opponent_rating(self, own_rating: float, opponent_rating: float) -> float:
+        return max(own_rating - self._delta, min(own_rating + self._delta, opponent_rating))
+
     def beat(self, competitor: BaseCompetitor) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
@@ -358,14 +361,11 @@ class ECFCompetitor(BaseCompetitor):
         self_rating = self.rating
         competitors_rating = competitor_ecf.rating
 
-        if abs(self_rating - competitors_rating) > self._delta:
-            if self_rating > competitors_rating:
-                competitors_rating = self_rating - self._delta
-            else:
-                competitors_rating = self_rating + self._delta
+        opponent_rating_for_self = self._clamp_opponent_rating(self_rating, competitors_rating)
+        opponent_rating_for_competitor = self._clamp_opponent_rating(competitors_rating, self_rating)
 
-        performance_rating_self = competitors_rating + self._delta
-        performance_rating_competitor = self_rating - self._delta
+        performance_rating_self = opponent_rating_for_self + self._delta
+        performance_rating_competitor = opponent_rating_for_competitor - self._delta
 
         # Update scores
         self._update(performance_rating_self)
@@ -394,14 +394,8 @@ class ECFCompetitor(BaseCompetitor):
         self_rating = self.rating
         competitors_rating = competitor_ecf.rating
 
-        if abs(self_rating - competitors_rating) > self._delta:
-            if self_rating > competitors_rating:
-                competitors_rating = self_rating - self._delta
-            else:
-                competitors_rating = self_rating + self._delta
-
-        performance_rating_self = competitors_rating
-        performance_rating_competitor = self_rating
+        performance_rating_self = self._clamp_opponent_rating(self_rating, competitors_rating)
+        performance_rating_competitor = self._clamp_opponent_rating(competitors_rating, self_rating)
 
         # Update scores
         self._update(performance_rating_self)

--- a/tests/test_ECFCompetitor_known_values.py
+++ b/tests/test_ECFCompetitor_known_values.py
@@ -100,6 +100,40 @@ class TestECFKnownValues(unittest.TestCase):
         # After beat, player1's scores deque contains [100, 150+50] = [100, 200]
         # So the mean is (100 + 200) / 2 = 150
         self.assertEqual(player1.rating, 150)
+        self.assertEqual(player2.rating, 150)
+
+    def test_expected_result_outside_delta_leaves_ratings_unchanged(self):
+        """Test that an expected result outside the delta changes neither rating."""
+        stronger = ECFCompetitor(initial_rating=200)
+        weaker = ECFCompetitor(initial_rating=100)
+
+        stronger.beat(weaker)
+
+        self.assertEqual(stronger.rating, 200)
+        self.assertEqual(weaker.rating, 100)
+
+    def test_draw_outside_delta_with_known_values(self):
+        """Test a draw between players whose ratings differ by more than delta."""
+        stronger = ECFCompetitor(initial_rating=200)
+        weaker = ECFCompetitor(initial_rating=100)
+
+        stronger.tied(weaker)
+
+        self.assertEqual(stronger.rating, 175)
+        self.assertEqual(weaker.rating, 125)
+
+    def test_draw_outside_delta_is_independent_of_argument_order(self):
+        """Test that reversing the caller does not change draw updates."""
+        stronger_first = ECFCompetitor(initial_rating=200)
+        weaker_second = ECFCompetitor(initial_rating=100)
+        stronger_first.tied(weaker_second)
+
+        weaker_first = ECFCompetitor(initial_rating=100)
+        stronger_second = ECFCompetitor(initial_rating=200)
+        weaker_first.tied(stronger_second)
+
+        self.assertEqual(stronger_first.rating, stronger_second.rating)
+        self.assertEqual(weaker_second.rating, weaker_first.rating)
 
     def test_scores_deque_behavior(self):
         """Test that the scores deque behaves correctly with maxlen."""


### PR DESCRIPTION
Closes #84

## Summary

- clamp each competitor’s opponent rating independently in both `beat` and `tied`
- add exact regressions for an expected win, an upset, a draw, and draw argument-order symmetry
- extend the existing delta-limit test to assert both competitors and document the user-visible correction in the changelog

All `test_*ECF*` files were searched for frozen numeric assertions. The only affected fixture was `tests/test_ECFCompetitor_known_values.py::test_delta_limit`; its existing winner assertion remains correct and the missing opponent assertion is now included. The existing 120-vs-100 known-value test continues to assert the unchanged 135/85 within-delta result.

## Verification

- `make test` — 238 passed, 6 skipped
- `make lint` — passed
- `make typecheck` — the Make target exited successfully, but its mypy invocation reports the pre-existing `scipy-stubs` Python-3.10 syntax incompatibility before checking Elote
- `uv run mypy --python-version 3.12 elote` — passed, 24 source files checked
- `uv run pytest tests/test_ECFCompetitor.py tests/test_ECFCompetitor_known_values.py -q` — 14 passed
- `git diff --check` — passed

I also reinstated the exact one-sided clamp and confirmed the mutation was present before rerunning the known-value file. Four assertions failed as intended: the two-sided upset delta check, expected-result invariant, draw known value, and draw argument-order symmetry. The original 120-vs-100 within-delta assertions remained green.
