### PR TITLE
Exercise every supported Python version in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,41 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.10'
+            tox-env: py310
+          - python-version: '3.11'
+            tox-env: py311
+          - python-version: '3.12'
+            tox-env: py312
     
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+    
+    - name: Install dependencies
+      run: |
+        uv pip install --system -e ".[dev,datasets]"
+    
+    - name: Run tests
+      run: uv run tox -e ${{ matrix.tox-env }}
+
+  lint:
+    runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
@@ -30,15 +64,11 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
-    
+
     - name: Install dependencies
       run: |
         uv pip install --system -e ".[dev,datasets]"
-    
-    - name: Run tests
-      run: |
-        make test-all
-    
+
     - name: Run linting
       run: |
         make lint

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-matrix:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,3 +72,16 @@ jobs:
     - name: Run linting
       run: |
         make lint
+
+  # Single stable check name for branch protection; the matrix job names change
+  # whenever the Python version list does.
+  test:
+    runs-on: ubuntu-latest
+    needs: [test-matrix, lint]
+    if: always()
+
+    steps:
+    - name: Check results
+      run: |
+        [ "${{ needs.test-matrix.result }}" = "success" ] || exit 1
+        [ "${{ needs.lint.result }}" = "success" ] || exit 1


### PR DESCRIPTION
Closes #67

## Summary

- run tests in explicit Python 3.10, 3.11, and 3.12 matrix legs
- invoke the matching `py310`, `py311`, or `py312` tox environment in each leg
- keep Ruff in a separate lint job so it runs exactly once
- disable matrix fail-fast so every supported version completes while any failure still fails the workflow

## Verification

- `git diff --check` — passed
- parsed `.github/workflows/test-suite.yml` with PyYAML — passed
- `uv run ruff check .` — passed
- `uv run tox -e py310,py311,py312` — passed; 251 tests passed on each of Python 3.10.17, 3.11.13, and 3.12.11
