### PR TITLE
Make SyntheticDataset and split seeding instance-local and reproducible

### DIFF
--- a/elote/datasets/base.py
+++ b/elote/datasets/base.py
@@ -211,12 +211,10 @@ class BaseDataset(abc.ABC):
 
         data = self.get_data()
 
-        # Set random seed if provided
-        if seed is not None:
-            np.random.seed(seed)
+        rng = np.random.RandomState(seed)
 
         # Shuffle the data
-        indices = np.random.permutation(len(data))
+        indices = rng.permutation(len(data))
         split_idx = int(len(data) * (1 - test_ratio))
 
         train_indices = indices[:split_idx]
@@ -248,18 +246,17 @@ class BaseDataset(abc.ABC):
 
         data = self.get_data()
 
-        # Set random seed if provided
-        if seed is not None:
-            np.random.seed(seed)
+        rng = np.random.RandomState(seed)
 
-        # Get all unique competitors
-        all_competitors: Set[Any] = set()
+        # Get all unique competitors, in first-appearance order so the shuffle below
+        # depends only on the seed and not on set iteration order.
+        seen: Dict[Any, None] = {}
         for a, b, _, _, _ in data:
-            all_competitors.add(a)
-            all_competitors.add(b)
+            seen[a] = None
+            seen[b] = None
 
-        all_competitors_list: List[Any] = list(all_competitors)
-        np.random.shuffle(all_competitors_list)
+        all_competitors_list: List[Any] = list(seen)
+        rng.shuffle(all_competitors_list)
 
         # Split competitors
         split_idx = int(len(all_competitors_list) * (1 - test_ratio))

--- a/elote/datasets/synthetic.py
+++ b/elote/datasets/synthetic.py
@@ -61,10 +61,11 @@ class SyntheticDataset(BaseDataset):
         self.time_span_days = time_span_days
         self.seed = seed
 
-        # Set random seed if provided
-        if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
+        self._rng, self._np_rng = self._make_generators()
+
+    def _make_generators(self) -> Tuple[random.Random, np.random.RandomState]:
+        """Build the instance-local generators used to produce the dataset."""
+        return random.Random(self.seed), np.random.RandomState(self.seed)
 
     def download(self) -> None:
         """
@@ -85,15 +86,15 @@ class SyntheticDataset(BaseDataset):
             competitor_id = f"competitor_{i}"
 
             if self.skill_distribution == "normal":
-                skill = np.random.normal(self.skill_mean, self.skill_std)
+                skill = self._np_rng.normal(self.skill_mean, self.skill_std)
             elif self.skill_distribution == "uniform":
-                skill = np.random.uniform(
+                skill = self._np_rng.uniform(
                     self.skill_mean - self.skill_std * 1.73,  # Matching variance of normal
                     self.skill_mean + self.skill_std * 1.73,
                 )
             elif self.skill_distribution == "pareto":
                 # Pareto distribution for more realistic skill distribution with few very skilled competitors
-                skill = np.random.pareto(3) * self.skill_std + self.skill_mean - self.skill_std
+                skill = self._np_rng.pareto(3) * self.skill_std + self.skill_mean - self.skill_std
             else:
                 raise ValueError(f"Unknown skill distribution: {self.skill_distribution}")
 
@@ -121,21 +122,21 @@ class SyntheticDataset(BaseDataset):
 
         for _i in range(self.num_matchups):
             # Select two random competitors
-            a, b = random.sample(competitors, 2)
+            a, b = self._rng.sample(competitors, 2)
 
             # Generate a timestamp
-            days_offset = random.uniform(0, self.time_span_days)
+            days_offset = self._rng.uniform(0, self.time_span_days)
             timestamp = start_date + datetime.timedelta(days=days_offset)
 
             # Determine the outcome based on true skills plus noise
-            skill_a = skills[a] + np.random.normal(0, self.noise_std)
-            skill_b = skills[b] + np.random.normal(0, self.noise_std)
+            skill_a = skills[a] + self._np_rng.normal(0, self.noise_std)
+            skill_b = skills[b] + self._np_rng.normal(0, self.noise_std)
 
             # Calculate skill difference and normalize
             skill_diff = skill_a - skill_b
 
             # Determine if it's a draw
-            if abs(skill_diff) < self.noise_std and random.random() < self.draw_probability:
+            if abs(skill_diff) < self.noise_std and self._rng.random() < self.draw_probability:
                 outcome = 0.5  # Draw
             else:
                 outcome = 1.0 if skill_diff > 0 else 0.0
@@ -161,6 +162,9 @@ class SyntheticDataset(BaseDataset):
         Returns:
             List of matchup tuples (competitor_a, competitor_b, outcome, timestamp, attributes)
         """
+        # Restart the generators so a seeded dataset reproduces itself on every load.
+        self._rng, self._np_rng = self._make_generators()
+
         # Generate true skills for all competitors
         skills = self._generate_skills()
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -344,17 +344,19 @@ class TestDatasetReproducibility(unittest.TestCase):
     def test_competitor_split_ordering_does_not_depend_on_set_iteration(self):
         """The shuffled competitor list must come from the data order, not a set."""
         data = [
-            ("z", "a", 1.0, None, None),
-            ("m", "b", 0.0, None, None),
-            ("a", "m", 0.5, None, None),
+            (3, 1, 1.0, None, None),
+            (2, 0, 0.0, None, None),
+            (1, 2, 0.5, None, None),
         ]
         dataset = self._dataset(42)
         dataset._data = data
 
         split = dataset.competitor_split(test_ratio=0.5, seed=1)
 
+        # Small ints hash to themselves, so ``list({3, 1, 2, 0})`` is ``[0, 1, 2, 3]``
+        # under every PYTHONHASHSEED -- reliably different from first-appearance order.
         rng = np.random.RandomState(1)
-        order = ["z", "a", "m", "b"]
+        order = [3, 1, 2, 0]
         rng.shuffle(order)
         train_competitors = set(order[:2])
         expected_train = [row for row in data if row[0] in train_competitors and row[1] in train_competitors]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,7 +5,9 @@ Tests for the datasets module.
 import unittest
 import datetime
 import os
+import random
 import tempfile
+import numpy as np
 import pandas as pd
 from unittest.mock import patch, MagicMock
 import shutil
@@ -237,6 +239,127 @@ class TestDatasetArgumentValidation(unittest.TestCase):
         batches = list(dataset.get_data_iterator(batch_size=30))
 
         self.assertEqual([len(batch) for batch in batches], [30, 30, 30, 10])
+
+
+def _fingerprint(rows):
+    """Reduce generated rows to the part a seed is supposed to determine.
+
+    Absolute timestamps are anchored to ``datetime.now()`` at generation time, so only
+    the spacing between rows is reproducible; everything else must match exactly.
+    """
+    base = rows[0][3]
+    return [(a, b, outcome, (ts - base).total_seconds(), attrs) for a, b, outcome, ts, attrs in rows]
+
+
+class TestDatasetReproducibility(unittest.TestCase):
+    """A seed must fully determine the data, and must not reach outside the instance."""
+
+    def _dataset(self, seed):
+        return SyntheticDataset(num_competitors=10, num_matchups=50, seed=seed)
+
+    def test_seeded_generation_ignores_other_datasets(self):
+        """Constructing and loading another dataset in between must not change the data."""
+        first = self._dataset(42)
+        other = self._dataset(7)
+        other.get_data()
+        first_rows = first.get_data()
+
+        independent = self._dataset(42)
+
+        self.assertEqual(_fingerprint(first_rows), _fingerprint(independent.get_data()))
+
+    def test_seeded_generation_ignores_the_global_random_stream(self):
+        """Unrelated draws between construction and load must not change the data."""
+        dataset = self._dataset(42)
+        random.random()
+        np.random.random()
+        rows = dataset.get_data()
+
+        self.assertEqual(_fingerprint(rows), _fingerprint(self._dataset(42).get_data()))
+
+    def test_clear_cache_regenerates_identical_rows(self):
+        """One seeded object must reproduce itself across a cache clear."""
+        dataset = self._dataset(42)
+        first = _fingerprint(dataset.get_data())
+
+        dataset.clear_cache()
+        second = _fingerprint(dataset.get_data())
+
+        self.assertEqual(first, second)
+
+    def test_different_seeds_produce_different_data(self):
+        """Guards the reproducibility tests above against a constant generator."""
+        self.assertNotEqual(
+            _fingerprint(self._dataset(42).get_data()),
+            _fingerprint(self._dataset(7).get_data()),
+        )
+
+    def test_generation_preserves_the_callers_global_streams(self):
+        random.seed(1234)
+        np.random.seed(1234)
+        expected_python = [random.random() for _ in range(5)]
+        expected_numpy = np.random.random(5).tolist()
+
+        random.seed(1234)
+        np.random.seed(1234)
+        self._dataset(42).get_data()
+
+        self.assertEqual([random.random() for _ in range(5)], expected_python)
+        self.assertEqual(np.random.random(5).tolist(), expected_numpy)
+
+    def test_splits_preserve_the_callers_global_streams(self):
+        random.seed(1234)
+        np.random.seed(1234)
+        expected_python = [random.random() for _ in range(5)]
+        expected_numpy = np.random.random(5).tolist()
+
+        random.seed(1234)
+        np.random.seed(1234)
+        dataset = self._dataset(42)
+        dataset.random_split(test_ratio=0.3, seed=1)
+        dataset.competitor_split(test_ratio=0.3, seed=1)
+
+        self.assertEqual([random.random() for _ in range(5)], expected_python)
+        self.assertEqual(np.random.random(5).tolist(), expected_numpy)
+
+    def test_random_split_is_reproducible(self):
+        dataset = self._dataset(42)
+
+        first = dataset.random_split(test_ratio=0.3, seed=1)
+        second = dataset.random_split(test_ratio=0.3, seed=1)
+
+        self.assertEqual(list(first.train), list(second.train))
+        self.assertEqual(list(first.test), list(second.test))
+        self.assertNotEqual(list(first.train), list(dataset.random_split(test_ratio=0.3, seed=2).train))
+
+    def test_competitor_split_is_reproducible(self):
+        dataset = self._dataset(42)
+
+        first = dataset.competitor_split(test_ratio=0.3, seed=1)
+        second = dataset.competitor_split(test_ratio=0.3, seed=1)
+
+        self.assertEqual(list(first.train), list(second.train))
+        self.assertEqual(list(first.test), list(second.test))
+
+    def test_competitor_split_ordering_does_not_depend_on_set_iteration(self):
+        """The shuffled competitor list must come from the data order, not a set."""
+        data = [
+            ("z", "a", 1.0, None, None),
+            ("m", "b", 0.0, None, None),
+            ("a", "m", 0.5, None, None),
+        ]
+        dataset = self._dataset(42)
+        dataset._data = data
+
+        split = dataset.competitor_split(test_ratio=0.5, seed=1)
+
+        rng = np.random.RandomState(1)
+        order = ["z", "a", "m", "b"]
+        rng.shuffle(order)
+        train_competitors = set(order[:2])
+        expected_train = [row for row in data if row[0] in train_competitors and row[1] in train_competitors]
+
+        self.assertEqual(list(split.train), expected_train)
 
 
 class TestAvailableDatasets(unittest.TestCase):


### PR DESCRIPTION
Closes #100

## What was wrong

`SyntheticDataset.__init__` applied its `seed` by calling the process-global `random.seed(seed)` /
`np.random.seed(seed)` at *construction* time, while the data is generated lazily in `load()`.
`BaseDataset.random_split` and `competitor_split` did the same with `np.random.seed(seed)`.

So the seed was a promise the class did not keep, and it damaged the caller's RNG state on the way:
constructing a second, differently-seeded dataset before loading the first changed the first's data;
`clear_cache()` + `get_data()` on one seeded object returned different rows; and constructing a dataset
(or calling a seeded split) silently reset the calling program's `random` and `numpy.random` streams.

## What changed

- `SyntheticDataset` holds instance-local generators (`self._rng`, `self._np_rng`) built from
  `self.seed`, and `_generate_skills` / `_generate_matchups` draw from those. `load()` restarts both
  from `self.seed` at the top, so generation-time — not construction-time — is what the seed pins.
  The global `random.seed` / `np.random.seed` calls are gone.
- `BaseDataset.random_split` and `competitor_split` use a local `np.random.RandomState(seed)` and its
  `permutation` / `shuffle`. With `seed=None` that is seeded from OS entropy — still random, still not
  touching globals.
- `self.seed` stays a public attribute and every signature is unchanged. `time_split`, the row format,
  `ChessDataset` and `CollegeFootballDataset` are untouched.

### Two deliberate deviations from the issue's sketch

**1. `np.random.RandomState(seed)` rather than `np.random.default_rng(seed)`.** The issue's risk note
said "nothing in the repo or its tests asserts specific generated values" — that is no longer true.
PR #110 added three tests to `tests/test_datasets.py` that pin seeded output
(`test_train_arena_records_a_bout_for_every_row_including_draws` asserts 62 draws,
`test_accuracy_by_prior_bouts_counts_drawn_training_bouts` asserts 140/43 and bin `[23]`, and
`test_train_arena_ratings_unchanged_by_draw_bout_recording` pins twelve leaderboard literals).
`RandomState` is the same bit generator the global `np.random.*` functions use, so a per-instance
`RandomState(seed)` reproduces the legacy stream **exactly** — the fix is behaviour-preserving and the
existing tests pass unmodified, which is itself one of the issue's acceptance criteria. Verified by
hashing the generated rows of five seed/distribution configurations before and after the change: all
five identical (see Verification). Going to `default_rng` would have changed every user's seeded data
and forced a rebaseline of those literals for no correctness gain.

**2. `competitor_split` now orders competitors by first appearance in the data, not by `set` iteration.**
This was pre-existing and outside the issue's letter, but it defeats `seed=` in the very method the
issue is about: the shuffled list came from `list(set(...))`, whose order for string IDs varies with
`PYTHONHASHSEED`, so `competitor_split(seed=42)` gave different splits in different processes.
Measured on master: the same call returned 37/63 in one process and 19/81 in another. The list is now
built with a dict (first-appearance order), so the seed is the only input. `random_split` was already
free of this.

## Verification

All commands run as `env -u VIRTUAL_ENV uv run --extra dev ...` in a clean worktree.

- **Full suite:** `pytest -q --ignore=tests/test_examples.py` -> **289 passed, 6 skipped** (280 on the
  branch point + 9 new). `tests/test_examples.py` is excluded because it fails wholesale on master for
  an unrelated environmental reason (it shells out to an interpreter without `elote` installed).
- **Lint:** `ruff check .` -> All checks passed. **Types:** `mypy --python-version 3.12 elote` ->
  Success, no issues in 24 source files. (`ruff format --check` flags `elote/datasets/base.py` and
  `tests/test_datasets.py`, but both were already non-conformant on master — not touched here.)
- **Generated data is unchanged from master.** SHA-256 over `(a, b, outcome, attributes)` for
  `SyntheticDataset` at `(10,20,seed=42)`, `(12,200,seed=7,draw_probability=0.9,noise_std=200)`,
  `(60,3000,seed=42)`, `(10,100,seed=42,uniform)` and `(10,100,seed=3,pareto)`: all five hashes
  identical before and after. `random_split(0.3, seed=42)` returns the same train/test lists as master.

### Mutation checks

Each mutation was applied to the committed fix, the suite re-run, then reverted with
`git checkout HEAD -- <file>` and the clean tree re-confirmed.

| # | Mutation | Failing tests |
|---|---|---|
| 1 | Revert `elote/datasets/synthetic.py` wholesale (global `random.seed`/`np.random.seed` in `__init__`, globals in the generators, no restart in `load()`) — the **construction-time seeding** half | 5 failed: `test_seeded_generation_ignores_other_datasets`, `test_seeded_generation_ignores_the_global_random_stream`, `test_clear_cache_regenerates_identical_rows`, `test_generation_preserves_the_callers_global_streams`, `test_splits_preserve_the_callers_global_streams` |
| 2 | Restore `np.random.seed(seed)` + global `permutation`/`shuffle` in the two splits — the **global-clobbering** half | 1 failed: `test_splits_preserve_the_callers_global_streams` |
| 3 | Keep instance generators but delete the restart at the top of `load()` | 1 failed: `test_clear_cache_regenerates_identical_rows` |
| 4 | Restore `list(set(...))` competitor ordering in `competitor_split` | 1 failed: `test_competitor_split_ordering_does_not_depend_on_set_iteration` |

Mutations 2 and 3 isolate the two halves cleanly: 2 fails **only** the global-stream guard for the
splits, 3 fails **only** the clear-cache reproducibility guard. Mutation 1 subsumes both because
reverting the constructor reseeds the globals that the split test also measures.

Note on mutation 4: written with string competitor IDs, that test caught the mutation on 7 of 8
`PYTHONHASHSEED` values — it passed on the one where set order happened to equal insertion order.
It now uses small int IDs, whose hashes are not randomized (`list({3, 1, 2, 0})` is `[0, 1, 2, 3]`
under every hash seed), so the guard is deterministic; re-verified failing under `PYTHONHASHSEED` 1, 2
and 3.

`test_different_seeds_produce_different_data` is what stops the reproducibility tests from passing
by way of a constant generator; it is documentation rather than a guard against any mutation above.