### PR TITLE
Fix TrueSkill expected_score draw adjustment

### DIFF
--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -454,26 +454,22 @@ class TrueSkillCompetitor(BaseCompetitor):
         sigma_squared_sum = self._sigma**2 + competitor_ts._sigma**2
         v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
-        # Calculate the win probability
-        t = mu_diff / v
-        win_prob = self._gaussian_cdf(t)
-
-        # Calculate the draw probability
+        # Decompose the outcome into win/draw/loss against the draw margin, then
+        # score a draw as half a win.
         draw_margin = self._calculate_draw_margin(self._beta, self._draw_probability)
-        draw_prob = self._gaussian_cdf((mu_diff + draw_margin) / v) - self._gaussian_cdf((mu_diff - draw_margin) / v)
-
-        # Adjust win probability to account for draws
-        adjusted_win_prob = win_prob - draw_prob / 2
+        win_prob = self._gaussian_cdf((mu_diff - draw_margin) / v)
+        draw_prob = self._gaussian_cdf((mu_diff + draw_margin) / v) - win_prob
+        expected = win_prob + draw_prob / 2
 
         logger.debug(
-            "Expected score calculation: mu_diff=%.2f, v=%.2f, win_prob=%.4f, draw_prob=%.4f, adjusted_win_prob=%.4f",
+            "Expected score calculation: mu_diff=%.2f, v=%.2f, win_prob=%.4f, draw_prob=%.4f, expected=%.4f",
             mu_diff,
             v,
             win_prob,
             draw_prob,
-            adjusted_win_prob,
+            expected,
         )
-        return adjusted_win_prob
+        return expected
 
     def beat(self, competitor: BaseCompetitor) -> None:
         """Update ratings after this competitor has won against the given competitor.

--- a/tests/test_TrueSkillCompetitor.py
+++ b/tests/test_TrueSkillCompetitor.py
@@ -1,6 +1,6 @@
 import unittest
 import math
-from elote import TrueSkillCompetitor, EloCompetitor, LambdaArena
+from elote import TrueSkillCompetitor, EloCompetitor, BlendedCompetitor, LambdaArena
 from elote.competitors.base import MissMatchedCompetitorTypesException, InvalidParameterException
 
 
@@ -113,9 +113,8 @@ class TestTrueSkill(unittest.TestCase):
         # Test with equal ratings
         player1 = TrueSkillCompetitor(initial_mu=25, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25, initial_sigma=8.333)
-        # Externally derived from sqrt(2*beta^2 + sigma_i^2 + sigma_j^2); the
-        # single-noise form gives ~0.335.
-        self.assertAlmostEqual(player1.expected_score(player2), 0.342657, places=5)
+        # An even matchup is exactly 0.5 under the draw-aware expected score.
+        self.assertAlmostEqual(player1.expected_score(player2), 0.500000, places=5)
 
         # Test with different ratings
         player1 = TrueSkillCompetitor(initial_mu=30, initial_sigma=8.333)
@@ -212,6 +211,52 @@ class TestTrueSkill(unittest.TestCase):
         # Trying to tie with a different competitor type should raise an exception
         with self.assertRaises(MissMatchedCompetitorTypesException):
             player1.tied(player2)
+
+
+class TestTrueSkillExpectedScoreContract(unittest.TestCase):
+    """Probability contract for TrueSkill's draw-aware expected score."""
+
+    def test_identical_competitors_predict_even(self):
+        """Two default competitors are an even matchup."""
+        self.assertAlmostEqual(TrueSkillCompetitor().expected_score(TrueSkillCompetitor()), 0.5, places=12)
+
+    def test_identical_blends_containing_trueskill_predict_even(self):
+        """A blend containing TrueSkill inherits the even-matchup prediction."""
+
+        def blend():
+            return BlendedCompetitor(
+                competitors=[
+                    {"type": "EloCompetitor", "competitor_kwargs": {}},
+                    {"type": "TrueSkillCompetitor", "competitor_kwargs": {}},
+                ]
+            )
+
+        self.assertAlmostEqual(blend().expected_score(blend()), 0.5, places=12)
+
+    def test_expected_scores_are_complementary(self):
+        """expected_score is exactly complementary in both argument orders."""
+        cases = [
+            (TrueSkillCompetitor(initial_mu=30, initial_sigma=5), TrueSkillCompetitor(initial_mu=20, initial_sigma=5)),
+            (TrueSkillCompetitor(initial_mu=25, initial_sigma=3), TrueSkillCompetitor(initial_mu=25, initial_sigma=8)),
+        ]
+
+        # The configuration that returned a negative probability before the draw
+        # adjustment was corrected: four (and then five) wins for the same player.
+        winner = TrueSkillCompetitor()
+        loser = TrueSkillCompetitor()
+        for _ in range(4):
+            winner.beat(loser)
+        cases.append((winner, loser))
+        winner.beat(loser)
+        cases.append((winner, loser))
+
+        for a, b in cases:
+            with self.subTest(a=repr(a), b=repr(b)):
+                forward = a.expected_score(b)
+                reverse = b.expected_score(a)
+                self.assertAlmostEqual(forward + reverse, 1.0, places=12)
+                self.assertGreaterEqual(reverse, 0.0)
+                self.assertLessEqual(forward, 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_TrueSkillCompetitor_known_values.py
+++ b/tests/test_TrueSkillCompetitor_known_values.py
@@ -83,34 +83,34 @@ class TestTrueSkillKnownValues(unittest.TestCase):
 
         Reference values are computed independently of ``expected_score`` from the
         canonical two-player TrueSkill formula
-        ``win_prob = Phi(mu_diff / v) - draw_prob / 2`` where
-        ``v = sqrt(2*beta^2 + sigma_i^2 + sigma_j^2)`` (beta=4.166,
-        draw_probability=0.10). None of these assertions call the method under
-        test to derive its own expectation, and each fails if the beta^2 term is
-        mutated back to the single-noise ``sqrt(beta^2 + ...)`` form.
+        ``0.5 * (Phi((mu_diff + eps) / v) + Phi((mu_diff - eps) / v))`` where
+        ``v = sqrt(2*beta^2 + sigma_i^2 + sigma_j^2)`` and ``eps`` is the draw
+        margin (beta=4.166, draw_probability=0.10). None of these assertions call
+        the method under test to derive its own expectation, and the unequal-mean
+        pair fails if the beta^2 term is mutated back to the single-noise
+        ``sqrt(beta^2 + ...)`` form.
         """
-        # Equal ratings: symmetric matchup. mu_diff=0 so win_prob=0.5, and the
-        # draw correction depends on v, so the missing beta^2 term still shifts
-        # the result (single-noise form gives ~0.335).
+        # Equal ratings: symmetric matchup, so the draw-aware expected score is
+        # exactly 0.5 for any v.
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
-        self.assertAlmostEqual(player1.expected_score(player2), 0.342657, places=5)
+        self.assertAlmostEqual(player1.expected_score(player2), 0.500000, places=5)
 
         # Unequal means, equal sigmas: the corrected variance term materially
-        # softens the prediction (single-noise form gives ~0.761).
+        # softens the prediction (single-noise form gives ~0.842074).
         player1 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
         player2 = TrueSkillCompetitor(initial_mu=20.0, initial_sigma=5.0)
-        self.assertAlmostEqual(player1.expected_score(player2), 0.732131, places=5)
+        self.assertAlmostEqual(player1.expected_score(player2), 0.822961, places=5)
 
-        # Same matchup reversed: the weaker player. Probabilities are not required
-        # to sum to 1 because of the draw correction.
-        self.assertAlmostEqual(player2.expected_score(player1), 0.009389, places=5)
+        # Same matchup reversed: the weaker player, complementary by construction
+        # (single-noise form gives ~0.157926).
+        self.assertAlmostEqual(player2.expected_score(player1), 0.177039, places=5)
 
-        # Equal means, different sigmas (single-noise form gives ~0.287).
+        # Equal means, different sigmas: still an even matchup.
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=3.0)
         player2 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.0)
         expected_score = player1.expected_score(player2)
-        self.assertAlmostEqual(expected_score, 0.303476, places=5)
+        self.assertAlmostEqual(expected_score, 0.500000, places=5)
         # Probability bounds remain covered.
         self.assertGreaterEqual(expected_score, 0.0)
         self.assertLessEqual(expected_score, 1.0)
@@ -276,33 +276,37 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertNotEqual(player1_low_sigma.sigma, 3.0)
         self.assertNotEqual(player1_high_sigma.sigma, 8.333)
 
-    def test_draw_probability_effect(self):
-        """Test the effect of draw probability on expected scores."""
-        # Create a player with default parameters
+    def test_draw_margin_effect(self):
+        """A wider draw margin pulls the expected score toward 0.5.
+
+        The sweep is ordered by the resulting margin, not by draw probability:
+        ``_calculate_draw_margin`` (used only by ``expected_score``) maps a
+        HIGHER draw probability to a SMALLER margin, the opposite direction from
+        the ``ndtri((p + 1) / 2)`` margin ``beat``/``tied`` use. That
+        inconsistency is a separate defect and is out of scope here.
+        """
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
 
-        # Store the original draw probability
         original_draw_prob = TrueSkillCompetitor._draw_probability
 
         try:
-            # Test with different draw probabilities
-            expected_scores = []
-            draw_probs = [0.05, 0.10, 0.20]
+            # Ordered so that the draw margin strictly increases.
+            draw_probs = [0.20, 0.10, 0.05]
+            margins = []
+            distances_from_even = []
 
             for draw_prob in draw_probs:
-                # Change the draw probability
                 TrueSkillCompetitor._draw_probability = draw_prob
+                margins.append(TrueSkillCompetitor._calculate_draw_margin(TrueSkillCompetitor._beta, draw_prob))
+                distances_from_even.append(abs(player1.expected_score(player2) - 0.5))
 
-                # Calculate expected score
-                expected_scores.append(player1.expected_score(player2))
-
-            # Higher draw probability should make expected scores closer to 0.5
-            self.assertLess(expected_scores[0], expected_scores[1])
-            self.assertLess(expected_scores[1], expected_scores[2])
+            self.assertLess(margins[0], margins[1])
+            self.assertLess(margins[1], margins[2])
+            self.assertLess(distances_from_even[2], distances_from_even[1])
+            self.assertLess(distances_from_even[1], distances_from_even[0])
 
         finally:
-            # Restore the original draw probability
             TrueSkillCompetitor._draw_probability = original_draw_prob
 
 

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -2,6 +2,8 @@ import unittest
 from elote import (
     EloCompetitor,
     GlickoCompetitor,
+    Glicko2Competitor,
+    TrueSkillCompetitor,
     ECFCompetitor,
     DWZCompetitor,
     BlendedCompetitor,
@@ -417,6 +419,35 @@ class TestUnifiedInterface(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             competitor1.rating = 1500
+
+
+class TestExpectedScoreBounds(unittest.TestCase):
+    """Every concrete competitor must return a probability in [0, 1]."""
+
+    COMPETITOR_CLASSES = (
+        EloCompetitor,
+        GlickoCompetitor,
+        Glicko2Competitor,
+        TrueSkillCompetitor,
+        ECFCompetitor,
+        DWZCompetitor,
+        ColleyMatrixCompetitor,
+        BradleyTerryCompetitor,
+    )
+
+    def test_expected_score_within_bounds_after_results(self):
+        """A run of wins and draws never pushes expected_score outside [0, 1]."""
+        for competitor_class in self.COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                a = competitor_class()
+                b = competitor_class()
+
+                for step, result in enumerate(["beat", "beat", "tied", "beat", "beat", "tied", "beat"]):
+                    getattr(a, result)(b)
+                    for first, second in ((a, b), (b, a)):
+                        score = first.expected_score(second)
+                        self.assertGreaterEqual(score, 0.0, f"step {step} ({result}) produced {score}")
+                        self.assertLessEqual(score, 1.0, f"step {step} ({result}) produced {score}")
 
 
 if __name__ == "__main__":

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -435,6 +435,10 @@ class TestExpectedScoreBounds(unittest.TestCase):
         BradleyTerryCompetitor,
     )
 
+    # A lopsided run: long enough that a one-sided rating gap opens up, with
+    # draws interleaved so draw handling is exercised too.
+    RESULTS = ["beat"] * 5 + ["tied"] + ["beat"] * 3
+
     def test_expected_score_within_bounds_after_results(self):
         """A run of wins and draws never pushes expected_score outside [0, 1]."""
         for competitor_class in self.COMPETITOR_CLASSES:
@@ -442,7 +446,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
                 a = competitor_class()
                 b = competitor_class()
 
-                for step, result in enumerate(["beat", "beat", "tied", "beat", "beat", "tied", "beat"]):
+                for step, result in enumerate(self.RESULTS):
                     getattr(a, result)(b)
                     for first, second in ((a, b), (b, a)):
                         score = first.expected_score(second)


### PR DESCRIPTION
Closes #105

## What changed

`TrueSkillCompetitor.expected_score` subtracted half the draw probability from a base term that was already draw-inclusive:

```python
win_prob = Phi(mu_diff / v)                  # ~= P(win) + P(draw)/2
adjusted_win_prob = win_prob - draw_prob / 2 # subtracts the draw mass a second time
```

so it returned roughly `P(win) - P(draw)/2`. It now decomposes the outcome against the draw margin and scores a draw as half a win:

```python
win_prob  = Phi((mu_diff - draw_margin) / v)
draw_prob = Phi((mu_diff + draw_margin) / v) - win_prob
return win_prob + draw_prob / 2
```

This is in `[0, 1]` by construction, exactly complementary (`Phi(-x) == 1 - Phi(x)`), and `0.5` for an even matchup. The `v = sqrt(2*beta^2 + ...)` term from #78 is untouched, as are `beat`/`lost_to`/`tied`.

### Tests

- Corrected the five frozen literals (`0.342657` → `0.500000`, `0.732131` → `0.822961`, `0.009389` → `0.177039`, `0.303476` → `0.500000`, plus the duplicate `0.342657` in `test_TrueSkillCompetitor.py`) and removed the docstring sentence claiming probabilities need not sum to 1. The values were derived from the formula in a standalone script, not read off the method.
- New `TestTrueSkillExpectedScoreContract` in `tests/test_TrueSkillCompetitor.py`: identical defaults predict `0.5`; an Elo+TrueSkill blend of two fresh identical blends predicts `0.5`; and `a.expected_score(b) + b.expected_score(a) == 1.0` to 12 places across four configurations, including the 4-win and 5-win pairs that previously returned `-0.007066` and `-0.010896`.
- New `TestExpectedScoreBounds` in `tests/test_unified_interface.py`: all eight concrete classes stay within `[0, 1]` in both argument orders after every step of a nine-result run of wins and draws.

### One pre-existing test I had to rewrite

`test_draw_probability_effect` asserted "higher draw probability moves the expected score closer to 0.5" and passed on the buggy code only coincidentally — its `player1` is the weaker player, so the erroneous subtraction happened to move in the asserted direction. It fails under the fix, because `_calculate_draw_margin` (`erfinv(1 - 2p)`, used only by `expected_score`) maps a *higher* draw probability to a *smaller* margin — the opposite direction from the `ndtri((p + 1) / 2)` margin `beat`/`tied` use:

| draw_probability | `_calculate_draw_margin` | margin used by `beat`/`tied` |
|---|---|---|
| 0.05 | 6.8525 | 0.3694 |
| 0.10 | 5.3389 | 0.7403 |
| 0.20 | 3.5062 | 1.4926 |

That inconsistency is a separate defect and is out of this issue's scope — the corrected reference values above are computed against the existing helper, so changing it here would invalidate them. The test is now `test_draw_margin_effect`, ordered by the resulting margin and asserting the invariant that holds regardless of the mapping (a wider draw margin pulls the expected score toward 0.5), with the discrepancy documented in its docstring.

## Verification

All commands run from a clean worktree at `968ca7e`.

**Suite** — `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` → **270 passed, 6 skipped** (266 before this PR; `test_examples.py` is excluded because it shells out to an interpreter without `elote` installed, which fails on `master` too).

**Lint** — `make lint` → `All checks passed!`. `ruff format --check` on the four touched files → `4 files already formatted`. `uv run mypy --python-version 3.12 elote` → `Success: no issues found in 24 source files`.

**Mutation checks** (fix committed first, mutation applied on top, line grepped to confirm it landed, then `git checkout` restored and the suite re-run green at 270 passed):

| mutation | result |
|---|---|
| Reinstate `expected = win_prob - draw_prob / 2` with `win_prob = Phi(mu_diff / v)` | **6 failed** — including `test_expected_score` (known values), `test_expected_scores_are_complementary`, `test_identical_competitors_predict_even`, `test_identical_blends_containing_trueskill_predict_even`, and `TestExpectedScoreBounds::test_expected_score_within_bounds_after_results` |
| Reinstate single-noise `v = math.sqrt(beta_squared + sigma_squared_sum)` in `expected_score` only | **1 failed** — `test_expected_score`, so the #78 fix stays guarded |
| Same, applied to all four `v` sites | 4 failed (`test_expected_score`, `test_beat_with_known_values`, `test_tied_with_known_values`, `test_match_quality`) |

Note the equal-mean reference cases are now `0.5` for any `v`, so it is the `30/5` vs `20/5` pair (`0.822961` corrected vs `0.842074` single-noise) that carries the variance-term guard.

**Downstream** — `SyntheticDataset(num_competitors=60, num_matchups=3000, seed=42).time_split(test_ratio=0.3)` through `train_arena_with_dataset` / `evaluate_arena_with_dataset`, 900 evaluation bouts:

| | accuracy | mean predicted prob | min | max | predictions < 0 |
|---|---|---|---|---|---|
| TrueSkill (before) | 0.8433 | 0.3381 | — | — | 363 (40.3%) |
| TrueSkill (after) | **0.8789** | 0.4822 | 0.0000 | 1.0000 | **0** |
| Elo (control) | 0.8767 | 0.4831 | 0.0057 | 0.9917 | 0 |