### PR TITLE
Restore LambdaArena from its own export_state() output

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -30,7 +30,9 @@ class LambdaArena(BaseArena):
             base_competitor_kwargs (dict, optional): Keyword arguments to pass to
                 the base_competitor constructor.
             initial_state (dict, optional): Initial state for competitors, mapping
-                competitor IDs to their initial parameters.
+                competitor IDs either to exported competitor state documents (as
+                produced by :meth:`export_state`) or to plain keyword arguments for
+                the base_competitor constructor, such as ``{"initial_rating": 1200}``.
         """
         super().__init__()
         logger.debug("Initializing LambdaArena with competitor type: %s", base_competitor.__name__)
@@ -47,7 +49,13 @@ class LambdaArena(BaseArena):
         # if some initial state is passed in, we can seed the population
         if initial_state is not None:
             for k, v in initial_state.items():
-                self.competitors[k] = self.base_competitor(**v)
+                # An exported competitor state document carries its own concrete type,
+                # which from_state resolves through the subclass registry. Anything else
+                # is treated as constructor keyword arguments.
+                if isinstance(v, dict) and "type" in v:
+                    self.competitors[k] = BaseCompetitor.from_state(v)
+                else:
+                    self.competitors[k] = self.base_competitor(**v)
 
         self.history: History = History()
         self.eval_history = History()

--- a/examples/persist_state_arena.py
+++ b/examples/persist_state_arena.py
@@ -22,13 +22,9 @@ print(json.dumps(arena.leaderboard(), indent=4))
 # Use a simple dict comprehension instead of deepcopy to avoid issues with non-serializable types
 saved_state = {k: v for k, v in arena.export_state().items()}
 
-# Create a new arena with the saved state
+# Create a new arena from the saved state and run more matches
 matchups = [(random.randint(1, 10), random.randint(1, 10)) for _ in range(100)]
-new_arena = LambdaArena(func, base_competitor=GlickoCompetitor)
-
-# Use from_state to recreate competitors
-for k, v in saved_state.items():
-    new_arena.competitors[k] = GlickoCompetitor.from_state(v)
+new_arena = LambdaArena(func, base_competitor=GlickoCompetitor, initial_state=saved_state)
 
 # Run more matches
 new_arena.tournament(matchups)

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -1,5 +1,19 @@
+import datetime
+import json
+import random
 import unittest
-from elote import LambdaArena, EloCompetitor, GlickoCompetitor
+
+from elote import (
+    BradleyTerryCompetitor,
+    ColleyMatrixCompetitor,
+    DWZCompetitor,
+    ECFCompetitor,
+    EloCompetitor,
+    Glicko2Competitor,
+    GlickoCompetitor,
+    LambdaArena,
+    TrueSkillCompetitor,
+)
 
 
 class TestArenas(unittest.TestCase):
@@ -228,3 +242,115 @@ class TestArenas(unittest.TestCase):
                 # validate only records predictions; it must not update ratings.
                 ratings_after = {cid: c.rating for cid, c in arena.competitors.items()}
                 self.assertEqual(ratings_before, ratings_after)
+
+
+class TestArenaStateRoundTrip(unittest.TestCase):
+    """LambdaArena must be restorable from its own export_state() output."""
+
+    # Every shipped competitor class must survive the round trip.
+    ALL_COMPETITORS = (
+        EloCompetitor,
+        GlickoCompetitor,
+        Glicko2Competitor,
+        TrueSkillCompetitor,
+        ECFCompetitor,
+        DWZCompetitor,
+        ColleyMatrixCompetitor,
+        BradleyTerryCompetitor,
+    )
+
+    # Colley and Bradley-Terry reset their opponent match graph on import by design
+    # (documented in their own docstrings), so only the incremental systems can be
+    # expected to keep rating identically after a restore.
+    INCREMENTAL_COMPETITORS = (
+        EloCompetitor,
+        GlickoCompetitor,
+        Glicko2Competitor,
+        TrueSkillCompetitor,
+        ECFCompetitor,
+        DWZCompetitor,
+    )
+
+    # Elo aborts on its rating floor when a competitor loses repeatedly from the
+    # default start of 400, so give it the same headroom the examples use.
+    COMPETITOR_KWARGS = {EloCompetitor: {"initial_rating": 1200}}
+
+    @staticmethod
+    def _matchups(seed, count):
+        rng = random.Random(seed)
+        pairs = []
+        while len(pairs) < count:
+            a, b = str(rng.randint(1, 8)), str(rng.randint(1, 8))
+            if a != b:
+                pairs.append((a, b))
+        return pairs
+
+    @classmethod
+    def _trained_arena(cls, competitor_cls):
+        arena = LambdaArena(
+            lambda a, b: a > b,
+            base_competitor=competitor_cls,
+            base_competitor_kwargs=cls.COMPETITOR_KWARGS.get(competitor_cls),
+        )
+        for a, b in cls._matchups(seed=1, count=60):
+            arena.matchup(a, b)
+        return arena
+
+    @staticmethod
+    def _ratings(arena):
+        return {entry["competitor"]: entry["rating"] for entry in arena.leaderboard()}
+
+    def test_round_trip_through_json_reproduces_leaderboard(self):
+        """A JSON round trip of export_state() must reproduce the leaderboard exactly."""
+        for competitor_cls in self.ALL_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = self._trained_arena(competitor_cls)
+
+                # Going through JSON proves the exported state is serializable, which
+                # is the whole point of the persist-and-resume journey.
+                state = json.loads(json.dumps(arena.export_state()))
+                restored = LambdaArena(lambda a, b: a > b, base_competitor=competitor_cls, initial_state=state)
+
+                self.assertEqual(arena.leaderboard(), restored.leaderboard())
+
+    def test_round_trip_resolves_concrete_type_from_state(self):
+        """The recorded type in the state decides the class, not base_competitor."""
+        arena = self._trained_arena(GlickoCompetitor)
+        state = json.loads(json.dumps(arena.export_state()))
+
+        # base_competitor is left at its default (EloCompetitor) on purpose.
+        restored = LambdaArena(lambda a, b: a > b, initial_state=state)
+
+        self.assertEqual(len(restored.competitors), len(arena.competitors))
+        for competitor in restored.competitors.values():
+            self.assertIsInstance(competitor, GlickoCompetitor)
+        self.assertEqual(arena.leaderboard(), restored.leaderboard())
+
+    def test_restored_arena_keeps_rating_identically(self):
+        """Playing on further must give the same ratings as never having restored."""
+        # A fixed match time keeps the time-aware systems deterministic; without it
+        # the two arenas inflate rating deviations by slightly different elapsed times.
+        match_time = datetime.datetime.now() + datetime.timedelta(days=1)
+
+        for competitor_cls in self.INCREMENTAL_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = self._trained_arena(competitor_cls)
+                state = json.loads(json.dumps(arena.export_state()))
+                restored = LambdaArena(lambda a, b: a > b, base_competitor=competitor_cls, initial_state=state)
+
+                for a, b in self._matchups(seed=2, count=25):
+                    arena.matchup(a, b, match_time=match_time)
+                    restored.matchup(a, b, match_time=match_time)
+
+                self.assertEqual(self._ratings(arena), self._ratings(restored))
+
+    def test_plain_constructor_kwargs_are_still_supported(self):
+        """The pre-existing kwargs form of initial_state must keep working."""
+        arena = LambdaArena(
+            lambda a, b: a > b,
+            initial_state={"A": {"initial_rating": 1200}, "B": {"initial_rating": 800}},
+        )
+
+        self.assertIsInstance(arena.competitors["A"], EloCompetitor)
+        self.assertEqual(arena.competitors["A"].rating, 1200)
+        self.assertEqual(arena.competitors["B"].rating, 800)


### PR DESCRIPTION
Closes #93

`LambdaArena.__init__` treated every `initial_state` value as constructor kwargs (`self.base_competitor(**v)`), while `export_state()` returns each competitor's standardized state document. The obvious round trip therefore raised `TypeError: <C>.__init__() got an unexpected keyword argument 'type'` for all eight shipped competitor classes, and even the kwargs reading would have discarded every learned rating.

## What changed

- `elote/arenas/lambda_arena.py`: values carrying a recorded `"type"` are rebuilt via `BaseCompetitor.from_state(v)`, which resolves the concrete class through the subclass registry. Anything else still goes to `self.base_competitor(**v)`, so the pre-existing `{"initial_rating": 1200}` form is unchanged. Docstring updated to describe both accepted shapes.
- `tests/test_Arenas.py`: new `TestArenaStateRoundTrip` covering the round trip through `json.dumps`/`json.loads` for all eight classes, concrete-type resolution from the state, continued play on a restored arena, and the plain-kwargs form.
- `examples/persist_state_arena.py`: dropped the hand-rolled `from_state` loop that existed to work around this, and passed `initial_state=saved_state` as the example was always meant to.

Colley and Bradley-Terry restore their ratings exactly but still diverge once you *continue* playing on a restored arena, because their `_import_current_state` resets the opponent match graph by design (documented in their own docstrings). That is out of scope here, so the continued-play test covers the six incremental systems only.

## Verification

All commands run with `uv` in a clean worktree.

- `uv run pytest --ignore=tests/test_examples.py` → **247 passed, 6 skipped**.
- `make lint` (`ruff check .`) → **All checks passed!**
- `uv run mypy --python-version 3.12 elote` → **Success: no issues found in 24 source files**. (`make typecheck` aborts in `scipy-stubs` before reaching `elote`; that is pre-existing and unrelated to this diff.)
- `uv run python examples/persist_state_arena.py` → runs and prints both leaderboards.

Measured round trip, 8 competitors / 60 matchups, state passed through `json.dumps`/`json.loads`:

| class | leaderboard max diff after restore | max diff after 25 further matchups |
|---|---|---|
| Elo | 0.0 | 0.0 |
| Glicko-1 | 0.0 | 0.0 |
| Glicko-2 | 0.0 | 0.0 |
| TrueSkill | 0.0 | 0.0 |
| ECF | 0.0 | 0.0 |
| DWZ | 0.0 | 0.0 |
| Colley | 0.0 | 3.16 (match graph reset, by design) |
| Bradley-Terry | 0.0 | 737.09 (match graph reset, by design) |

### Mutation check

Two mutations, each caught by a disjoint set of tests, with the fix committed and the mutation applied on top:

1. Reverting the dispatch to `self.competitors[k] = self.base_competitor(**v)` → **3 failed** (`test_round_trip_through_json_reproduces_leaderboard`, `test_round_trip_resolves_concrete_type_from_state`, `test_restored_arena_keeps_rating_identically`), all with `TypeError: EloCompetitor.__init__() got an unexpected keyword argument 'type'`. The plain-kwargs test still passes here, as it should — it documents back-compat rather than guarding the fix.
2. Dropping the kwargs branch (`self.competitors[k] = BaseCompetitor.from_state(v)` unconditionally) → **4 failed**: the new `test_plain_constructor_kwargs_are_still_supported` plus the three pre-existing `initial_state={"A": {"initial_rating": 1200}}` tests, all with `InvalidStateException: State must contain a 'type' field`. So the back-compat branch is load-bearing and covered.

The file was restored from a pre-mutation copy after each run and the suite re-run green.

### A note on determinism

The continued-play test passes an explicit `match_time`. Without it the two arenas inflate Glicko/Glicko-2 rating deviations by slightly different elapsed wall-clock times and the ratings differ by ~1e-10 — real, but an artifact of the test, not of the restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)