### PR TITLE
Handle empty dataset splits safely

### DIFF
--- a/elote/datasets/utils.py
+++ b/elote/datasets/utils.py
@@ -29,6 +29,9 @@ def train_arena_with_dataset(
     Returns:
         The trained arena
     """
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+
     # Sort by timestamp if available
     train_data_with_time = [(a, b, outcome, ts, attrs) for a, b, outcome, ts, attrs in train_data if ts is not None]
     train_data_without_time = [(a, b, outcome, ts, attrs) for a, b, outcome, ts, attrs in train_data if ts is None]
@@ -40,6 +43,9 @@ def train_arena_with_dataset(
         sorted_data = train_data_with_time + train_data_without_time
     else:
         sorted_data = train_data
+
+    if not sorted_data:
+        return arena
 
     # Process in batches if requested
     if batch_size is None:
@@ -96,6 +102,9 @@ def evaluate_arena_with_dataset(
     Returns:
         History object containing the evaluation results
     """
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+
     # Create a new history object
     history = History()
 
@@ -110,6 +119,9 @@ def evaluate_arena_with_dataset(
         sorted_data = test_data_with_time + test_data_without_time
     else:
         sorted_data = test_data
+
+    if not sorted_data:
+        return history
 
     # Process in batches if requested
     if batch_size is None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -521,6 +521,15 @@ class TestDatasetUtils(unittest.TestCase):
         # Check that history was recorded
         self.assertGreater(len(trained_arena.history.bouts), 0)
 
+    def test_train_arena_with_empty_dataset(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        progress_callback = MagicMock()
+
+        trained_arena = train_arena_with_dataset(arena, [], progress_callback=progress_callback)
+
+        self.assertIs(trained_arena, arena)
+        progress_callback.assert_not_called()
+
     def test_evaluate_arena_with_dataset(self):
         """Test that evaluate_arena_with_dataset works correctly."""
         # Create a synthetic dataset
@@ -542,6 +551,43 @@ class TestDatasetUtils(unittest.TestCase):
 
         # Check that history was recorded
         self.assertGreater(len(history.bouts), 0)
+
+    def test_evaluate_arena_with_empty_dataset(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        progress_callback = MagicMock()
+
+        history = evaluate_arena_with_dataset(arena, [], progress_callback=progress_callback)
+
+        self.assertEqual(history.bouts, [])
+        progress_callback.assert_not_called()
+
+    def test_dataset_helpers_reject_non_positive_batch_sizes(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        data = [("A", "B", 1.0, None, None)]
+
+        for helper in (train_arena_with_dataset, evaluate_arena_with_dataset):
+            for batch_size in (0, -1):
+                for dataset in ([], data):
+                    with self.subTest(helper=helper.__name__, batch_size=batch_size, empty=not dataset):
+                        with self.assertRaisesRegex(ValueError, "batch_size must be a positive integer"):
+                            helper(arena, dataset, batch_size=batch_size)
+
+    def test_dataset_helpers_report_batched_progress(self):
+        data = [
+            ("A", "B", 1.0, None, None),
+            ("A", "C", 1.0, None, None),
+            ("B", "C", 1.0, None, None),
+        ]
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        train_progress = MagicMock()
+        eval_progress = MagicMock()
+
+        train_arena_with_dataset(arena, data, batch_size=2, progress_callback=train_progress)
+        history = evaluate_arena_with_dataset(arena, data, batch_size=2, progress_callback=eval_progress)
+
+        self.assertEqual(train_progress.call_args_list, [unittest.mock.call(2, 3), unittest.mock.call(3, 3)])
+        self.assertEqual(eval_progress.call_args_list, [unittest.mock.call(2, 3), unittest.mock.call(3, 3)])
+        self.assertEqual(len(history.bouts), 3)
 
     def test_train_and_evaluate_arena(self):
         """Test that train_and_evaluate_arena works correctly."""


### PR DESCRIPTION
Closes #107

## Summary

- return the unchanged arena or an empty `History` for empty dataset inputs
- reject explicit zero and negative batch sizes with a clear `ValueError`
- cover empty inputs, callback behavior, invalid sizes, and non-empty batched progress through the public helpers

## Verification

- `env -u VIRTUAL_ENV .venv/bin/python -m pytest -q tests/test_datasets.py` — 14 passed, 6 skipped
- `env -u VIRTUAL_ENV .venv/bin/python -m pytest -q --ignore=tests/test_examples.py` — 266 passed, 6 skipped
- `env -u VIRTUAL_ENV .venv/bin/python -m ruff check .` — passed
- `git diff --check` — passed
- Mutation check: removed both validation and empty-input guards; all three focused regression tests failed with the original `ZeroDivisionError` behavior, then passed after restoration
