### PR TITLE
Remove Colley rating tie perturbation

### DIFF
--- a/elote/competitors/colley.py
+++ b/elote/competitors/colley.py
@@ -268,18 +268,12 @@ class ColleyMatrixCompetitor(BaseCompetitor):
                 C_sparse = csc_matrix(C)
                 r = spsolve(C_sparse, b)
 
+            r = np.round(r, decimals=15)
+
             # Update ratings efficiently
             logger.debug("Updating ratings for %d competitors", n)
             for i, comp in enumerate(competitors):
                 comp._rating = float(r[i])  # Ensure Python float type
-
-            # Check for duplicate ratings and add small perturbations if needed
-            ratings = r.copy()
-            unique_ratings = np.unique(ratings)
-            if len(unique_ratings) < n:
-                # Add small perturbations to make ratings unique
-                for i in range(n):
-                    competitors[i]._rating += (i + 1) * 1e-10
 
             # Normalize ratings to ensure sum is n/2
             total_rating = np.sum(r)

--- a/tests/test_ColleyMatrixCompetitor.py
+++ b/tests/test_ColleyMatrixCompetitor.py
@@ -5,6 +5,15 @@ from elote.competitors.base import MissMatchedCompetitorTypesException
 
 
 class TestColleyMatrix(unittest.TestCase):
+    @staticmethod
+    def _symmetric_connected_population():
+        a, b, c, d = (ColleyMatrixCompetitor() for _ in range(4))
+        a.beat(b)
+        c.beat(d)
+        a.tied(c)
+        b.tied(d)
+        return a, b, c, d
+
     def test_improvement(self):
         """Test that beating stronger opponents improves rating."""
         initial_rating = 0.5
@@ -50,11 +59,9 @@ class TestColleyMatrix(unittest.TestCase):
         competitors[3].beat(competitors[4])
         competitors[4].beat(competitors[0])
 
-        # All ratings should be different after this circular pattern
+        # All competitors have identical records in this circular pattern
         ratings = [c.rating for c in competitors]
-        self.assertEqual(
-            len(set(ratings)), len(ratings), "Each competitor should have a unique rating after circular matches"
-        )
+        self.assertEqual(len(set(ratings)), 1)
 
         # Ratings should sum to n/2 = 2.5 (property of Colley Matrix Method)
         self.assertAlmostEqual(sum(ratings), len(competitors) / 2)
@@ -76,6 +83,17 @@ class TestColleyMatrix(unittest.TestCase):
 
         with self.assertRaises(MissMatchedCompetitorTypesException):
             player1.expected_score(player2)
+
+    def test_identical_records_have_identical_ratings(self):
+        a, b, c, d = self._symmetric_connected_population()
+
+        self.assertEqual(a.rating, c.rating)
+        self.assertEqual(b.rating, d.rating)
+
+    def test_duplicate_ratings_preserve_sum_invariant(self):
+        competitors = self._symmetric_connected_population()
+
+        self.assertAlmostEqual(sum(competitor.rating for competitor in competitors), 2.0, places=12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #90

## Summary

- remove Colley's artificial duplicate-rating perturbation so ties are no longer ordered by graph traversal
- canonicalize solver output at 15 decimal places so mathematically symmetric records compare exactly equal despite one-ulp linear-solver noise
- add the symmetric four-competitor regression fixture and assert both tied pairs are exactly equal
- tighten the duplicate-population sum invariant to 12 decimal places
- correct the existing circular-schedule assertion: all five competitors have identical 1-1 records, so equal ratings are the intended result

The 12-place sum assertion is the test carrying the `n/2` invariant guard; the older default-tolerance assertions pass even with the perturbation present.

`LambdaArena.leaderboard()` remains deterministic for tied populations because Python's sort is stable. The real arena fixture repeatedly returned `a, c, b, d`, preserving insertion order within the tied winner and loser groups.

## Verification

- `env -u VIRTUAL_ENV uv run --python 3.12 --extra dev pytest -q tests/test_ColleyMatrixCompetitor.py tests/test_ColleyMatrixCompetitor_known_values.py` — 14 passed
- `env -u VIRTUAL_ENV uv run --python 3.12 --extra dev pytest -q --ignore=tests/test_examples.py` — 258 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --python 3.12 --extra dev ruff check elote/competitors/colley.py tests/test_ColleyMatrixCompetitor.py` — passed
- `git diff --check` — passed
- stable-sort arena probe — repeated leaderboards matched and returned `a, c, b, d`

Mutation check: reinstated the original duplicate-detection/perturbation block and verified it was present before running the two new regressions. Both failed: the exact-equality test observed `0.6250000004 != 0.6250000003`, and the tightened sum test observed `2.000000001 != 2.0`. After restoring the fix, the whole runnable suite returned to 258 passed, 6 skipped.
