### PR TITLE
Fix Glicko-2 triple RD inflation and non-simultaneous rating updates

### DIFF
--- a/elote/competitors/glicko2.py
+++ b/elote/competitors/glicko2.py
@@ -1,11 +1,21 @@
 import math
-from typing import Dict, Any, ClassVar, Type, TypeVar, Optional, List, Tuple, cast
+from typing import Dict, Any, ClassVar, NamedTuple, Type, TypeVar, Optional, List, cast
 from datetime import datetime
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
 from elote.logging import logger  # Import directly from the logging submodule
 
 T = TypeVar("T", bound="Glicko2Competitor")
+
+
+class _MatchResult(NamedTuple):
+    """A recorded match result plus the opponent's pre-match Glicko-2 scale state."""
+
+    opponent: "Glicko2Competitor"
+    score: float
+    match_time: datetime
+    opponent_mu: float
+    opponent_phi: float
 
 
 class Glicko2Competitor(BaseCompetitor):
@@ -82,7 +92,7 @@ class Glicko2Competitor(BaseCompetitor):
         self._rd = initial_rd
 
         # Store match results for rating period and track last activity
-        self._match_results: List[Tuple["Glicko2Competitor", float, datetime]] = []
+        self._match_results: List[_MatchResult] = []
         self._last_activity = initial_time if initial_time is not None else datetime.now()
 
         logger.debug(
@@ -485,6 +495,10 @@ class Glicko2Competitor(BaseCompetitor):
         increases based on the current volatility (sigma) parameter and the number
         of rating periods that have passed.
 
+        The last-activity timestamp is advanced to ``current_time`` so that the
+        inflation is applied exactly once per elapsed period: calling this method
+        repeatedly with the same timestamp is a no-op after the first call.
+
         Args:
             current_time (datetime, optional): The current time to calculate inactivity against.
                 If None, uses the current system time.
@@ -508,6 +522,7 @@ class Glicko2Competitor(BaseCompetitor):
                 logger.debug("RD capped at 350 (was %.1f)", self._rd)
                 self._rd = 350
                 self._phi = self._rd_to_phi(350)
+            self._last_activity = current_time
             logger.debug(
                 "Updated RD for %s due to inactivity (%.1f periods): %.1f -> %.1f",
                 self,
@@ -531,7 +546,7 @@ class Glicko2Competitor(BaseCompetitor):
             return
 
         # Get the most recent match time
-        current_time = max(match_time for _, _, match_time in self._match_results)
+        current_time = max(result.match_time for result in self._match_results)
 
         # Update RD for inactivity before processing matches
         logger.debug("Updating RD for %s before processing %d matches.", self, len(self._match_results))
@@ -549,14 +564,15 @@ class Glicko2Competitor(BaseCompetitor):
         # Step 2: For each opponent j, compute g(phi_j) and E(mu, mu_j, phi_j)
         v_inv = 0.0
         delta_sum = 0.0
-        for opponent, score, _ in self._match_results:
-            self.verify_competitor_types(opponent)
-            opponent_glicko2 = cast(Glicko2Competitor, opponent)
-            phi_j = self._rd_to_phi(opponent.rd)
+        for result in self._match_results:
+            self.verify_competitor_types(result.opponent)
+            # Read the opponent's state as recorded at match time, so that both players
+            # of a bout update against the same pre-match snapshot.
+            phi_j = result.opponent_phi
             g_j = self._g(phi_j)
-            E_j = self._E(mu, opponent_glicko2._mu, phi_j)
+            E_j = self._E(mu, result.opponent_mu, phi_j)
             v_inv += g_j**2 * E_j * (1 - E_j)
-            delta_sum += g_j * (score - E_j)
+            delta_sum += g_j * (result.score - E_j)
 
         # Step 3: Compute v and delta
         v = 1 / v_inv
@@ -658,51 +674,7 @@ class Glicko2Competitor(BaseCompetitor):
         """
         self.verify_competitor_types(competitor)
         logger.debug("%s beat %s (time=%s). Recording result.", self, competitor, match_time)
-        competitor_glicko2 = cast(Glicko2Competitor, competitor)
-
-        # Get the match time
-        current_time = match_time if match_time is not None else datetime.now()
-
-        # Validate match time is not before last activity
-        if current_time < self._last_activity:
-            logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
-            raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor_glicko2._last_activity:
-            logger.error(
-                "Match time %s is before opponent last activity %s", current_time, competitor_glicko2._last_activity
-            )
-            raise InvalidParameterException("Match time cannot be before opponent's last activity time")
-
-        # Update RDs for both competitors based on inactivity before recording match
-        self.update_rd_for_inactivity(current_time)
-        competitor_glicko2.update_rd_for_inactivity(current_time)
-
-        # Get the match time
-        current_time = match_time if match_time is not None else datetime.now()
-
-        # Validate match time is not before last activity
-        if current_time < self._last_activity:
-            logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
-            raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor_glicko2._last_activity:
-            logger.error(
-                "Match time %s is before opponent last activity %s", current_time, competitor_glicko2._last_activity
-            )
-            raise InvalidParameterException("Match time cannot be before opponent's last activity time")
-
-        # Update RDs for both competitors based on inactivity before recording match
-        self.update_rd_for_inactivity(current_time)
-        competitor_glicko2.update_rd_for_inactivity(current_time)
-
-        # Record the match result for this competitor
-        self._match_results.append((competitor_glicko2, 1.0, current_time))
-
-        # Record the match result for the opponent
-        competitor_glicko2._match_results.append((self, 0.0, current_time))
-
-        # Update ratings immediately
-        self.update_ratings()
-        competitor_glicko2.update_ratings()
+        self._compute_match_result(cast(Glicko2Competitor, competitor), s=1.0, match_time=match_time)
 
     def tied(self, competitor: BaseCompetitor, match_time: Optional[datetime] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
@@ -720,48 +692,45 @@ class Glicko2Competitor(BaseCompetitor):
         """
         self.verify_competitor_types(competitor)
         logger.debug("%s tied with %s (time=%s). Recording result.", self, competitor, match_time)
-        competitor_glicko2 = cast(Glicko2Competitor, competitor)
+        self._compute_match_result(cast(Glicko2Competitor, competitor), s=0.5, match_time=match_time)
 
-        # Get the match time
+    def _compute_match_result(
+        self, competitor: "Glicko2Competitor", s: float, match_time: Optional[datetime] = None
+    ) -> None:
+        """Record a match result for both competitors and update both ratings.
+
+        Both players' updates are computed from the same pre-match snapshot: inactivity
+        is applied once to each competitor, each competitor's Glicko-2 scale state is
+        then recorded on the opponent's match result, and only afterwards are the two
+        ratings updated. Without the snapshot the second update would read the first
+        player's already-updated rating and RD.
+
+        Args:
+            competitor (Glicko2Competitor): The opponent competitor.
+            s (float): The score of this competitor (1 for win, 0.5 for draw, 0 for loss).
+            match_time (datetime, optional): The time when the match occurred. Default: current time.
+
+        Raises:
+            InvalidParameterException: If the match time is before either competitor's last activity.
+        """
         current_time = match_time if match_time is not None else datetime.now()
 
         # Validate match time is not before last activity
         if current_time < self._last_activity:
             logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
             raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor_glicko2._last_activity:
-            logger.error(
-                "Match time %s is before opponent last activity %s", current_time, competitor_glicko2._last_activity
-            )
+        if current_time < competitor._last_activity:
+            logger.error("Match time %s is before opponent last activity %s", current_time, competitor._last_activity)
             raise InvalidParameterException("Match time cannot be before opponent's last activity time")
 
-        # Update RDs for both competitors based on inactivity before recording match
+        # Update RDs for both competitors based on inactivity before recording the match
         self.update_rd_for_inactivity(current_time)
-        competitor_glicko2.update_rd_for_inactivity(current_time)
+        competitor.update_rd_for_inactivity(current_time)
 
-        # Get the match time
-        current_time = match_time if match_time is not None else datetime.now()
-
-        # Validate match time is not before last activity
-        if current_time < self._last_activity:
-            logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
-            raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor_glicko2._last_activity:
-            logger.error(
-                "Match time %s is before opponent last activity %s", current_time, competitor_glicko2._last_activity
-            )
-            raise InvalidParameterException("Match time cannot be before opponent's last activity time")
-
-        # Update RDs for both competitors based on inactivity before recording match
-        self.update_rd_for_inactivity(current_time)
-        competitor_glicko2.update_rd_for_inactivity(current_time)
-
-        # Record the match result for this competitor
-        self._match_results.append((competitor_glicko2, 0.5, current_time))
-
-        # Record the match result for the opponent
-        competitor_glicko2._match_results.append((self, 0.5, current_time))
+        # Record the match result for each competitor against the other's pre-match state
+        self._match_results.append(_MatchResult(competitor, s, current_time, competitor._mu, competitor._phi))
+        competitor._match_results.append(_MatchResult(self, 1.0 - s, current_time, self._mu, self._phi))
 
         # Update ratings immediately
         self.update_ratings()
-        competitor_glicko2.update_ratings()
+        competitor.update_ratings()

--- a/tests/test_Glicko2Competitor_known_values.py
+++ b/tests/test_Glicko2Competitor_known_values.py
@@ -173,6 +173,108 @@ class TestGlicko2KnownValues(unittest.TestCase):
         # The rating change with higher RD should be greater
         self.assertGreater(rating_change_high_rd, rating_change_low_rd)
 
+    def test_inactivity_update_is_idempotent(self):
+        """Repeated inactivity updates for the same timestamp must inflate RD only once."""
+        initial_time = datetime(2020, 1, 1)
+        match_time = initial_time + timedelta(days=10)
+        player = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+
+        # sqrt((200 / 173.7178)^2 + 10 * 0.06^2) * 173.7178
+        player.update_rd_for_inactivity(match_time)
+        self.assertAlmostEqual(player.rd, 202.6978, places=4)
+
+        # Applying the same timestamp again must be a no-op
+        player.update_rd_for_inactivity(match_time)
+        self.assertAlmostEqual(player.rd, 202.6978, places=4)
+        player.update_rd_for_inactivity(match_time)
+        self.assertAlmostEqual(player.rd, 202.6978, places=4)
+
+    def test_single_match_applies_inactivity_once(self):
+        """A single timestamped match must inflate RD for inactivity exactly once."""
+        initial_time = datetime(2020, 1, 1)
+        match_time = initial_time + timedelta(days=10)
+        player1 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        player2 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+
+        reference = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        reference.update_rd_for_inactivity(match_time)
+        # phi used by the match update is the once-inflated one, so v (and therefore the
+        # posterior RD) must match what a single inactivity update produces.
+        expected_phi = reference._phi
+
+        player1.beat(player2, match_time=match_time)
+        v = 1 / (player1._g(expected_phi) ** 2 * 0.25)
+        phi_star_sq = expected_phi**2 + player1.volatility**2
+        expected_rd = 173.7178 / math.sqrt(1 / phi_star_sq + 1 / v)
+        self.assertAlmostEqual(player1.rd, expected_rd, places=6)
+
+    def test_symmetric_match_has_no_rating_drift(self):
+        """Two identical competitors must end a match with equal RD and zero rating drift."""
+        initial_time = datetime(2020, 1, 1)
+        match_time = initial_time + timedelta(days=10)
+
+        player1 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        player2 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        player1.beat(player2, match_time=match_time)
+        self.assertEqual(player1.rd, player2.rd)
+        self.assertEqual(player1.volatility, player2.volatility)
+        self.assertAlmostEqual(player1.rating + player2.rating, 3000.0, places=9)
+
+        # The same must hold on the default (untimestamped) path.
+        player1 = Glicko2Competitor(initial_rating=1500, initial_rd=200, initial_volatility=0.06)
+        player2 = Glicko2Competitor(initial_rating=1500, initial_rd=200, initial_volatility=0.06)
+        player1.beat(player2)
+        self.assertAlmostEqual(player1.rd, player2.rd, places=6)
+        self.assertAlmostEqual(player1.rating + player2.rating, 3000.0, places=6)
+
+    def test_symmetric_tie_leaves_ratings_unchanged(self):
+        """A draw between two identical competitors must not move either rating."""
+        initial_time = datetime(2020, 1, 1)
+        match_time = initial_time + timedelta(days=10)
+
+        player1 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        player2 = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        player1.tied(player2, match_time=match_time)
+        self.assertAlmostEqual(player1.rating, 1500.0, places=9)
+        self.assertAlmostEqual(player2.rating, 1500.0, places=9)
+        self.assertEqual(player1.rd, player2.rd)
+
+    def test_beat_known_values_ten_day_gap(self):
+        """Pin the posterior state for the documented 1500/200/0.06, 10-day-gap match."""
+        initial_time = datetime(2020, 1, 1)
+        match_time = initial_time + timedelta(days=10)
+
+        winner = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        loser = Glicko2Competitor(
+            initial_rating=1500, initial_rd=200, initial_volatility=0.06, initial_time=initial_time
+        )
+        winner.beat(loser, match_time=match_time)
+
+        self.assertAlmostEqual(winner.rating, 1580.327992, places=6)
+        self.assertAlmostEqual(winner.rd, 182.167363, places=6)
+        self.assertAlmostEqual(winner.volatility, 0.059999626, places=9)
+        self.assertAlmostEqual(loser.rating, 1419.672008, places=6)
+        self.assertAlmostEqual(loser.rd, 182.167363, places=6)
+        self.assertAlmostEqual(loser.volatility, 0.059999626, places=9)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #83

## What was wrong

`Glicko2Competitor.beat` and `.tied` were each built from a byte-identical duplicated block — the same match-time resolution, the same two validations, and the same pair of `update_rd_for_inactivity(current_time)` calls — and then handed off to `update_ratings()`, which applied inactivity a third time. `update_rd_for_inactivity` never advanced `_last_activity` (only `update_ratings()` did), so each call inflated `phi` from the same baseline: `rd` went 202.6978 → 205.3602 → 207.9885 for one/two/three calls with the same timestamp.

Separately, the two players were updated **sequentially**. `update_ratings()` read the opponent's *live* `rd` and `_mu` inside its loop, so the second player's update ran against the first player's already-updated rating and RD. Glickman's algorithm requires both updates to use the same pre-match snapshot; Glicko-1's `_compute_match_result` already did this correctly.

## What changed (`elote/competitors/glicko2.py` only)

1. **Deduplicated `beat`/`tied`** onto a shared `_compute_match_result(competitor, s, match_time)`, mirroring Glicko-1's structure. Both duplicated blocks are gone; `beat`/`tied` signatures are unchanged.
2. **Made `update_rd_for_inactivity` idempotent** by advancing `_last_activity` to `current_time` when it applies inflation. This is the "one owner" option from the issue: `update_ratings()`'s call is now a no-op when `_compute_match_result` has already applied it, and the method is safe to call repeatedly.
3. **Made the pair update simultaneous.** `_match_results` entries are now a `_MatchResult` NamedTuple that carries the opponent's pre-match `(mu, phi)` alongside the score and match time; `update_ratings()` reads that recorded snapshot instead of the live opponent object.

Only `mu` and `phi` are snapshotted — those are the only opponent fields `update_ratings()` consumes (the opponent's `sigma` is never read, and `rd` is only used to derive `phi`). `_match_results` is private and not serialized, so this is not a state-format change.

### Numbers

Two players at `1500 / rd=200 / sigma=0.06`, `_last_activity` at t0, match 10 days later:

| | winner | loser | rating-sum drift |
|---|---|---|---|
| before | 1583.51 (rd 186.10) | 1431.85 (rd 185.87) | +15.37 |
| after | 1580.328 (rd 182.167) | 1419.672 (rd 182.167) | 0.00 |

The untimestamped path (`a.beat(b)` from equal defaults) drifted +45.67 before and is now zero to floating-point tolerance.

## Frozen tests

I grepped every `test_*Glicko2*` file for assertions frozen around the old behaviour. **None were found** — the existing Glicko-2 tests are all directional (`assertGreater`/`assertLess`) or assert values that inactivity/match updates don't pin, so no existing assertion needed correcting. All 13 pre-existing Glicko-2 tests pass unmodified. The only test-file change is the five new tests appended to `tests/test_Glicko2Competitor_known_values.py`.

I also ran the cross-competitor invariant sweep (win-drift and tie-symmetry for every class in `elote.__init__`): Glicko-2 now reports `win-drift=+0.0000`, joining Elo/Glicko-1/ECF/Colley/Bradley-Terry/TrueSkill. DWZ's nonzero drift is pre-existing and legitimate (its development coefficient depends on games played and age).

## CHANGELOG

Deliberately **not** touched. This repo maintains `CHANGELOG.md` at release-prep time — the file has version headings only (no `Unreleased` section) and none of the recent numeric-correctness PRs (#73, #77, #78, #80, #85) added an entry. This fix should be listed in the next release's section along with those.

## Verification

Commands run in this worktree:

- `uv run pytest tests/ -q --ignore=tests/test_examples.py` → **238 passed, 6 skipped**.
- `tests/test_examples.py` fails 16/17 both on this branch **and on a clean `master` tree** (verified via `git stash`). Cause is environmental, not this diff: the tests shell out with `subprocess.run([sys.executable, script])` and that interpreter has no `elote` installed (`ModuleNotFoundError: No module named 'elote'`). Every example runs fine directly — `uv run python examples/glicko2_example.py` etc.
- `make lint` (`ruff check .`) → **All checks passed!**
- `uv run ruff format --check` on both changed files → **2 files already formatted**.
- `make typecheck` fails on a pre-existing, environmental issue unrelated to this diff: `scipy-stubs/__init__.pyi:74` uses PEP 695 `type` syntax that mypy rejects under the repo's `python_version = "3.10"` target, aborting before `elote` is checked (reproduces on a clean tree). `elote` itself is clean: `uv run mypy --python-version 3.12 elote` → **Success: no issues found in 24 source files**.

### Mutation testing (tests are not vacuous)

Each mutation was applied with `sed`-equivalent in-place rewrites and **grep-verified to have landed** before running the suite, then reverted from a saved copy.

**Mutation A — reinstate the non-idempotent inactivity** (drop the `self._last_activity = current_time` advance, restoring triple inflation). 3 failed / 10 passed:
- `test_inactivity_update_is_idempotent` — `205.3602 != 202.6978`
- `test_single_match_applies_inactivity_once` — `184.0824 != 182.1674`
- `test_beat_known_values_ten_day_gap` — `1582.0258 != 1580.3280`

**Mutation B — reinstate the sequential update** (read `result.opponent.rd` / `result.opponent._mu` live instead of the recorded snapshot). 3 failed / 10 passed:
- `test_symmetric_match_has_no_rating_drift` — `182.1674 != 181.8440`
- `test_symmetric_tie_leaves_ratings_unchanged` — `182.1674 != 181.1200`
- `test_beat_known_values_ten_day_gap` — `1433.8797 != 1419.6720`

The two mutations are caught by **disjoint** test sets apart from the known-value pin, so each half of the fix carries its own guard: the idempotency tests guard the inactivity half, the symmetry/zero-drift tests guard the simultaneity half, and `test_beat_known_values_ten_day_gap` pins the combined result. Note that the zero-drift tests alone would *not* catch Mutation A — symmetric triple inflation still nets zero drift — which is why the explicit RD-value assertions are needed.

After reverting both mutations the suite is green again and `git diff` shows only the intended change.
