### PR TITLE
Record a Bout for drawn training matchups

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -95,6 +95,7 @@ class LambdaArena(BaseArena):
         b: Any,
         attributes: Optional[Dict[str, Any]] = None,
         match_time: Optional[datetime.datetime] = None,
+        outcome: Optional[float] = None,
     ) -> None:
         """Process a single matchup between two competitors.
 
@@ -107,7 +108,16 @@ class LambdaArena(BaseArena):
             b: The second competitor or competitor identifier.
             attributes (dict, optional): Additional attributes to record with this bout.
             match_time (datetime, optional): The time when the match occurred.
+            outcome (float, optional): A known result for this matchup, expressed from
+                a's perspective as ``1.0`` (a wins), ``0.0`` (b wins) or ``0.5`` (draw).
+                When supplied, the comparison function is not called.
+
+        Raises:
+            ValueError: If ``outcome`` is supplied and is not one of 1.0, 0.0 or 0.5.
         """
+        if outcome is not None and outcome not in (1.0, 0.0, 0.5):
+            raise ValueError(f"outcome must be one of 1.0, 0.0 or 0.5, got {outcome!r}")
+
         if a not in self.competitors:
             self.competitors[a] = self.base_competitor(**self.base_competitor_kwargs)
         if b not in self.competitors:
@@ -115,10 +125,18 @@ class LambdaArena(BaseArena):
 
         predicted_outcome: float = self.expected_score(a, b)
 
-        if attributes:
-            res = self.func(a, b, attributes=attributes)
+        res: Optional[bool]
+        if outcome is None:
+            if attributes:
+                res = self.func(a, b, attributes=attributes)
+            else:
+                res = self.func(a, b)
+        elif outcome == 1.0:
+            res = True
+        elif outcome == 0.0:
+            res = False
         else:
-            res = self.func(a, b)
+            res = None
 
         # Check if the competitor supports time-based ratings
         supports_time = hasattr(self.competitors[a], "_last_activity")

--- a/elote/datasets/utils.py
+++ b/elote/datasets/utils.py
@@ -67,15 +67,8 @@ def train_arena_with_dataset(
                 # B wins
                 arena.matchup(b, a, attributes=attributes)
             else:
-                # Draw - we need to handle this specially
-                # First, get the competitors
-                if a not in arena.competitors:
-                    arena.competitors[a] = arena.base_competitor(**arena.base_competitor_kwargs)
-                if b not in arena.competitors:
-                    arena.competitors[b] = arena.base_competitor(**arena.base_competitor_kwargs)
-
-                # Then, record the draw
-                arena.competitors[a].tied(arena.competitors[b])
+                # Draw
+                arena.matchup(a, b, attributes=attributes, outcome=0.5)
 
         # Report progress
         if progress_callback is not None:

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -68,6 +68,46 @@ class TestArenas(unittest.TestCase):
         # Y should have won despite X normally being greater alphabetically
         self.assertGreater(arena.competitors["Y"].rating, initial_rating)
 
+    def test_lambda_arena_matchup_outcome_override(self):
+        """A supplied outcome bypasses the comparison function and is recorded as a bout."""
+        calls = []
+
+        def compare(a, b, attributes=None):
+            calls.append((a, b))
+            return True
+
+        arena = LambdaArena(compare)
+        attributes = {"round": 1}
+
+        arena.matchup("A", "B", attributes=attributes, outcome=0.5)
+        arena.matchup("C", "D", outcome=1.0)
+        arena.matchup("E", "F", outcome=0.0)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(len(arena.history.bouts), 3)
+
+        draw_bout, win_bout, loss_bout = arena.history.bouts
+        self.assertEqual(draw_bout._normalized_outcome(), "draw")
+        self.assertEqual(draw_bout.attributes, attributes)
+        self.assertEqual(win_bout._normalized_outcome(), "a")
+        self.assertEqual(loss_bout._normalized_outcome(), "b")
+
+        # The ratings follow the supplied outcome, not the comparison function.
+        initial_rating = EloCompetitor().rating
+        self.assertEqual(arena.competitors["A"].rating, initial_rating)
+        self.assertGreater(arena.competitors["C"].rating, initial_rating)
+        self.assertGreater(arena.competitors["F"].rating, initial_rating)
+
+    def test_lambda_arena_matchup_rejects_unknown_outcome(self):
+        """Only 1.0, 0.0 and 0.5 are valid explicit outcomes."""
+        arena = LambdaArena(lambda a, b: True)
+
+        with self.assertRaisesRegex(ValueError, "outcome must be one of"):
+            arena.matchup("A", "B", outcome=0.25)
+
+        self.assertEqual(arena.history.bouts, [])
+        self.assertEqual(arena.competitors, {})
+
     def test_lambda_arena_tournament(self):
         """Test that tournaments work correctly in the LambdaArena."""
         arena = LambdaArena(lambda a, b: a > b)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -21,6 +21,7 @@ from elote import (
     train_and_evaluate_arena,
     list_available_datasets,
 )
+from elote.arenas.base import Bout, History
 
 # Conditionally import optional datasets
 try:
@@ -588,6 +589,111 @@ class TestDatasetUtils(unittest.TestCase):
         self.assertEqual(train_progress.call_args_list, [unittest.mock.call(2, 3), unittest.mock.call(3, 3)])
         self.assertEqual(eval_progress.call_args_list, [unittest.mock.call(2, 3), unittest.mock.call(3, 3)])
         self.assertEqual(len(history.bouts), 3)
+
+    def test_train_arena_records_a_bout_for_every_row_including_draws(self):
+        """Every training row, drawn or decisive, must appear in the arena history."""
+        dataset = SyntheticDataset(
+            num_competitors=12,
+            num_matchups=200,
+            seed=7,
+            draw_probability=0.9,
+            noise_std=200.0,
+        )
+        rows = dataset.get_data()
+        draws = [row for row in rows if row[2] == 0.5]
+        self.assertEqual(len(draws), 62)
+
+        arena = LambdaArena(lambda a, b, attributes=None: True, base_competitor=EloCompetitor)
+        trained_arena = train_arena_with_dataset(arena, rows)
+
+        self.assertEqual(len(trained_arena.history.bouts), len(rows))
+
+    def test_train_arena_records_draw_bouts_with_outcome_and_attributes(self):
+        """Drawn rows must record a draw outcome and carry their attributes through."""
+        draw_attributes = {"event": "round-3", "board": 7}
+        win_attributes = {"event": "round-4", "board": 2}
+        data = [
+            ("A", "B", 0.5, None, draw_attributes),
+            ("A", "B", 1.0, None, win_attributes),
+        ]
+
+        arena = LambdaArena(lambda a, b, attributes=None: True, base_competitor=EloCompetitor)
+        trained_arena = train_arena_with_dataset(arena, data)
+
+        self.assertEqual(len(trained_arena.history.bouts), 2)
+        draw_bout, win_bout = trained_arena.history.bouts
+        self.assertEqual((draw_bout.a, draw_bout.b), ("A", "B"))
+        self.assertEqual(draw_bout._normalized_outcome(), "draw")
+        self.assertEqual(draw_bout.attributes, draw_attributes)
+        self.assertEqual(win_bout._normalized_outcome(), "a")
+        self.assertEqual(win_bout.attributes, win_attributes)
+
+    def test_accuracy_by_prior_bouts_counts_drawn_training_bouts(self):
+        """Prior-bout bins must be seeded from the complete training history."""
+        dataset = SyntheticDataset(
+            num_competitors=12,
+            num_matchups=200,
+            seed=7,
+            draw_probability=0.9,
+            noise_std=200.0,
+        )
+        split = dataset.time_split(test_ratio=0.3)
+        self.assertEqual(len(split.train), 140)
+        self.assertEqual(sum(1 for row in split.train if row[2] == 0.5), 43)
+
+        arena = LambdaArena(lambda a, b, attributes=None: True, base_competitor=EloCompetitor)
+        train_arena_with_dataset(arena, split.train)
+
+        # competitor_0 and competitor_2 appear in 23 and 24 training rows respectively,
+        # of which 20 and 17 are decisive -- so the pre-fix history binned this bout at 17.
+        history = History()
+        history.add_bout(Bout("competitor_0", "competitor_2", 0.5, 0.5))
+        binned = history.accuracy_by_prior_bouts(arena, bin_size=1)["binned"]
+
+        self.assertEqual(list(binned.keys()), [23])
+        self.assertEqual(binned[23]["total"], 1)
+
+    def test_train_arena_ratings_unchanged_by_draw_bout_recording(self):
+        """Recording draw bouts must not change the ratings the draws produce.
+
+        The expected values were captured before the draw branch was routed through
+        ``LambdaArena.matchup``, when draws called ``competitor.tied()`` directly.
+        """
+        dataset = SyntheticDataset(
+            num_competitors=12,
+            num_matchups=200,
+            seed=7,
+            draw_probability=0.9,
+            noise_std=200.0,
+        )
+
+        arena = LambdaArena(
+            lambda a, b, attributes=None: True,
+            base_competitor=EloCompetitor,
+            base_competitor_kwargs={"initial_rating": 1500},
+        )
+        trained_arena = train_arena_with_dataset(arena, dataset.get_data())
+
+        expected = [
+            ("competitor_8", 1713.983015442147),
+            ("competitor_0", 1693.4325854310873),
+            ("competitor_3", 1587.1903055628625),
+            ("competitor_9", 1533.9165724655888),
+            ("competitor_5", 1527.8487497240067),
+            ("competitor_2", 1512.8963021933225),
+            ("competitor_6", 1505.589946609411),
+            ("competitor_11", 1484.3664770734704),
+            ("competitor_1", 1436.529021706998),
+            ("competitor_10", 1385.3428838446823),
+            ("competitor_4", 1376.9278018383588),
+            ("competitor_7", 1241.976338108064),
+        ]
+        leaderboard = trained_arena.leaderboard()
+        self.assertEqual(len(leaderboard), len(expected))
+        for entry, (name, rating) in zip(leaderboard, expected, strict=True):
+            with self.subTest(competitor=name):
+                self.assertEqual(entry["competitor"], name)
+                self.assertAlmostEqual(entry["rating"], rating, places=10)
 
     def test_train_and_evaluate_arena(self):
         """Test that train_and_evaluate_arena works correctly."""


### PR DESCRIPTION
Closes #106

## What changed

`train_arena_with_dataset` handled drawn rows in an `else` branch that bypassed the arena
entirely — it lazily created competitors through `arena.competitors` /
`arena.base_competitor` / `arena.base_competitor_kwargs` and called
`competitor_a.tied(competitor_b)` directly. The draw was applied to the ratings, but no
`Bout` was appended to `arena.history` and the row's `attributes` were dropped.

- `LambdaArena.matchup` gains an optional `outcome` override (`1.0` / `0.0` / `0.5`,
  from `a`'s perspective). When supplied, the comparison function is not called and the
  supplied result drives both the rating update and the recorded `Bout`. Anything other
  than those three values raises `ValueError` before any competitor is created.
- `train_arena_with_dataset`'s draw branch is now a single
  `arena.matchup(a, b, attributes=attributes, outcome=0.5)`. The helper no longer touches
  `arena.competitors`, `arena.base_competitor` or `arena.base_competitor_kwargs`.

I picked the `outcome=` override over a dedicated "record a draw" method because it is the
more general of the two shapes the issue sketched: it also gives callers a way to feed
known results into an arena without the "comparison function must always return `True`"
convention the dataset helpers rely on. Only the draw branch is rewired in this PR — the
win/loss branches still encode the result by argument order, and passing historical
`match_time` values remains out of scope (it is blocked by #101).

## Verification

All commands run from a clean worktree with `env -u VIRTUAL_ENV uv run --extra dev`.

**Gates**

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` →
  **272 passed, 6 skipped** (258 passed, 6 skipped before this branch's 6 new tests plus
  the ones merged since; `tests/test_examples.py` is excluded because it shells out to an
  interpreter without `elote` installed, on `master` too).
- `make lint` → `All checks passed!`
- `uv run mypy --python-version 3.12 elote` → `Success: no issues found in 24 source files`
- `ruff format --check` on the three files whose formatting this PR could affect
  (`elote/arenas/lambda_arena.py`, `elote/datasets/utils.py`, `tests/test_Arenas.py`) →
  clean. `tests/test_datasets.py` was already non-conformant on `master` (unrelated
  import-block and trailing-comma spots); the added block itself is conformant and I left
  the pre-existing spots alone.

**Bout count, by exact value**

`SyntheticDataset(num_competitors=12, num_matchups=200, seed=7, draw_probability=0.9,
noise_std=200.0)` yields 200 rows, 62 of them draws. Before: 138 bouts recorded. After:
200. Asserted as an exact equality against `len(rows)` in
`test_train_arena_records_a_bout_for_every_row_including_draws`.

**Prior-bout bins**

On the `time_split(test_ratio=0.3)` training half (140 rows, 43 draws), `competitor_0` and
`competitor_2` appear in 23 and 24 rows, of which 20 and 17 are decisive.
`test_accuracy_by_prior_bouts_counts_drawn_training_bouts` feeds one evaluation bout
between them through `History.accuracy_by_prior_bouts(arena, bin_size=1)` and asserts the
bin key is **23**. On the pre-fix code the same assertion produces **17**.

**Ratings unchanged**

The full 12-competitor leaderboard was captured from `master` before editing any source
and is asserted to 10 decimal places in
`test_train_arena_ratings_unchanged_by_draw_bout_recording`; it matches exactly after the
change. Separately, a one-off sweep trained the same draw-heavy dataset through the old
draw branch and the new one for all eight competitor classes: max rating delta was exactly
0.0 for Elo, TrueSkill, ECF, DWZ, Colley and Bradley-Terry, and 3.1e-09 / 1.3e-10 for
Glicko-1 / Glicko-2 — that residue is the known wall-clock RD inflation between the two
runs, not a behaviour change (`tied(x, match_time=None)` is identical to `tied(x)` for
both).

**Mutation checks**

1. Draw branch reverted to the direct `.tied()` call (mutation grepped to confirm it
   landed) → 3 failures:
   `test_train_arena_records_a_bout_for_every_row_including_draws` (1 != 2 / count
   mismatch), `test_train_arena_records_draw_bouts_with_outcome_and_attributes`, and
   `test_accuracy_by_prior_bouts_counts_drawn_training_bouts` (`[17] != [23]`).
   `test_train_arena_ratings_unchanged_by_draw_bout_recording` passes on this mutation by
   design — it documents that the fix is rating-inert, it does not guard the fix.
2. `outcome=0.5` changed to `outcome=0.0` in the helper → the ratings test and the
   attributes/outcome test both fail, so the leaderboard literals are not vacuous.

The suite was re-run green after restoring from each mutation.