### PR TITLE
Saturate Elo ratings at the minimum rating instead of raising

### DIFF
--- a/elote/competitors/elo.py
+++ b/elote/competitors/elo.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, ClassVar, Optional, Type, TypeVar
+from typing import Dict, Any, ClassVar, Optional, Type, TypeVar, cast
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
 from elote.logging import logger  # Import directly from the logging submodule
@@ -240,6 +240,21 @@ class EloCompetitor(BaseCompetitor):
             raise InvalidRatingValueException(f"Rating cannot be below the minimum rating of {self._minimum_rating}")
         self._rating = value
 
+    def _new_rating(self, actual_score: float, expected_score: float) -> float:
+        """Calculate this competitor's new rating after a match.
+
+        Args:
+            actual_score (float): The score achieved in the match (1.0, 0.5, or 0.0).
+            expected_score (float): The expected score against the opponent.
+
+        Returns:
+            float: The new rating, saturated at the minimum rating.
+        """
+        new_rating = self._rating + self._k_factor * (actual_score - expected_score)
+        new_rating_clamped = max(self._minimum_rating, new_rating)
+        logger.debug("New rating calculated: %.1f (Clamped: %.1f)", new_rating, new_rating_clamped)
+        return float(new_rating_clamped)
+
     def expected_score(self, competitor: "BaseCompetitor") -> float:
         """Calculate the expected score against another competitor.
 
@@ -265,13 +280,17 @@ class EloCompetitor(BaseCompetitor):
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
-        logger.debug("%s beat %s", self, competitor)
-        # Revert to original logic
-        win_es = self.expected_score(competitor)
-        lose_es = competitor.expected_score(self)
+        competitor_elo = cast(EloCompetitor, competitor)
+        logger.debug("%s beat %s", self, competitor_elo)
 
-        self._rating = self._rating + self._k_factor * (1 - win_es)
-        competitor.rating = competitor.rating + self._k_factor * (0 - lose_es)
+        win_es = self.expected_score(competitor_elo)
+        lose_es = competitor_elo.expected_score(self)
+
+        my_new_rating = self._new_rating(1, win_es)
+        opponent_new_rating = competitor_elo._new_rating(0, lose_es)
+
+        self.rating = my_new_rating
+        competitor_elo.rating = opponent_new_rating
 
     def tied(self, competitor: BaseCompetitor) -> None:
         """Update ratings after this competitor has tied with the given competitor.
@@ -286,10 +305,14 @@ class EloCompetitor(BaseCompetitor):
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
-        logger.debug("%s tied with %s", self, competitor)
-        # Revert to original logic
-        win_es = self.expected_score(competitor)
-        lose_es = competitor.expected_score(self)
+        competitor_elo = cast(EloCompetitor, competitor)
+        logger.debug("%s tied with %s", self, competitor_elo)
 
-        self._rating = self._rating + self._k_factor * (0.5 - win_es)
-        competitor.rating = competitor.rating + self._k_factor * (0.5 - lose_es)
+        win_es = self.expected_score(competitor_elo)
+        lose_es = competitor_elo.expected_score(self)
+
+        my_new_rating = self._new_rating(0.5, win_es)
+        opponent_new_rating = competitor_elo._new_rating(0.5, lose_es)
+
+        self.rating = my_new_rating
+        competitor_elo.rating = opponent_new_rating

--- a/tests/test_EloCompetitor.py
+++ b/tests/test_EloCompetitor.py
@@ -1,6 +1,8 @@
+import itertools
 import unittest
-from elote import EloCompetitor, GlickoCompetitor
-from elote.competitors.base import MissMatchedCompetitorTypesException
+
+from elote import EloCompetitor, GlickoCompetitor, LambdaArena
+from elote.competitors.base import InvalidRatingValueException, MissMatchedCompetitorTypesException
 
 
 class TestElo(unittest.TestCase):
@@ -37,3 +39,57 @@ class TestElo(unittest.TestCase):
 
         with self.assertRaises(MissMatchedCompetitorTypesException):
             player1.verify_competitor_types(player2)
+
+
+class TestEloMinimumRating(unittest.TestCase):
+    """Behaviour of EloCompetitor at the _minimum_rating floor."""
+
+    def test_weakest_competitor_saturates_at_the_floor(self):
+        """A long arena run with a clearly weakest member saturates instead of raising."""
+        pairs = list(itertools.permutations([1, 2, 3, 4], 2))
+        matchups = [pairs[i % len(pairs)] for i in range(200)]
+
+        arena = LambdaArena(lambda a, b: a > b)
+        arena.tournament(matchups)
+
+        ratings = {entry["competitor"]: entry["rating"] for entry in arena.leaderboard()}
+        self.assertEqual(ratings[1], EloCompetitor._minimum_rating)
+        self.assertGreater(ratings[2], EloCompetitor._minimum_rating)
+        self.assertGreater(ratings[3], ratings[2])
+        self.assertGreater(ratings[4], ratings[3])
+
+    def test_both_participants_saturate_at_the_floor(self):
+        """Neither side of a match may be driven below the floor, whichever is the caller."""
+        winner = EloCompetitor(initial_rating=EloCompetitor._minimum_rating)
+        loser = EloCompetitor(initial_rating=EloCompetitor._minimum_rating)
+
+        # The loser is already at the floor and would otherwise go below it.
+        winner.beat(loser)
+        self.assertEqual(loser.rating, EloCompetitor._minimum_rating)
+        self.assertGreater(winner.rating, EloCompetitor._minimum_rating)
+
+        # The caller's own side is only reachable through a draw it was favoured to win,
+        # and needs a large K-factor to cross the floor in one step.
+        favourite = EloCompetitor(initial_rating=EloCompetitor._minimum_rating + 10, k_factor=1000)
+        underdog = EloCompetitor(initial_rating=EloCompetitor._minimum_rating, k_factor=1000)
+        favourite.tied(underdog)
+        self.assertEqual(favourite.rating, EloCompetitor._minimum_rating)
+
+    def test_explicit_assignment_below_the_floor_still_raises(self):
+        """The rating setter keeps rejecting explicit out-of-range assignments."""
+        player = EloCompetitor(initial_rating=400)
+
+        with self.assertRaises(InvalidRatingValueException):
+            player.rating = EloCompetitor._minimum_rating - 1
+
+        self.assertEqual(player.rating, 400)
+
+    def test_ratings_away_from_the_floor_are_unchanged(self):
+        """Ordinary Elo arithmetic is untouched: equal 400s exchange exactly K/2."""
+        winner = EloCompetitor(initial_rating=400, k_factor=32)
+        loser = EloCompetitor(initial_rating=400, k_factor=32)
+
+        winner.beat(loser)
+
+        self.assertAlmostEqual(winner.rating, 416.0)
+        self.assertAlmostEqual(loser.rating, 384.0)


### PR DESCRIPTION
Closes #92

`EloCompetitor` was the only shipped rating system that **aborted** on the `_minimum_rating`
floor rather than clamping or ignoring it. `beat`/`tied` assigned the loser's post-match value
through the `rating` property setter, which raises `InvalidRatingValueException`. With Elo's
default `initial_rating=400` against the inherited floor of 100 there are only 300 points of
headroom, so any population with a clearly weakest member kills the run mid-tournament —
including the README's own arena example.

## What changed

`elote/competitors/elo.py` only:

- New private `EloCompetitor._new_rating(actual_score, expected_score)` computes
  `rating + k * (actual - expected)` and returns `max(self._minimum_rating, new_rating)`,
  mirroring the `DWZCompetitor._new_rating` pattern already in the codebase.
- `beat` and `tied` route **both** participants through it and assign both via the `rating`
  property. Previously the winner's side was written `self._rating = ...` (bypassing the setter
  and its validation) while the loser's side went through the validated setter — the two halves
  of one event were enforced differently. They now use the same path, and because the value is
  clamped first the setter never fires for an algorithm-driven update.
- The setter's `InvalidRatingValueException` is **unchanged**: an explicit user assignment below
  the floor is still an error. Only algorithm-driven updates saturate.

Nothing else was touched — in particular Elo's default `initial_rating` is unchanged (raising it
only delays the crash, per the issue), and the hand-written `initial_rating=1200` workaround in
`examples/sample_arena.py` is left alone as out of scope for this PR.

## Recorded trade-off

This makes Elo **non-zero-sum at the floor**: when a loser saturates, the winner still gains the
full K while the loser absorbs less than K. That is exactly the trade-off `DWZCompetitor` already
makes with its own clamp. Away from the floor Elo remains exactly zero-sum. Flagging it explicitly
so it is a recorded decision rather than a silent one.

## Verification

All commands run from a clean worktree with `env -u VIRTUAL_ENV uv run --extra dev ...`.

**README arena snippet, seeds 0-19** — the verbatim snippet (`LambdaArena(comparison)`, 1000
matchups over `random.randint(1, 10)`) with `random.seed(s)`:

- Before: `20/20` seeds abort with `InvalidRatingValueException` (between matchup 148 and 245).
- After: `seeds 0-19 completed: 20 /20`. Final leaderboard for seed 19 ends
  `..., (2, 109.17), (1, 100.0), (3, 100.0)` — the weakest competitors sit exactly on the floor.

**Test suite:** `uv run pytest --ignore=tests/test_examples.py` → `247 passed, 6 skipped`
(4 new). `tests/test_examples.py` is excluded because it shells out to an interpreter without
`elote` installed and fails identically on `master`; both examples were run directly
(`uv run python examples/sample_arena.py`, `examples/persist_state_arena.py`) and pass.

**Lint / types:** `make lint` → `All checks passed!`.
`uv run mypy --python-version 3.12 elote` → `Success: no issues found in 24 source files`.
(`make typecheck` aborts in `scipy-stubs` under its Python 3.10 target before reaching `elote` —
pre-existing and unrelated to this diff.)

### Mutation check — which test guards which half

Each mutation was applied on top of the committed fix, verified present by grep, the suite run,
then reverted and the baseline re-confirmed green.

| Mutation | Result |
| --- | --- |
| Clamp reverted (`new_rating_clamped = new_rating`) | **2 failed** — `test_weakest_competitor_saturates_at_the_floor` and `test_both_participants_saturate_at_the_floor`. All other Elo tests pass. |
| Setter's `raise` deleted (replaced with `pass`) | **1 failed** — `test_explicit_assignment_below_the_floor_still_raises`. The two clamp tests still pass. |

The two mutations therefore fail **disjoint** test sets: the clamp tests carry the fix, the setter
test carries the preserved validation.

### New tests (`tests/test_EloCompetitor.py::TestEloMinimumRating`)

- `test_weakest_competitor_saturates_at_the_floor` — 4 competitors with fixed distinct strengths
  (`a > b`), default `EloCompetitor`, 200 matchups through `LambdaArena`. No exception, and the
  weakest competitor's rating is **exactly** `EloCompetitor._minimum_rating` while the other three
  stay strictly above it in strength order. This test raises `InvalidRatingValueException` on
  unfixed code.
- `test_both_participants_saturate_at_the_floor` — covers the opponent side (a winner beating a
  competitor already at the floor) and the caller's own side. Honest note on the second half: the
  caller can only cross the floor via a draw it was *favoured* to win, and at the default K=32 the
  rating change is always smaller than the caller's distance above the floor — so that half is
  unreachable with default settings and the assertion uses `k_factor=1000`, where it is reachable.
  Pre-fix that case silently produced a below-floor rating (the winner's side bypassed the setter),
  so it guards a real second defect, just not the crash.
- `test_explicit_assignment_below_the_floor_still_raises` — `competitor.rating = floor - 1` still
  raises and leaves the rating unmodified.
- `test_ratings_away_from_the_floor_are_unchanged` — known-value assertion that ordinary Elo
  arithmetic is untouched: two 400-rated players with K=32 land on exactly 416.0 / 384.0.
  (`tests/test_EloCompetitor_known_values.py` continues to pass unmodified.)