### PR TITLE
Vectorize the Bradley-Terry MM refit with NumPy

### DIFF
--- a/elote/competitors/bradley_terry.py
+++ b/elote/competitors/bradley_terry.py
@@ -26,6 +26,8 @@ References:
 import math
 from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
 
+import numpy as np
+
 from elote.competitors.base import BaseCompetitor, InvalidParameterException
 from elote.logging import logger
 
@@ -240,57 +242,49 @@ class BradleyTerryCompetitor(BaseCompetitor):
         idx = {comp: i for i, comp in enumerate(competitors)}
 
         # Win counts: wins[i][j] = number of times i beat j (ties count as 0.5 to each side).
-        wins = [[0.0] * n for _ in range(n)]
+        wins = np.zeros((n, n), dtype=np.float64)
         for i, comp in enumerate(competitors):
             for opponent, w in comp._head_to_head.items():
                 j = idx.get(opponent)
                 if j is not None:
-                    wins[i][j] += w
+                    wins[i, j] += w
 
         # Total games between each pair (symmetric).
-        games = [[wins[i][j] + wins[j][i] for j in range(n)] for i in range(n)]
+        games = wins + wins.T
 
         # Total wins per competitor (ties are already counted as half in the win matrix).
-        total_wins = [math.fsum(wins[i]) for i in range(n)]
+        total_wins = wins.sum(axis=1)
 
         # Strengths p_i = exp(beta_i). The Bradley-Terry log-likelihood is concave with a
         # unique maximum, so we seed from a flat, well-conditioned starting point rather than
         # warm-starting from the (possibly extreme) current strengths.
-        p = [1.0] * n
+        p = np.ones(n, dtype=np.float64)
 
         reg = self._reg
+        # Regularization: a virtual win and loss against a phantom opponent of unit strength,
+        # guaranteeing a finite, unique solution even for undefeated or winless competitors.
+        numerator = total_wins + reg
         for iteration in range(self._max_iter):
-            new_p = [0.0] * n
-            for i in range(n):
-                denominator = 0.0
-                for j in range(n):
-                    if i == j or games[i][j] == 0:
-                        continue
-                    denominator += games[i][j] / (p[i] + p[j])
-                # Regularization: a virtual win and loss against a phantom opponent of unit
-                # strength, guaranteeing a finite, unique solution even for undefeated or
-                # winless competitors.
-                numerator = total_wins[i] + reg
-                denominator += 2.0 * reg / (p[i] + 1.0)
-                new_p[i] = numerator / denominator if denominator > 0 else p[i]
+            # games[i][i] is zero, so the diagonal contributes nothing and needs no masking.
+            denominator = (games / (p[:, None] + p[None, :])).sum(axis=1) + 2.0 * reg / (p + 1.0)
+            new_p = np.divide(numerator, denominator, out=p.copy(), where=denominator > 0)
 
             # Normalize by the geometric mean to fix the overall scale.
-            log_sum = sum(math.log(v) for v in new_p if v > 0)
-            geo_mean = math.exp(log_sum / n)
+            geo_mean = math.exp(np.log(new_p).sum() / n)
             if geo_mean > 0:
-                new_p = [v / geo_mean for v in new_p]
+                new_p = new_p / geo_mean
 
-            max_delta = max(abs(math.log(new_p[i]) - math.log(p[i])) for i in range(n) if new_p[i] > 0)
+            max_delta = float(np.max(np.abs(np.log(new_p) - np.log(p))))
             p = new_p
             if max_delta < self._tol:
                 logger.debug("Bradley-Terry fit converged in %d iterations", iteration + 1)
                 break
 
         # Write back re-centered log-strengths (mean beta == 0).
-        betas = [math.log(v) for v in p]
-        mean_beta = sum(betas) / n
+        betas = np.log(p)
+        betas = betas - betas.mean()
         for i, comp in enumerate(competitors):
-            comp._beta = betas[i] - mean_beta
+            comp._beta = float(betas[i])
 
     def _export_parameters(self) -> Dict[str, Any]:
         """Export the parameters used to initialize this competitor.

--- a/tests/test_BradleyTerryCompetitor.py
+++ b/tests/test_BradleyTerryCompetitor.py
@@ -1,6 +1,8 @@
+import random
+import time
 import unittest
 
-from elote import BradleyTerryCompetitor, EloCompetitor
+from elote import BradleyTerryCompetitor, EloCompetitor, LambdaArena
 from elote.competitors.base import (
     BaseCompetitor,
     MissMatchedCompetitorTypesException,
@@ -138,6 +140,39 @@ class TestBradleyTerryCompetitor(unittest.TestCase):
             BradleyTerryCompetitor.configure_class(max_iter=0)
         with self.assertRaises(InvalidParameterException):
             BradleyTerryCompetitor.configure_class(scale=0)
+
+
+class TestBradleyTerryPerformance(unittest.TestCase):
+    """Wall-clock budget for the maximum-likelihood re-fit.
+
+    The MM update is re-run over the whole connected component after every result, so this
+    is the assertion that guards the vectorized fit against a regression to a Python-level
+    inner loop. Measured on the development machine: 5.9 s vectorized against 39.0 s for the
+    pure-Python fit it replaced, so the budget sits roughly 2.6x above one and 2.6x below the
+    other.
+    """
+
+    BUDGET_SECONDS = 15.0
+
+    def test_arena_refit_stays_within_wall_clock_budget(self):
+        rng = random.Random(7)
+        num_competitors = 40
+        strength = {i: rng.uniform(0.5, 3.0) for i in range(num_competitors)}
+        arena = LambdaArena(lambda a, b: strength[a] > strength[b], base_competitor=BradleyTerryCompetitor)
+        pairs = [tuple(rng.sample(range(num_competitors), 2)) for _ in range(200)]
+
+        start = time.perf_counter()
+        for a, b in pairs:
+            arena.matchup(a, b)
+        elapsed = time.perf_counter() - start
+
+        self.assertLess(
+            elapsed,
+            self.BUDGET_SECONDS,
+            msg=f"200 Bradley-Terry matchups over 40 competitors took {elapsed:.1f}s",
+        )
+        # Sanity check that the timed work actually fit ratings.
+        self.assertEqual(len(arena.leaderboard()), num_competitors)
 
 
 if __name__ == "__main__":

--- a/tests/test_BradleyTerryCompetitor_known_values.py
+++ b/tests/test_BradleyTerryCompetitor_known_values.py
@@ -1,4 +1,5 @@
 import math
+import random
 import unittest
 
 from elote import BradleyTerryCompetitor, EloCompetitor
@@ -61,6 +62,39 @@ class TestBradleyTerryKnownValues(unittest.TestCase):
         b.beat(c)
         self.assertGreater(a.rating, b.rating)
         self.assertGreater(b.rating, c.rating)
+
+    def test_fitted_ratings_reference_sequence(self):
+        # 40 seeded results over 8 competitors of increasing latent strength. The expected
+        # values were captured from the pure-Python MM fit that preceded the NumPy
+        # vectorization, so any change to the fit's numerics fails here.
+        expected = [
+            1406.526800597342,
+            1453.917525539735,
+            1359.3482613392841,
+            1637.441707487984,
+            1486.3943959448877,
+            1552.866921329233,
+            1608.3156308174016,
+            1495.1887569441324,
+        ]
+
+        rng = random.Random(20240401)
+        n = 8
+        competitors = [BradleyTerryCompetitor() for _ in range(n)]
+        strength = [1.0 + 0.5 * i for i in range(n)]
+        for _ in range(40):
+            i, j = rng.sample(range(n), 2)
+            roll = rng.random()
+            p_i = strength[i] / (strength[i] + strength[j])
+            if roll < 0.1:
+                competitors[i].tied(competitors[j])
+            elif roll < 0.1 + 0.9 * p_i:
+                competitors[i].beat(competitors[j])
+            else:
+                competitors[j].beat(competitors[i])
+
+        for i, (competitor, reference) in enumerate(zip(competitors, expected, strict=True)):
+            self.assertAlmostEqual(competitor.rating, reference, delta=1e-9, msg=f"competitor {i}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #89

## What changed

`BradleyTerryCompetitor._recalculate_ratings` now expresses the minorization-maximization update with NumPy array operations instead of a Python-level `for i` / `for j` double loop over the connected component. This is a pure vectorization:

- `_reg`, `_tol` and `_max_iter` keep their values.
- The regularization term, the geometric-mean normalization, the convergence test on the max change in log-strength, and the mean-zero re-centering of `_beta` are all unchanged.
- The `denominator > 0` fallback to the previous strength is preserved via `np.divide(..., out=p.copy(), where=denominator > 0)`.
- The `i == j` / `games[i][j] == 0` skips in the old inner loop needed no replacement: `games` has a zero diagonal by construction and zero entries contribute zero to the sum.

Two tests are added. Neither existing expected value in `tests/test_BradleyTerryCompetitor.py` or `tests/test_BradleyTerryCompetitor_known_values.py` was edited.

## Measurements

Same seeded `LambdaArena` harness on both sides (random pairings, outcomes from a fixed latent strength), measured on the development machine:

| case | before | after | speedup |
|---|---|---|---|
| n=25, 150 matches | 11.4 s | 3.4 s | 3.3x |
| n=40, 200 matches | 39.0 s | 5.9 s | 6.7x |
| n=60, 300 matches | 118.9 s | 12.2 s | 9.8x |

Maximum rating difference between the two implementations across all three cases: **4.55e-13** (on the ~1500-point reporting scale, i.e. relative ~3e-16). On the smaller 8-competitor reference sequence the ratings are bit-identical.

## Which assertion carries the guard

**`TestBradleyTerryPerformance::test_arena_refit_stays_within_wall_clock_budget`** (in `tests/test_BradleyTerryCompetitor.py`) is the guard. A perf fix produces the same values as the slow code, so only a wall-clock budget catches a regression here. It builds a seeded 40-competitor arena, runs 200 matchups, and asserts the loop finishes in under 15.0 s — roughly 2.6x above the vectorized time (5.9 s) and 2.6x below the pure-Python time (39.0 s), so it is not tuned tight against either side.

`TestBradleyTerryKnownValues::test_fitted_ratings_reference_sequence` is a **values-only** test: it asserts the eight final ratings of a fixed seeded 40-result sequence against literals captured from the pre-change implementation, to a 1e-9 tolerance. It documents that the rewrite did not change the numerics — it passes on the slow code too and guards nothing about performance. It is what catches a transcription error in the new expression.

## Verification

All commands run from a clean worktree with `env -u VIRTUAL_ENV uv run --extra dev ...`.

- **Full suite:** `pytest -q --ignore=tests/test_examples.py` → **258 passed, 6 skipped** (base `master` at d996f39 is 256 passed, 6 skipped; the two new tests are the delta). `tests/test_examples.py` is excluded because it fails wholesale on `master` too — it shells out to an interpreter that lacks `elote`.
- **Lint:** `make lint` (`ruff check .`) → `All checks passed!`
- **Types:** `mypy --python-version 3.12 elote` → `Success: no issues found in 24 source files`. (`make typecheck` pins `python_version = "3.10"` and aborts inside `scipy-stubs` before reaching `elote`; that is pre-existing and unrelated to this diff.)
- **`ruff format`:** the two files this PR touches under `elote/`/`tests/` already had pre-existing format non-conformances on `master`; this diff adds none and does not fix them.

### Mutation tests

The budget test was run against the pre-change implementation (restored with `git checkout HEAD -- elote/competitors/bradley_terry.py`, verified by grepping for the `for j in range(n)` inner loop):

- `test_arena_refit_stays_within_wall_clock_budget` → **FAILED**: `37.90586895798333 not less than 15.0`.
- `test_fitted_ratings_reference_sequence` → passed, as expected for a values-only test.

Three transcription errors were then introduced into the vectorized expression, each verified applied before running:

| mutation | reference-values test |
|---|---|
| `p[:, None] + p[None, :]` → `p[None, :] + p[None, :]` | **FAILED** (plus `test_two_player_mle_ratio`) |
| `2.0 * reg` → `1.0 * reg` in the denominator | **FAILED** |
| `wins.sum(axis=1)` → `wins.sum(axis=0)` | **FAILED** (plus two pre-existing tests) |

A fourth mutation, `games` → `games.T`, was **not** caught — correctly so: `games = wins + wins.T` is symmetric by construction, so it is a no-op rather than a real mutation.

The working tree was restored from a copy after each mutation and the suite re-confirmed green.

## Out of scope

As noted in the issue, warm-starting `p` from the current strengths is a further ~1.5x but shifts converged ratings by ~1e-4, so it is a behaviour change and is not done here. Likewise the deeper question of refitting the whole component after every single result.