### PR TITLE
Make the benchmark's initial-rating normalization real and stop it mutating competitor class state

### DIFF
--- a/elote/benchmark.py
+++ b/elote/benchmark.py
@@ -5,8 +5,10 @@ This module provides functions for benchmarking and comparing different rating s
 using consistent evaluation metrics and visualization.
 """
 
+import contextlib
+import inspect
 import logging
-from typing import Dict, List, Type, Optional, Any, Callable
+from typing import Dict, Iterator, List, Type, Optional, Any, Callable
 import time
 
 from elote.arenas.lambda_arena import LambdaArena
@@ -16,6 +18,56 @@ from elote.datasets.utils import train_arena_with_dataset, evaluate_arena_with_d
 
 
 logger = logging.getLogger(__name__)
+
+
+#: Starting rating handed to every benchmarked rating system that accepts one, so the
+#: systems are compared from a common point rather than from their own varied defaults.
+BENCHMARK_INITIAL_RATING = 1500
+
+_UNSET = object()
+
+
+def _accepts_common_initial_rating(competitor_class: Type[BaseCompetitor]) -> bool:
+    """Report whether the common benchmark starting rating is meaningful for a class.
+
+    A class qualifies when its constructor actually takes an ``initial_rating`` and it is
+    not a global-fit system. Global-fit systems (marked by a ``_recalculate_ratings`` hook)
+    re-derive every rating from the whole match graph, so their starting value is a pre-fit
+    placeholder the first refit discards -- and their scales are not Elo-like, so forcing
+    1500 on them is meaningless at best.
+
+    Args:
+        competitor_class: The competitor class being benchmarked.
+
+    Returns:
+        bool: True if ``initial_rating`` should be passed to the constructor.
+    """
+    if hasattr(competitor_class, "_recalculate_ratings"):
+        return False
+    return "initial_rating" in inspect.signature(competitor_class.__init__).parameters
+
+
+@contextlib.contextmanager
+def _restored_class_vars(cls: Type[BaseCompetitor], names: List[str]) -> Iterator[None]:
+    """Restore the given class variables on ``cls`` when the block exits.
+
+    Attributes that were inherited rather than set directly on ``cls`` are deleted again
+    so the class is left exactly as it was found.
+
+    Args:
+        cls: The class whose attributes will be mutated inside the block.
+        names: The attribute names to snapshot and restore.
+    """
+    saved = {name: cls.__dict__.get(name, _UNSET) for name in names}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is _UNSET:
+                if name in cls.__dict__:
+                    delattr(cls, name)
+            else:
+                setattr(cls, name, value)
 
 
 def evaluate_competitor(
@@ -52,77 +104,88 @@ def evaluate_competitor(
 
     logger.info(f"Evaluating {competitor_name}...")
 
+    # Put every rating system that accepts a starting rating on a common scale. This has to
+    # go through the constructor: __init__ assigns self._initial_rating, which would shadow
+    # any class attribute set here.
+    base_competitor_kwargs: Dict[str, Any] = {}
+    if _accepts_common_initial_rating(competitor_class):
+        base_competitor_kwargs["initial_rating"] = BENCHMARK_INITIAL_RATING
+
     # Create the arena with the specified rating system
-    arena = LambdaArena(comparison_function, base_competitor=competitor_class)
-
-    # Set common parameters
-    arena.set_competitor_class_var("_minimum_rating", 0)
-    arena.set_competitor_class_var("_initial_rating", 1500)
-
-    # Set any additional parameters
-    for param, value in competitor_params.items():
-        arena.set_competitor_class_var(f"_{param}", value)
-
-    # Train the arena on training data
-    start_time = time.time()
-
-    if progress_callback:
-
-        def train_progress(current: int, total: int) -> None:
-            return progress_callback("train", current, total)
-    else:
-        train_progress = None
-
-    train_arena_with_dataset(arena, data_split.train, batch_size=batch_size, progress_callback=train_progress)
-
-    train_time = time.time() - start_time
-    logger.info(f"Training completed in {train_time:.2f} seconds")
-
-    # Evaluate on test data
-    start_time = time.time()
-
-    if progress_callback:
-
-        def eval_progress(current: int, total: int) -> None:
-            return progress_callback("eval", current, total)
-    else:
-        eval_progress = None
-
-    history = evaluate_arena_with_dataset(
-        arena, data_split.test, batch_size=batch_size, progress_callback=eval_progress
+    arena = LambdaArena(
+        comparison_function, base_competitor=competitor_class, base_competitor_kwargs=base_competitor_kwargs
     )
 
-    eval_time = time.time() - start_time
-    logger.info(f"Evaluation completed in {eval_time:.2f} seconds")
+    mutated_class_vars = ["_minimum_rating"] + [f"_{param}" for param in competitor_params]
 
-    # Calculate metrics with default thresholds
-    metrics = history.calculate_metrics()
+    with _restored_class_vars(competitor_class, mutated_class_vars):
+        # Set common parameters
+        arena.set_competitor_class_var("_minimum_rating", 0)
 
-    # Optimize thresholds if requested
-    if optimize_thresholds:
-        best_accuracy, best_thresholds = history.optimize_thresholds()
-        optimized_metrics = history.calculate_metrics(*best_thresholds)
-        metrics["accuracy_opt"] = optimized_metrics["accuracy"]
-        metrics["optimized_thresholds"] = best_thresholds
+        # Set any additional parameters
+        for param, value in competitor_params.items():
+            arena.set_competitor_class_var(f"_{param}", value)
 
-    # Add competitor info and timing
-    metrics["name"] = competitor_name
-    metrics["train_time"] = train_time
-    metrics["eval_time"] = eval_time
+        # Train the arena on training data
+        start_time = time.time()
 
-    # Get top teams (leaderboard is already sorted best-first)
-    top_teams = arena.leaderboard()[:5]
-    metrics["top_teams"] = top_teams
+        if progress_callback:
 
-    # Add history and arena to metrics
-    metrics["history"] = history
-    metrics["arena"] = arena
+            def train_progress(current: int, total: int) -> None:
+                return progress_callback("train", current, total)
+        else:
+            train_progress = None
 
-    # Calculate accuracy by prior bouts if optimize_thresholds is True
-    if optimize_thresholds:
-        thresholds = best_thresholds
-        bout_data = history.accuracy_by_prior_bouts(arena, thresholds)
-        metrics["accuracy_by_prior_bouts"] = bout_data
+        train_arena_with_dataset(arena, data_split.train, batch_size=batch_size, progress_callback=train_progress)
+
+        train_time = time.time() - start_time
+        logger.info(f"Training completed in {train_time:.2f} seconds")
+
+        # Evaluate on test data
+        start_time = time.time()
+
+        if progress_callback:
+
+            def eval_progress(current: int, total: int) -> None:
+                return progress_callback("eval", current, total)
+        else:
+            eval_progress = None
+
+        history = evaluate_arena_with_dataset(
+            arena, data_split.test, batch_size=batch_size, progress_callback=eval_progress
+        )
+
+        eval_time = time.time() - start_time
+        logger.info(f"Evaluation completed in {eval_time:.2f} seconds")
+
+        # Calculate metrics with default thresholds
+        metrics = history.calculate_metrics()
+
+        # Optimize thresholds if requested
+        if optimize_thresholds:
+            best_accuracy, best_thresholds = history.optimize_thresholds()
+            optimized_metrics = history.calculate_metrics(*best_thresholds)
+            metrics["accuracy_opt"] = optimized_metrics["accuracy"]
+            metrics["optimized_thresholds"] = best_thresholds
+
+        # Add competitor info and timing
+        metrics["name"] = competitor_name
+        metrics["train_time"] = train_time
+        metrics["eval_time"] = eval_time
+
+        # Get top teams (leaderboard is already sorted best-first)
+        top_teams = arena.leaderboard()[:5]
+        metrics["top_teams"] = top_teams
+
+        # Add history and arena to metrics
+        metrics["history"] = history
+        metrics["arena"] = arena
+
+        # Calculate accuracy by prior bouts if optimize_thresholds is True
+        if optimize_thresholds:
+            thresholds = best_thresholds
+            bout_data = history.accuracy_by_prior_bouts(arena, thresholds)
+            metrics["accuracy_by_prior_bouts"] = bout_data
 
     # Log results
     logger.info(f"Results for {competitor_name}:")

--- a/elote/benchmark.py
+++ b/elote/benchmark.py
@@ -88,7 +88,8 @@ def evaluate_competitor(
         data_split: DataSplit object containing train and test sets
         comparison_function: Function to compare competitors (used in LambdaArena)
         competitor_name: Name for the competitor (defaults to class name if None)
-        competitor_params: Dictionary of parameters to set on the competitor
+        competitor_params: Dictionary of parameters to set as class variables on the
+            competitor class for the duration of this call; they are restored afterwards
         batch_size: Number of matchups to process in each batch
         progress_callback: Callback function for reporting progress
         optimize_thresholds: Whether to optimize prediction thresholds

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -1,11 +1,14 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import logging
-from elote.benchmark import evaluate_competitor, benchmark_competitors
+from elote.benchmark import BENCHMARK_INITIAL_RATING, evaluate_competitor, benchmark_competitors
 from elote.competitors.elo import EloCompetitor
+from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.glicko import GlickoCompetitor
+from elote.competitors.trueskill import TrueSkillCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
+from elote.datasets.synthetic import SyntheticDataset
 
 
 class TestBenchmarkModule(unittest.TestCase):
@@ -280,6 +283,111 @@ class TestBenchmarkModule(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["name"], "Elo")
         self.assertEqual(results[1]["name"], "Glicko")
+
+
+def _always_true(a, b, attributes=None):
+    """Comparison function for the dataset helpers.
+
+    ``train_arena_with_dataset`` encodes the real outcome in the argument order it hands to
+    ``arena.matchup``, so the comparison function only has to agree that the first argument
+    won. It must accept ``attributes`` as a keyword because rows carry attributes.
+    """
+    return True
+
+
+class TestBenchmarkEndToEnd(unittest.TestCase):
+    """Exercises evaluate_competitor against real data, with nothing mocked out."""
+
+    @classmethod
+    def setUpClass(cls):
+        dataset = SyntheticDataset(num_competitors=20, num_matchups=200, seed=42)
+        cls.data_split = dataset.time_split(test_ratio=0.3)
+
+    def test_class_variables_are_restored_after_evaluation(self):
+        """evaluate_competitor must leave no residue on the competitor class."""
+        before_minimum = EloCompetitor._minimum_rating
+        before_minimum_is_own = "_minimum_rating" in vars(EloCompetitor)
+        before_k_factor = EloCompetitor._k_factor
+
+        evaluate_competitor(
+            competitor_class=EloCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            competitor_params={"k_factor": 12},
+            optimize_thresholds=False,
+        )
+
+        self.assertEqual(EloCompetitor._minimum_rating, before_minimum)
+        self.assertEqual("_minimum_rating" in vars(EloCompetitor), before_minimum_is_own)
+        self.assertEqual(EloCompetitor._k_factor, before_k_factor)
+
+    def test_competitors_start_from_the_common_initial_rating(self):
+        """The competitors the arena actually built must start at the benchmark rating.
+
+        Asserted on real competitor objects rather than on the class attribute: every
+        __init__ assigns self._initial_rating from its own argument, so a class attribute
+        set on the competitor class is shadowed and proves nothing.
+        """
+        for competitor_class in (EloCompetitor, DWZCompetitor):
+            with self.subTest(competitor=competitor_class.__name__):
+                result = evaluate_competitor(
+                    competitor_class=competitor_class,
+                    data_split=self.data_split,
+                    comparison_function=_always_true,
+                    optimize_thresholds=False,
+                )
+                competitors = list(result["arena"].competitors.values())
+                self.assertGreater(len(competitors), 0)
+                for competitor in competitors:
+                    self.assertEqual(competitor._initial_rating, BENCHMARK_INITIAL_RATING)
+
+    def test_competitor_without_initial_rating_argument(self):
+        """A class whose __init__ takes no initial_rating must not be handed one."""
+        result = evaluate_competitor(
+            competitor_class=TrueSkillCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=False,
+        )
+
+        competitors = list(result["arena"].competitors.values())
+        self.assertGreater(len(competitors), 0)
+        for competitor in competitors:
+            self.assertIsInstance(competitor, TrueSkillCompetitor)
+
+    def test_end_to_end_metrics_are_non_degenerate(self):
+        """A real train/evaluate run must produce plausible, fully accounted-for metrics."""
+        result = evaluate_competitor(
+            competitor_class=EloCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=True,
+        )
+
+        arena = result["arena"]
+        scored_bouts = sum(
+            1 for a, b, _, _, _ in self.data_split.test if a in arena.competitors and b in arena.competitors
+        )
+        self.assertGreater(scored_bouts, 0)
+        self.assertEqual(len(result["history"].bouts), scored_bouts)
+
+        confusion_matrix = result["confusion_matrix"]
+        self.assertEqual(sum(confusion_matrix.values()), scored_bouts)
+
+        self.assertGreater(result["accuracy"], 0.0)
+        self.assertLess(result["accuracy"], 1.0)
+        expected_accuracy = (confusion_matrix["tp"] + confusion_matrix["tn"]) / scored_bouts
+        self.assertAlmostEqual(result["accuracy"], expected_accuracy)
+
+        # Optimized thresholds can only improve on the default ones.
+        self.assertGreaterEqual(result["accuracy_opt"], result["accuracy"])
+        lower, upper = result["optimized_thresholds"]
+        self.assertLessEqual(lower, upper)
+
+        self.assertEqual(len(result["top_teams"]), 5)
+        ratings = [team["rating"] for team in result["top_teams"]]
+        self.assertEqual(ratings, sorted(ratings, reverse=True))
+        self.assertGreater(ratings[0], ratings[-1])
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -304,22 +304,42 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
         cls.data_split = dataset.time_split(test_ratio=0.3)
 
     def test_class_variables_are_restored_after_evaluation(self):
-        """evaluate_competitor must leave no residue on the competitor class."""
-        before_minimum = EloCompetitor._minimum_rating
-        before_minimum_is_own = "_minimum_rating" in vars(EloCompetitor)
-        before_k_factor = EloCompetitor._k_factor
+        """evaluate_competitor must leave no residue on the competitor class.
+
+        GlickoCompetitor is used because no other test in this module benchmarks it, so a
+        leak from an earlier test cannot mask the assertions here.
+        """
+        # _minimum_rating is inherited from BaseCompetitor rather than declared on
+        # GlickoCompetitor, so restoring it means removing the attribute again.
+        self.assertNotIn("_minimum_rating", vars(GlickoCompetitor))
+        before_minimum = GlickoCompetitor._minimum_rating
+        before_c = GlickoCompetitor._c
+
+        evaluate_competitor(
+            competitor_class=GlickoCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            competitor_params={"c": 20.0},
+            optimize_thresholds=False,
+        )
+
+        self.assertNotIn("_minimum_rating", vars(GlickoCompetitor))
+        self.assertEqual(GlickoCompetitor._minimum_rating, before_minimum)
+        self.assertEqual(GlickoCompetitor._c, before_c)
+
+    def test_unknown_competitor_params_are_not_left_behind(self):
+        """A class variable that did not exist before the run must not exist after it."""
+        self.assertNotIn("_benchmark_probe", vars(EloCompetitor))
 
         evaluate_competitor(
             competitor_class=EloCompetitor,
             data_split=self.data_split,
             comparison_function=_always_true,
-            competitor_params={"k_factor": 12},
+            competitor_params={"benchmark_probe": 123},
             optimize_thresholds=False,
         )
 
-        self.assertEqual(EloCompetitor._minimum_rating, before_minimum)
-        self.assertEqual("_minimum_rating" in vars(EloCompetitor), before_minimum_is_own)
-        self.assertEqual(EloCompetitor._k_factor, before_k_factor)
+        self.assertNotIn("_benchmark_probe", vars(EloCompetitor))
 
     def test_competitors_start_from_the_common_initial_rating(self):
         """The competitors the arena actually built must start at the benchmark rating.


### PR DESCRIPTION
Closes #94

## What was wrong

`elote/benchmark.py::evaluate_competitor` configured every arena with two lines:

```python
arena.set_competitor_class_var("_minimum_rating", 0)
arena.set_competitor_class_var("_initial_rating", 1500)
```

1. **`_initial_rating` was inert.** No competitor declares `_initial_rating` as a class variable; every `__init__` assigns `self._initial_rating` from its own argument and shadows whatever the arena set. So the benchmark's stated intent — start every system from a common rating before comparing them — never happened. Measured starting ratings inside a benchmark arena on `master`: Elo 400, DWZ 400, ECF 100, Glicko 1500 (its own default, by coincidence). `ECFCompetitor` additionally stores the name-mangled `self.__initial_rating`, so the class attribute reported as 1500 on introspection while the competitor actually started at 100.
2. **`_minimum_rating` leaked permanently.** That one *is* a real `ClassVar`, so it took effect — and was never restored. After a single `evaluate_competitor(EloCompetitor, ...)` call, `EloCompetitor._minimum_rating` stayed `0` for the rest of the process, changing every unrelated `EloCompetitor` created afterwards. The same applied to every `competitor_params` entry.
3. **No end-to-end coverage.** Every test in `tests/test_benchmark_module.py` patched out `train_arena_with_dataset` / `evaluate_arena_with_dataset`, so the real path never ran and both defects survived a green suite.

## What changed

All in `elote/benchmark.py` plus tests:

- The common starting rating is now passed through `LambdaArena`'s existing `base_competitor_kwargs`, so it reaches the constructor and actually takes effect. It is exposed as `BENCHMARK_INITIAL_RATING = 1500`.
- `_accepts_common_initial_rating()` decides per class whether to pass it, so `TrueSkillCompetitor` (whose `__init__` takes `initial_mu`/`initial_sigma`) is not handed an argument it does not accept.
- `_restored_class_vars()` snapshots `_minimum_rating` and every `competitor_params` class variable and restores them in a `finally`. Attributes that were *inherited* rather than declared on the class are deleted again rather than pinned to their inherited value, so the class is left byte-for-byte as it was found.
- Four new tests in `tests/test_benchmark_module.py` that mock nothing, running a real `SyntheticDataset` time split through `evaluate_competitor`.

### One deviation from the issue's proposal, worth a look

The issue proposed gating purely on `inspect.signature(...)` "so `TrueSkillCompetitor` and the global-fit systems are not handed an argument they do not take". `TrueSkillCompetitor` indeed does not take it — but `ColleyMatrixCompetitor` and `BradleyTerryCompetitor` *do*, so a pure signature check would hand them 1500 too. That is wrong for Colley, whose ratings live on a 0–1 scale (default 0.5): forcing 1500 produced `RuntimeWarning: overflow encountered in exp` inside `ColleyMatrixCompetitor.expected_score` and degenerate first-bout predictions for every competitor entering the arena.

So the gate also excludes global-fit systems, detected by the `_recalculate_ratings` hook that both of them define. Those systems re-derive every rating from the whole match graph, so their starting value is a pre-fit placeholder the first refit discards — normalizing it is meaningless. This matches the issue's stated intent; only its stated mechanism is adjusted.

`competitor_params` is left on the class-variable route (now with restore). For `EloCompetitor` that is correct — `_k_factor` is a genuine `ClassVar` that `__init__` reads as its default — so no change was needed there.

## Behaviour change to be aware of

Stopping the `_minimum_rating` leak is itself a behaviour change for any caller that was unknowingly relying on `EloCompetitor._minimum_rating == 0` persisting after a benchmark run. Such a caller will now see the inherited floor of `100` again.

Measured accuracy effect on `SyntheticDataset(num_competitors=60, num_matchups=3000, seed=42).time_split(test_ratio=0.3)`, `optimize_thresholds=False`:

| competitor | master | this PR |
| --- | --- | --- |
| `EloCompetitor` | **raises `InvalidRatingValueException`** | 0.8767 |
| `DWZCompetitor` | 0.8589 | 0.8767 |
| `ECFCompetitor` | 0.8700 | 0.8700 |
| `GlickoCompetitor` | 0.8778 | 0.8778 |
| `Glicko2Competitor` | 0.8722 | 0.8722 |
| `TrueSkillCompetitor` | 0.8433 | 0.8433 |
| `ColleyMatrixCompetitor` | 0.8811 | 0.8811 |

Two things fall out of that table. `DWZCompetitor` moves because it was previously benchmarked at 400, inside the German formula's braking region (`Z_A < 1300`), a regime its constants were never calibrated for. And on `master` at this size, benchmarking `EloCompetitor` **crashes**: it starts at 400 against the leaked floor of 0, and a consistently-losing competitor eventually drives the loser's rating negative. Starting at 1500 gives it enough headroom at this scale, but that only delays the underlying Elo floor defect filed separately as #92 — this PR does not fix that.

ECF is unchanged despite its start moving from 100 to 1500 because its update is shift-invariant; Glicko/Glicko-2 already defaulted to 1500; TrueSkill and Colley are excluded by the gate.

## Verification

Run from a clean `.venv` (Python 3.12) built with `env -u VIRTUAL_ENV uv venv --python 3.12` + `uv pip install -e ".[dev]"`.

- `uv run pytest --ignore=tests/test_examples.py` → **248 passed, 6 skipped, 8 subtests passed**. (`tests/test_examples.py` is excluded because it shells out to an interpreter that lacks `elote`; it fails the same way on `master`.)
- `make lint` (`uv run ruff check .`) → **All checks passed!**
- `uv run mypy --python-version 3.12 elote` → **Success: no issues found in 24 source files**. (`make typecheck` pins `python_version = "3.10"` and aborts inside `scipy-stubs` before reaching `elote`; that is pre-existing and reproduces on a clean tree.)
- Manually benchmarked all eight shipped competitor classes end to end and confirmed the actual starting rating on the competitor objects the arena built, and that `_minimum_rating` value *and* ownership are identical before and after each call.

### Mutation checks (the tests are not vacuous)

Fix committed first, then each mutation applied to the committed file, verified by grep, run, and reverted; the suite is green again afterwards.

| mutation | result |
| --- | --- |
| Restore `arena.set_competitor_class_var("_initial_rating", 1500)` in place of the `base_competitor_kwargs` plumbing | `test_competitors_start_from_the_common_initial_rating` fails: `AssertionError: 400 != 1500` for both `EloCompetitor` and `DWZCompetitor` |
| Replace the `try/finally` body of `_restored_class_vars` with a bare `yield` | `test_class_variables_are_restored_after_evaluation` and `test_unknown_competitor_params_are_not_left_behind` fail |

The two mutations are caught by **disjoint** test sets, so neither half of the fix is riding on the other's coverage.

One note on the restoration test: it benchmarks `GlickoCompetitor` specifically because the pre-existing mocked tests in the same module benchmark `EloCompetitor` and — with the restore removed — leak onto it before the new test runs, which would silently mask the `_minimum_rating` assertion.