### PR TITLE
Reject mismatched blended competitor compositions

### DIFF
--- a/elote/competitors/ensemble.py
+++ b/elote/competitors/ensemble.py
@@ -1,6 +1,11 @@
 from typing import Dict, Any, List, Type, TypeVar
 
-from elote.competitors.base import BaseCompetitor, InvalidParameterException, InvalidStateException
+from elote.competitors.base import (
+    BaseCompetitor,
+    InvalidParameterException,
+    InvalidStateException,
+    MissMatchedCompetitorTypesException,
+)
 from elote import (
     EloCompetitor,
     ECFCompetitor,
@@ -310,6 +315,20 @@ class BlendedCompetitor(BaseCompetitor):
             logger.debug("Resetting sub-competitor: %s", competitor)
             competitor.reset()
 
+    def verify_competitor_types(self, competitor: BaseCompetitor) -> None:
+        """Verify that both ensembles have matching sub-competitor types."""
+        super().verify_competitor_types(competitor)
+
+        self_composition = [type(c).__name__ for c in self.sub_competitors]
+        competitor_composition = [type(c).__name__ for c in competitor.sub_competitors]
+        if self_composition != competitor_composition:
+            logger.warning(
+                "Blended competitor composition mismatch: %s vs %s", self_composition, competitor_composition
+            )
+            raise MissMatchedCompetitorTypesException(
+                f"BlendedCompetitor compositions {self_composition} and {competitor_composition} cannot be co-mingled"
+            )
+
     def expected_score(self, competitor: BaseCompetitor) -> float:
         """Calculate the expected score (probability of winning) against another competitor.
 
@@ -333,7 +352,7 @@ class BlendedCompetitor(BaseCompetitor):
 
         if self.blend_mode == "mean":
             es = []
-            for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=False):
+            for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=True):
                 es.append(c.expected_score(other_c))
             result = sum(es) / len(es)
             logger.debug("Mean expected score: %.4f", result)
@@ -356,7 +375,7 @@ class BlendedCompetitor(BaseCompetitor):
         self.verify_competitor_types(competitor)
         logger.debug("%s beat %s. Updating %d sub-competitors.", self, competitor, len(self.sub_competitors))
 
-        for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=False):
+        for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=True):
             logger.debug("Updating sub-competitors via beat: %s vs %s", c, other_c)
             c.beat(other_c)
 
@@ -374,6 +393,6 @@ class BlendedCompetitor(BaseCompetitor):
         self.verify_competitor_types(competitor)
         logger.debug("%s tied with %s. Updating %d sub-competitors.", self, competitor, len(self.sub_competitors))
 
-        for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=False):
+        for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=True):
             logger.debug("Updating sub-competitors via tied: %s vs %s", c, other_c)
             c.tied(other_c)  # Fixed: was using beat() instead of tied()

--- a/tests/test_BlendedCompetitor.py
+++ b/tests/test_BlendedCompetitor.py
@@ -4,6 +4,10 @@ from elote.competitors.base import MissMatchedCompetitorTypesException
 
 
 class TestBlendedCompetitor(unittest.TestCase):
+    @staticmethod
+    def _blended(*competitor_types):
+        return BlendedCompetitor(competitors=[{"type": competitor_type} for competitor_type in competitor_types])
+
     def test_Improvement(self):
         player1 = BlendedCompetitor(
             competitors=[
@@ -96,3 +100,31 @@ class TestBlendedCompetitor(unittest.TestCase):
 
         with self.assertRaises(MissMatchedCompetitorTypesException):
             player1.verify_competitor_types(player2)
+
+    def test_rejects_different_composition_lengths_before_mutation(self):
+        for operation in ("expected_score", "beat", "tied"):
+            with self.subTest(operation=operation):
+                player1 = self._blended("EloCompetitor", "GlickoCompetitor")
+                player2 = self._blended("EloCompetitor")
+                sub_competitors = player1.sub_competitors + player2.sub_competitors
+                initial_ratings = [c.rating for c in sub_competitors]
+
+                with self.assertRaisesRegex(
+                    MissMatchedCompetitorTypesException,
+                    r"\['EloCompetitor', 'GlickoCompetitor'\].*\['EloCompetitor'\]",
+                ):
+                    getattr(player1, operation)(player2)
+
+                self.assertEqual([c.rating for c in sub_competitors], initial_ratings)
+
+    def test_rejects_different_ordered_compositions(self):
+        for operation in ("expected_score", "beat", "tied"):
+            with self.subTest(operation=operation):
+                player1 = self._blended("EloCompetitor", "GlickoCompetitor")
+                player2 = self._blended("GlickoCompetitor", "EloCompetitor")
+
+                with self.assertRaisesRegex(
+                    MissMatchedCompetitorTypesException,
+                    r"BlendedCompetitor compositions .* cannot be co-mingled",
+                ):
+                    getattr(player1, operation)(player2)


### PR DESCRIPTION
Closes #91

## Summary

- validate that two `BlendedCompetitor` instances contain the same concrete sub-competitor types in the same order
- raise `MissMatchedCompetitorTypesException` with both compositions before prediction or rating mutation
- use strict `zip` iteration after validation as an internal invariant
- cover length and ordered-type mismatches across `expected_score`, `beat`, and `tied`, including unchanged child ratings after rejected updates

## Verification

- `.venv/bin/python -m pytest -q tests/test_BlendedCompetitor.py` — 6 passed
- `.venv/bin/python -m pytest -q --ignore=tests/test_examples.py` — 258 passed, 6 skipped
- `.venv/bin/python -m ruff check elote tests` — passed
- `git diff --check` — passed

Mutation check: removed the ensemble composition override and restored `strict=False` temporarily. The new suite failed in both regression tests: the length mismatch did not raise, and the equal-length mismatch raised only from a child competitor with the old child-level message. Restoring the implementation returned the focused suite to 6 passed.