### PR TITLE
Reject invalid dataset split ratios and iterator batch sizes

### DIFF
--- a/elote/datasets/base.py
+++ b/elote/datasets/base.py
@@ -107,16 +107,35 @@ class BaseDataset(abc.ABC):
                 
         return self._data
 
+    @staticmethod
+    def _validate_test_ratio(test_ratio: float) -> None:
+        """Reject a test ratio outside the documented 0.0 to 1.0 range."""
+        if not 0.0 <= test_ratio <= 1.0:
+            raise ValueError(f"test_ratio must be between 0.0 and 1.0, got {test_ratio!r}")
+
+    @staticmethod
+    def _validate_batch_size(batch_size: int) -> None:
+        """Reject a non-positive batch size."""
+        if batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer")
+
     def get_data_iterator(self, batch_size: int = 1000) -> Iterator[List[Tuple[Any, Any, float, Optional[datetime.datetime], Optional[Dict[str, Any]]]]]:
         """
         Get an iterator over the dataset in batches for memory-efficient processing.
-        
+
         Args:
             batch_size: Number of matchups per batch.
-            
+
         Yields:
             Batches of matchup tuples.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
         """
+        self._validate_batch_size(batch_size)
+        return self._iter_batches(batch_size)
+
+    def _iter_batches(self, batch_size: int) -> Iterator[List[Tuple[Any, Any, float, Optional[datetime.datetime], Optional[Dict[str, Any]]]]]:
         data = self.get_data()
         for i in range(0, len(data), batch_size):
             yield data[i:i + batch_size]
@@ -148,7 +167,12 @@ class BaseDataset(abc.ABC):
 
         Returns:
             DataSplit object containing train and test sets
+
+        Raises:
+            ValueError: If test_ratio is outside the 0.0 to 1.0 range.
         """
+        self._validate_test_ratio(test_ratio)
+
         data = self.get_data()
 
         # Sort by timestamp if available
@@ -179,7 +203,12 @@ class BaseDataset(abc.ABC):
 
         Returns:
             DataSplit object containing train and test sets
+
+        Raises:
+            ValueError: If test_ratio is outside the 0.0 to 1.0 range.
         """
+        self._validate_test_ratio(test_ratio)
+
         data = self.get_data()
 
         # Set random seed if provided
@@ -211,7 +240,12 @@ class BaseDataset(abc.ABC):
 
         Returns:
             DataSplit object containing train and test sets
+
+        Raises:
+            ValueError: If test_ratio is outside the 0.0 to 1.0 range.
         """
+        self._validate_test_ratio(test_ratio)
+
         data = self.get_data()
 
         # Set random seed if provided

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -191,6 +191,54 @@ class TestSyntheticDataset(unittest.TestCase):
         self.assertFalse(dataset_high._memory_efficient)
 
 
+class TestDatasetArgumentValidation(unittest.TestCase):
+    """Tests for argument validation on the BaseDataset split and iterator helpers."""
+
+    def _dataset(self):
+        return SyntheticDataset(num_competitors=12, num_matchups=100, seed=42)
+
+    def test_splits_reject_ratios_outside_the_unit_interval(self):
+        dataset = self._dataset()
+
+        for split_name in ("time_split", "random_split", "competitor_split"):
+            for test_ratio in (-1.0, -0.2, 1.2, 2.0):
+                with self.subTest(split=split_name, test_ratio=test_ratio):
+                    with self.assertRaisesRegex(ValueError, "test_ratio must be between 0.0 and 1.0"):
+                        getattr(dataset, split_name)(test_ratio=test_ratio)
+
+    def test_splits_accept_the_endpoint_ratios(self):
+        dataset = self._dataset()
+        total = len(dataset.get_data())
+        self.assertEqual(total, 100)
+
+        for split_name in ("time_split", "random_split", "competitor_split"):
+            with self.subTest(split=split_name):
+                no_test = getattr(dataset, split_name)(test_ratio=0.0)
+                self.assertEqual(len(no_test.train), total)
+                self.assertEqual(len(no_test.test), 0)
+
+                no_train = getattr(dataset, split_name)(test_ratio=1.0)
+                self.assertEqual(len(no_train.train), 0)
+                self.assertEqual(len(no_train.test), total)
+
+    def test_get_data_iterator_rejects_non_positive_batch_sizes(self):
+        for batch_size in (0, -1):
+            with self.subTest(batch_size=batch_size):
+                dataset = self._dataset()
+                with self.assertRaisesRegex(ValueError, "batch_size must be a positive integer"):
+                    dataset.get_data_iterator(batch_size=batch_size)
+
+                # The error is raised eagerly, before the dataset is loaded.
+                self.assertIsNone(dataset._data)
+
+    def test_get_data_iterator_still_batches_positive_sizes(self):
+        dataset = self._dataset()
+
+        batches = list(dataset.get_data_iterator(batch_size=30))
+
+        self.assertEqual([len(batch) for batch in batches], [30, 30, 30, 10])
+
+
 class TestAvailableDatasets(unittest.TestCase):
     """Tests for dataset availability functions."""
 


### PR DESCRIPTION
Closes #109

## What changed

`BaseDataset.time_split`, `random_split`, and `competitor_split` turned `test_ratio` straight into a slice index, so values outside the documented 0.0–1.0 range did not fail — on a 100-row `SyntheticDataset`, `test_ratio=-0.2` gave 100 train / 0 test and `test_ratio=1.2` gave 0 train / 100 test. The partitions look structurally valid but do not represent the requested proportion. Separately, `get_data_iterator` passed `batch_size` straight to `range`, so a zero size leaked `ValueError: range() arg 3 must not be zero` and a negative size silently yielded no batches, which reads as an empty dataset.

- Added two shared validators on `BaseDataset`: `_validate_test_ratio` (requires `0.0 <= test_ratio <= 1.0`, raising `ValueError` with a stable parameter-specific message) and `_validate_batch_size` (requires `batch_size > 0`, reusing the message the dataset helpers in `elote/datasets/utils.py` already raise).
- All three split methods call the ratio validator before touching the data. Both endpoints stay supported: `0.0` means no test rows, `1.0` means no training rows.
- `get_data_iterator` validates **eagerly** and then returns a private `_iter_batches` generator. A generator function's body does not run until the first `next()`, so keeping the check inline would have deferred the error past the call — this way `get_data_iterator(batch_size=0)` raises immediately and never downloads or loads the dataset.

No split algorithm, RNG behavior, or dataset row format was touched. Public signatures and valid-input results are unchanged.

## Verification

Ran from the worktree with `env -u VIRTUAL_ENV uv run --extra dev ...`:

- `pytest -q tests/test_datasets.py` → **22 passed, 6 skipped** (skips are the optional chess/football adapters).
- `pytest -q --ignore=tests/test_examples.py` (full suite) → **280 passed, 6 skipped**. `tests/test_examples.py` is excluded because it fails wholesale in a fresh worktree for an unrelated environmental reason (it shells out to an interpreter that lacks `elote`).
- `ruff check .` → **All checks passed!**
- `mypy --python-version 3.12 elote` → **Success: no issues found in 24 source files**. (`make typecheck` pins `python_version = "3.10"` and aborts inside `scipy-stubs` before reaching `elote`; that is pre-existing and unrelated to this diff.)
- `ruff format --check` already fails on both touched files at the base commit, so this PR neither fixes nor worsens that; only `ruff check` is a gate.

### The new tests are not vacuous

Each mutation was applied to `elote/datasets/base.py`, the suite re-run, then the file restored from a pristine copy:

| Mutation | Result |
| --- | --- |
| Delete the three `self._validate_test_ratio(test_ratio)` calls | `test_splits_reject_ratios_outside_the_unit_interval` **fails** |
| Delete `self._validate_batch_size(batch_size)` in `get_data_iterator` | `test_get_data_iterator_rejects_non_positive_batch_sizes` **fails** |
| Tighten the bound to `0.0 < test_ratio < 1.0` | `test_splits_accept_the_endpoint_ratios` **fails** |

The third mutation is what makes the endpoint test load-bearing: `0.0` and `1.0` already worked before this change, so that test does not guard the fix itself — it guards against the fix being written too strictly. The first two carry the new behavior. Deleting the batch-size call also covers the eager/lazy distinction, since a lazily-validating generator would not raise at call time either.