### PR TITLE
Fix TrueSkill conservative rating ordering

### DIFF
--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -246,7 +246,7 @@ class TrueSkillCompetitor(BaseCompetitor):
         Returns:
             float: The current conservative rating.
         """
-        return max(self._mu - 3 * self._sigma, self._minimum_rating)
+        return self._mu - 3 * self._sigma
 
     @rating.setter
     def rating(self, value: float) -> None:

--- a/tests/test_TrueSkillCompetitor.py
+++ b/tests/test_TrueSkillCompetitor.py
@@ -1,6 +1,6 @@
 import unittest
 import math
-from elote import TrueSkillCompetitor, EloCompetitor
+from elote import TrueSkillCompetitor, EloCompetitor, LambdaArena
 from elote.competitors.base import MissMatchedCompetitorTypesException, InvalidParameterException
 
 
@@ -41,13 +41,13 @@ class TestTrueSkill(unittest.TestCase):
         player = TrueSkillCompetitor()
         self.assertEqual(player.mu, player._default_mu)
         self.assertEqual(player.sigma, player._default_sigma)
-        self.assertEqual(player.rating, max(player.mu - 3 * player.sigma, player._minimum_rating))
+        self.assertEqual(player.rating, player.mu - 3 * player.sigma)
 
         # Test with custom parameters
         player = TrueSkillCompetitor(initial_mu=30, initial_sigma=5)
         self.assertEqual(player.mu, 30)
         self.assertEqual(player.sigma, 5)
-        self.assertEqual(player.rating, max(30 - 3 * 5, player._minimum_rating))
+        self.assertEqual(player.rating, 30 - 3 * 5)
 
         # Test with invalid parameters
         with self.assertRaises(InvalidParameterException):
@@ -62,14 +62,14 @@ class TestTrueSkill(unittest.TestCase):
         # Test getters
         self.assertEqual(player.mu, 25)
         self.assertEqual(player.sigma, 8.333)
-        self.assertEqual(player.rating, max(25 - 3 * 8.333, player._minimum_rating))
+        self.assertEqual(player.rating, 25 - 3 * 8.333)
 
         # Test setters
         player.mu = 30
         self.assertEqual(player.mu, 30)
         player.sigma = 5
         self.assertEqual(player.sigma, 5)
-        self.assertEqual(player.rating, max(30 - 3 * 5, player._minimum_rating))
+        self.assertEqual(player.rating, 30 - 3 * 5)
 
         # Test invalid values
         with self.assertRaises(InvalidParameterException):
@@ -80,6 +80,33 @@ class TestTrueSkill(unittest.TestCase):
         # Test that rating cannot be set directly
         with self.assertRaises(NotImplementedError):
             player.rating = 100
+
+    def test_comparison_uses_conservative_rating(self):
+        winner = TrueSkillCompetitor()
+        loser = TrueSkillCompetitor()
+
+        for _ in range(50):
+            winner.beat(loser)
+
+        self.assertGreater(winner, loser)
+        self.assertNotEqual(winner, loser)
+
+    def test_arena_leaderboard_uses_conservative_rating(self):
+        arena = LambdaArena(lambda a, b: a > b, base_competitor=TrueSkillCompetitor)
+        arena.competitors = {
+            "low": TrueSkillCompetitor(initial_mu=10, initial_sigma=5),
+            "high": TrueSkillCompetitor(initial_mu=30, initial_sigma=5),
+            "medium": TrueSkillCompetitor(initial_mu=20, initial_sigma=5),
+        }
+
+        self.assertEqual(
+            arena.leaderboard(),
+            [
+                {"competitor": "high", "rating": 15},
+                {"competitor": "medium", "rating": 5},
+                {"competitor": "low", "rating": -5},
+            ],
+        )
 
     def test_expected_score_calculation(self):
         """Test that the expected score is calculated correctly."""

--- a/tests/test_TrueSkillCompetitor_known_values.py
+++ b/tests/test_TrueSkillCompetitor_known_values.py
@@ -12,13 +12,13 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         player = TrueSkillCompetitor()
         self.assertEqual(player.mu, 25.0)
         self.assertEqual(player.sigma, 8.333)
-        self.assertEqual(player.rating, 100)  # Updated expected value
+        self.assertAlmostEqual(player.rating, 0.001)
 
         # Test custom initialization
         player = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
         self.assertEqual(player.mu, 30.0)
         self.assertEqual(player.sigma, 5.0)
-        self.assertEqual(player.rating, 100)  # Updated expected value
+        self.assertEqual(player.rating, 15.0)
 
     def test_gaussian_functions(self):
         """Test the Gaussian CDF and PDF functions with known values."""


### PR DESCRIPTION
Closes #82

## Summary

- return TrueSkill’s native conservative estimate (`mu - 3*sigma`) without applying the inherited Elo-scale minimum
- correct the six TrueSkill rating assertions that were frozen around the clamp
- guard both rich comparison behavior and best-first `LambdaArena` leaderboard ordering, including negative conservative ratings

This is an intentional public numeric behavior change: consumers of `TrueSkillCompetitor.rating` will now receive the meaningful conservative estimate instead of the constant `100`. Serialized state is unchanged because `mu` and `sigma` remain the persisted values. Per the repository’s established release-preparation convention, the compatibility note is deferred to the next versioned `CHANGELOG.md` section rather than adding a standalone unreleased section in this focused PR.

## Behavior guard

`test_comparison_uses_conservative_rating` and `test_arena_leaderboard_uses_conservative_rating` carry the behavior guard. I temporarily reinstated the exact old `max(..., self._minimum_rating)` clamp and verified both tests failed: the 50-win competitors still compared equal at `100`, and the leaderboard stayed in insertion order with every rating at `100`. I verified the mutation was present with `rg` before running the tests, then restored the fix.

## Verification

- `uv run pytest -q tests/test_TrueSkillCompetitor.py tests/test_TrueSkillCompetitor_known_values.py` — 25 passed
- `PYTHONPATH="$PWD" make test` — 237 passed, 6 skipped
- `make lint` — passed
- `uv run python examples/trueskill_tournament.py` — produced distinct, best-first ratings from `42.60` through `-3.28` in the observed run
- `git diff --check` — passed

A bare `make test` reaches 236 passing tests before the known example-subprocess import issue (`ModuleNotFoundError: elote`); setting `PYTHONPATH` allows the unchanged full gate, including all examples, to complete.
