### PR TITLE
[autopilot] release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,55 @@
-Unreleased
-==========
+v1.2.1
+======
+
+A correctness release. Every shipped rating system except Elo, DWZ, Colley and Bradley-Terry had at
+least one numeric defect, and the prediction-quality metrics silently discarded drawn bouts. Ratings
+and predicted probabilities produced by this version differ from v1.2.0; state exported by v1.2.0
+still loads without changes.
 
 Bug fixes
 
+ * Fixed `GlickoCompetitor.expected_score` and the Glicko rating update squaring the rating deviation
+   twice and reading the wrong player's deviation. Expected scores had collapsed to roughly 0.5 for
+   any rating gap; a 2500-vs-1500 matchup now returns 0.979 instead of 0.504.
+ * Fixed `Glicko2Competitor.beat`/`tied` applying the inactivity rating-deviation inflation three
+   times per match, and updating the two competitors sequentially so the second update read the
+   first competitor's already-updated state. Both competitors are now updated from the same
+   pre-match snapshot, and `update_rd_for_inactivity` is idempotent for a repeated timestamp.
+ * Fixed `TrueSkillCompetitor.expected_score` using `sqrt(beta^2 + sigma_i^2 + sigma_j^2)` where
+   two-player TrueSkill uses `sqrt(2*beta^2 + ...)`. Predictions were too sharp.
+ * Fixed the TrueSkill win, loss and draw updates: skill variance is now inflated by `tau^2` before
+   the match, mean corrections are scaled by `sigma^2/c` and variance corrections by `sigma^2/c^2`,
+   and draws apply both the mean correction and the positive draw correction. Regression tested
+   against the reference `trueskill` package.
+ * Fixed `TrueSkillCompetitor.rating` clamping the conservative estimate at the inherited minimum
+   rating. It now returns `mu - 3*sigma` unclamped, so comparisons and `LambdaArena.leaderboard()`
+   order competitors on TrueSkill's own scale.
  * Fixed ECF rating updates to apply the rating-difference cap independently for each competitor.
+   Draws between widely-separated competitors were argument-order dependent, and a competitor could
+   gain rating from losing an expected result.
+ * Fixed `History.report_results()` comparing a predicted competitor identifier against a bout slot
+   label when computing `"correct"`, which made the field wrong for essentially every bout.
+ * Fixed `History.confusion_matrix`, `calculate_metrics`, `calculate_metrics_with_draws`,
+   `optimize_thresholds` and `random_search` discarding every drawn bout. Draw handling in those
+   methods had been unreachable; draws now count as true positives when predicted, false positives
+   when wrongly predicted, and false negatives when missed.
+
+Improvements
+
+ * `History.report_results()` now reports the winner under the correctly spelled key
+   `predicted_winner`. The historical misspelling `predicted_winnder` is retained as a deprecated
+   alias with the same value and will be removed in a future release.
+ * CI now runs the test suite against every supported Python version (3.10, 3.11, 3.12) instead of
+   3.10 only, lints in a separate job, and uses current GitHub Actions.
+
+Compatibility notes
+
+ * Metrics computed from a `History` will change for any dataset containing draws, and predicted
+   probabilities change for Glicko, Glicko-2 and TrueSkill. Recalibrate any thresholds tuned against
+   v1.2.0.
+ * `TrueSkillCompetitor.rating` may now be negative for a competitor that has played few matches.
+ * Recording a Glicko-2 match timestamped before a competitor's last recorded activity now raises
+   `InvalidParameterException` where it previously could be accepted.
 
 v1.2.0
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elote"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python module for rating bouts (like with Elo Rating)"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "elote"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
Release preparation for **v1.2.1**. Version bump in `pyproject.toml` (+ `uv.lock`) and a new `CHANGELOG.md` section. No source changes.

## Why now

Eleven commits have landed since `v1.2.0`, and nine of them are user-visible correctness fixes that change ratings, predicted probabilities, or reported metrics. The release policy says a correctness bug that changes ratings or predictions warrants a patch release once its focused fixes and numeric regressions are complete — each of these landed with known-value regression tests, so the set is complete. Nothing here adds an algorithm or a public API, so this is a **patch** release, not a minor.

## Release notes (v1.2.1)

A correctness release. Every shipped rating system except Elo, DWZ, Colley and Bradley-Terry had at least one numeric defect, and the prediction-quality metrics silently discarded drawn bouts. Ratings and predicted probabilities produced by this version differ from v1.2.0; state exported by v1.2.0 still loads without changes.

### Bug fixes

- Fixed `GlickoCompetitor.expected_score` and the Glicko rating update squaring the rating deviation twice and reading the wrong player's deviation. Expected scores had collapsed to roughly 0.5 for any rating gap; a 2500-vs-1500 matchup now returns 0.979 instead of 0.504. (#73)
- Fixed `Glicko2Competitor.beat`/`tied` applying the inactivity rating-deviation inflation three times per match, and updating the two competitors sequentially so the second update read the first competitor's already-updated state. Both competitors are now updated from the same pre-match snapshot, and `update_rd_for_inactivity` is idempotent for a repeated timestamp. (#86)
- Fixed `TrueSkillCompetitor.expected_score` using `sqrt(beta^2 + sigma_i^2 + sigma_j^2)` where two-player TrueSkill uses `sqrt(2*beta^2 + ...)`. Predictions were too sharp. (#78)
- Fixed the TrueSkill win, loss and draw updates: skill variance is now inflated by `tau^2` before the match, mean corrections are scaled by `sigma^2/c` and variance corrections by `sigma^2/c^2`, and draws apply both the mean correction and the positive draw correction. Regression tested against the reference `trueskill` package. (#80)
- Fixed `TrueSkillCompetitor.rating` clamping the conservative estimate at the inherited minimum rating. It now returns `mu - 3*sigma` unclamped, so comparisons and `LambdaArena.leaderboard()` order competitors on TrueSkill's own scale. (#87)
- Fixed ECF rating updates to apply the rating-difference cap independently for each competitor. Draws between widely-separated competitors were argument-order dependent, and a competitor could gain rating from losing an expected result. (#85)
- Fixed `History.report_results()` comparing a predicted competitor identifier against a bout slot label when computing `"correct"`, which made the field wrong for essentially every bout. (#72)
- Fixed `History.confusion_matrix`, `calculate_metrics`, `calculate_metrics_with_draws`, `optimize_thresholds` and `random_search` discarding every drawn bout. Draw handling in those methods had been unreachable; draws now count as true positives when predicted, false positives when wrongly predicted, and false negatives when missed. (#77)

### Improvements

- `History.report_results()` now reports the winner under the correctly spelled key `predicted_winner`. The historical misspelling `predicted_winnder` is retained as a deprecated alias with the same value and will be removed in a future release. (#69)
- CI now runs the test suite against every supported Python version (3.10, 3.11, 3.12) instead of 3.10 only, lints in a separate job, and uses current GitHub Actions. (#76, #88)

### Compatibility notes

- Metrics computed from a `History` will change for any dataset containing draws, and predicted probabilities change for Glicko, Glicko-2 and TrueSkill. Recalibrate any thresholds tuned against v1.2.0.
- `TrueSkillCompetitor.rating` may now be negative for a competitor that has played few matches.
- Recording a Glicko-2 match timestamped before a competitor's last recorded activity now raises `InvalidParameterException` where it previously could be accepted.

## Verification

- `pytest` — 249 passed (`tests/test_examples.py` excluded; it shells out to an interpreter without `elote` installed and fails on `master` too).
- `ruff check .` — clean.
- `mypy --python-version 3.12 elote` — clean. (`make typecheck` pins 3.10 and aborts inside `scipy-stubs`, pre-existing and unrelated.)
- `sphinx-build docs/source` — builds, with the same pre-existing warnings as `master`.
- `python -m build --sdist` — `dist/elote-1.2.1.tar.gz`; `PKG-INFO` reports `Version: 1.2.1` and the archive contains the full `elote` package (29 entries).

## Not included

PRs #95, #96 and #97 are open but unmerged, so none of their fixes are in this release. If you want them shipped, merge them first and I'll re-cut. Dependabot PRs (#59–#64, #66, #81) are dev/docs dependencies only and do not affect the sdist.

## Downstream

- `wdm0006/collaborank` — pins Elote in `pyproject.toml` (line 49: `"elote @ git+https://github.com/wdm0006/elote.git"`), an unpinned git reference that tracks this repo's default branch, and uses `elote.LambdaArena`. No version bump is required, but it picks these changes up on its next resolve, so it should be re-tested after this lands: `LambdaArena.leaderboard()` ordering is unchanged, but any TrueSkill or Glicko ratings and any `History` metrics it reports will move. Consider pinning it to `v1.2.1` while you're there.

## Post-merge steps (operator)

```
git checkout master && git pull
git tag -a v1.2.1 -m "v1.2.1" && git push origin v1.2.1
```

The tag alone does **not** publish. Create the GitHub Release from that tag:

```
gh release create v1.2.1 --repo wdm0006/elote --title "v1.2.1" --notes-file <notes>
```

Creating the release triggers the **PyPI Packaging** workflow (`.github/workflows/pypi-publish.yml`), which runs `python -m build --sdist` and publishes the sdist through PyPI Trusted Publishing. Verify `elote 1.2.1` on PyPI once it finishes.
