### PR TITLE
Make threshold optimization an exact, deterministic sweep

### DIFF
--- a/elote/arenas/base.py
+++ b/elote/arenas/base.py
@@ -1,4 +1,5 @@
 import abc
+import math
 import random
 from typing import Dict, Any, List, Tuple, Optional
 
@@ -206,14 +207,20 @@ class History:
         # Return results as a dictionary
         return {"tp": true_positives, "fp": false_positives, "tn": true_negatives, "fn": false_negatives}
 
-    def random_search(self, trials: int = 1000) -> Tuple[float, List[float]]:
+    def random_search(self, trials: int = 1000, seed: Optional[int] = None) -> Tuple[float, List[float]]:
         """Search for optimal prediction thresholds using random sampling.
 
         This method performs a random search to find the best lower and upper
         thresholds that maximize the overall accuracy, including draws.
 
+        Note:
+            :meth:`optimize_thresholds` computes the exact optimum deterministically
+            and should be preferred; this method is retained for backward compatibility.
+
         Args:
             trials (int): The number of random threshold pairs to try.
+            seed (int, optional): Seed for the sampling. When omitted the unseeded
+                global random module is used, so results vary between calls.
 
         Returns:
             tuple: A tuple containing (best_accuracy, best_thresholds).
@@ -227,17 +234,19 @@ class History:
             logger.warning("Cannot perform random search on empty history.")
             return best_accuracy, best_thresholds
 
-        for i in range(trials):
-            # Find min and max predicted outcomes in history
-            predicted_outcomes = [bout.predicted_outcome for bout in self.bouts if bout.predicted_outcome is not None]
-            min_outcome = min(predicted_outcomes) if predicted_outcomes else 0
-            max_outcome = max(predicted_outcomes) if predicted_outcomes else 1
+        rng: Any = random if seed is None else random.Random(seed)
 
+        # Find min and max predicted outcomes in history
+        predicted_outcomes = [bout.predicted_outcome for bout in self.bouts if bout.predicted_outcome is not None]
+        min_outcome = min(predicted_outcomes) if predicted_outcomes else 0
+        max_outcome = max(predicted_outcomes) if predicted_outcomes else 1
+
+        for i in range(trials):
             # Generate two random numbers between min and max
             thresholds = sorted(
                 [
-                    min_outcome + random.random() * (max_outcome - min_outcome),
-                    min_outcome + random.random() * (max_outcome - min_outcome),
+                    min_outcome + rng.random() * (max_outcome - min_outcome),
+                    min_outcome + rng.random() * (max_outcome - min_outcome),
                 ]
             )
 
@@ -260,144 +269,154 @@ class History:
         )
         return best_accuracy, best_thresholds
 
+    def _labeled_predictions(self) -> List[Tuple[float, str]]:
+        """Collect the (predicted probability, actual label) pairs used for scoring.
+
+        The skipping and coercion rules mirror :meth:`confusion_matrix` exactly, so the
+        number of returned pairs is the denominator of ``calculate_metrics()["accuracy"]``.
+
+        Returns:
+            list: A list of ``(probability, label)`` tuples where label is 'a', 'b' or 'draw'.
+        """
+        pairs: List[Tuple[float, str]] = []
+        for bout in self.bouts:
+            actual = bout._normalized_outcome()
+            predicted_prob = bout.predicted_outcome
+            if actual is None or predicted_prob is None:
+                continue
+            if isinstance(predicted_prob, str):
+                try:
+                    predicted_prob = float(predicted_prob)
+                except ValueError:
+                    continue
+            pairs.append((float(predicted_prob), actual))
+        return pairs
+
     def optimize_thresholds(
         self, method: str = "L-BFGS-B", initial_thresholds: Tuple[float, float] = (0.5, 0.5)
     ) -> Tuple[float, List[float]]:
-        """Optimize prediction thresholds using scipy.optimize.
+        """Find the prediction thresholds that maximize accuracy.
 
-        This method uses scipy's optimization algorithms to find the best thresholds
-        for maximizing prediction accuracy.
+        Accuracy is a step function of the thresholds: it only changes at the distinct
+        values of ``Bout.predicted_outcome``. This method therefore evaluates every
+        distinct threshold pair exactly, in ``O(n log n)``, rather than sampling. The
+        result is deterministic — repeated calls on an unchanged history return
+        identical values.
 
         Args:
-            method (str): The optimization method to use (e.g., 'L-BFGS-B', 'Nelder-Mead')
-            initial_thresholds (tuple): Initial guess for (lower_threshold, upper_threshold)
+            method (str): Deprecated and ignored. Retained for backward compatibility;
+                the search is exact, so no optimizer is selected.
+            initial_thresholds (tuple): Thresholds to fall back to. They are returned
+                unchanged whenever they already achieve the optimal accuracy.
 
         Returns:
             tuple: (best_accuracy, best_thresholds) where:
                 - best_accuracy: The accuracy achieved with the optimized thresholds
                 - best_thresholds: List of [lower_threshold, upper_threshold]
         """
-        from scipy import optimize
-
         num_bouts = len(self.bouts)
-        logger.info("Optimizing thresholds using scipy ('%s') on %d bouts.", method, num_bouts)
+        logger.info("Optimizing thresholds by exact sweep over %d bouts.", num_bouts)
 
         if num_bouts == 0:
             logger.warning("Cannot optimize thresholds on empty history.")
             return 0.0, list(initial_thresholds)
 
-        # Find min and max predicted outcomes in history
-        predicted_outcomes = [bout.predicted_outcome for bout in self.bouts if bout.predicted_outcome is not None]
-        if not predicted_outcomes:
+        pairs = self._labeled_predictions()
+        if not pairs:
             logger.warning("No valid predicted outcomes found in history. Cannot optimize.")
             return 0.0, list(initial_thresholds)
-        min_outcome = min(predicted_outcomes)
-        max_outcome = max(predicted_outcomes)
-        logger.debug("Predicted outcome range: [%.4f, %.4f]", min_outcome, max_outcome)
 
-        # Define the objective function to minimize (negative accuracy)
-        def objective(thresholds: List[float]) -> float:
-            # Ensure thresholds are sorted
-            sorted_thresholds = sorted(thresholds)
-            metrics = self.calculate_metrics(*sorted_thresholds)
-            return -metrics["accuracy"]  # Negative because we want to maximize accuracy
+        pairs.sort(key=lambda pair: pair[0])
+        total = len(pairs)
+        logger.debug("Predicted outcome range: [%.4f, %.4f]", pairs[0][0], pairs[-1][0])
 
-        # Calculate baseline accuracy with initial thresholds
-        baseline_metrics = self.calculate_metrics(*initial_thresholds)
-        baseline_accuracy = baseline_metrics["accuracy"]
+        # Group the sorted pairs by distinct probability and count each label per group.
+        values: List[float] = []
+        group_counts: List[List[int]] = []
+        label_index = {"a": 0, "b": 1, "draw": 2}
+        for probability, label in pairs:
+            if not values or probability != values[-1]:
+                values.append(probability)
+                group_counts.append([0, 0, 0])
+            group_counts[-1][label_index[label]] += 1
+
+        # Prefix counts: *_prefix[k] counts the label over the first k groups.
+        m = len(values)
+        a_prefix = [0] * (m + 1)
+        b_prefix = [0] * (m + 1)
+        d_prefix = [0] * (m + 1)
+        for k in range(m):
+            a_prefix[k + 1] = a_prefix[k] + group_counts[k][0]
+            b_prefix[k + 1] = b_prefix[k] + group_counts[k][1]
+            d_prefix[k + 1] = d_prefix[k] + group_counts[k][2]
+        a_total = a_prefix[m]
+
+        # Representative threshold value for each of the m + 1 cut points, chosen so that
+        # no observed probability ever sits exactly on a threshold: midpoints between
+        # adjacent distinct probabilities, plus one sentinel below the minimum and one
+        # above the maximum. The lower/upper values differ only in the degenerate case
+        # where two adjacent probabilities have no representable midpoint between them.
+        lower_cut = [0.0] * (m + 1)
+        upper_cut = [0.0] * (m + 1)
+        for k in range(m + 1):
+            if k == 0:
+                lower_cut[k] = upper_cut[k] = math.nextafter(values[0], -math.inf)
+            elif k == m:
+                lower_cut[k] = upper_cut[k] = math.nextafter(values[-1], math.inf)
+            else:
+                low, high = values[k - 1], values[k]
+                midpoint = (low + high) / 2.0
+                if low < midpoint < high:
+                    lower_cut[k] = upper_cut[k] = midpoint
+                else:
+                    lower_cut[k] = high
+                    upper_cut[k] = low
+
+        # With lower cut i and upper cut j (i <= j), the number of correct predictions is
+        #   #b below i + #draw between i and j + #a above j
+        # = (b_prefix[i] - d_prefix[i]) + (d_prefix[j] - a_prefix[j]) + a_total,
+        # so the best j for every i is a suffix maximum of d_prefix[j] - a_prefix[j].
+        best_upper_score = [0] * (m + 1)
+        best_upper_cut = [0] * (m + 1)
+        for j in range(m, -1, -1):
+            score = d_prefix[j] - a_prefix[j]
+            if j == m or score >= best_upper_score[j + 1]:
+                best_upper_score[j] = score
+                best_upper_cut[j] = j
+            else:
+                best_upper_score[j] = best_upper_score[j + 1]
+                best_upper_cut[j] = best_upper_cut[j + 1]
+
+        best_correct = -1
+        best_i = 0
+        best_j = 0
+        for i in range(m + 1):
+            correct = b_prefix[i] - d_prefix[i] + best_upper_score[i] + a_total
+            if correct > best_correct:
+                best_correct = correct
+                best_i = i
+                best_j = best_upper_cut[i]
+
+        best_accuracy = best_correct / total
+        best_thresholds = [lower_cut[best_i], upper_cut[best_j]]
+
+        # Keep the supplied thresholds when they already achieve the optimum.
+        baseline_accuracy = self.calculate_metrics(*initial_thresholds)["accuracy"]
         logger.debug(
             "Baseline accuracy with initial thresholds [%.2f, %.2f]: %.4f", *initial_thresholds, baseline_accuracy
         )
-
-        # Use initial_thresholds as the initial guess
-        initial_guess = list(initial_thresholds)
-
-        # Bounds for the thresholds
-        bounds = [(min_outcome, max_outcome), (min_outcome, max_outcome)]
-
-        # Run multiple optimizations with different methods and starting points
-        best_accuracy = baseline_accuracy
-        best_thresholds = list(initial_thresholds)
-
-        # Try different optimization methods
-        methods = [method]
-        if method != "L-BFGS-B":
-            methods.append("L-BFGS-B")
-        if "Nelder-Mead" not in methods:
-            methods.append("Nelder-Mead")
-
-        for opt_method in methods:
-            try:
-                # Run the optimization with current method
-                logger.debug("Running optimization with method: %s", opt_method)
-                result = optimize.minimize(
-                    objective,
-                    initial_guess,
-                    method=opt_method,
-                    bounds=bounds if opt_method != "Nelder-Mead" else None,
-                    options={"maxiter": 1000},
-                )
-
-                # Get the thresholds and ensure they're sorted
-                opt_thresholds = sorted(result.x)
-
-                # Calculate the accuracy
-                metrics = self.calculate_metrics(*opt_thresholds)
-                accuracy = metrics["accuracy"]
-
-                # Update best if better than current best
-                if accuracy > best_accuracy:
-                    logger.debug(
-                        "Optimization (%s): New best accuracy %.4f with thresholds [%.2f, %.2f]",
-                        opt_method,
-                        accuracy,
-                        *opt_thresholds,
-                    )
-                    best_accuracy = accuracy
-                    best_thresholds = opt_thresholds
-
-                # Try with a few random starting points
-                for j in range(3):
-                    random_guess = [
-                        random.uniform(min_outcome, max_outcome),
-                        random.uniform(min_outcome, max_outcome),
-                    ]
-                    random_guess.sort()
-                    result = optimize.minimize(
-                        objective, random_guess, method=opt_method, bounds=bounds, options={"disp": False}
-                    )
-                    if result.success:
-                        opt_thresholds = sorted(result.x)
-                        metrics = self.calculate_metrics(*opt_thresholds)
-                        accuracy = metrics["accuracy"]
-                        if accuracy > best_accuracy:
-                            logger.debug(
-                                "Optimization (%s, random start %d): New best accuracy %.4f with thresholds [%.2f, %.2f]",
-                                opt_method,
-                                j + 1,
-                                accuracy,
-                                *opt_thresholds,
-                            )
-                            best_accuracy = accuracy
-                            best_thresholds = opt_thresholds
-            except Exception as e:
-                # Skip if optimization fails
-                logger.warning("Optimization with method '%s' failed: %s", opt_method, e)
-                continue
-
-        # If optimized accuracy is worse than baseline, use baseline
-        if best_accuracy < baseline_accuracy:
+        if baseline_accuracy >= best_accuracy:
             logger.info(
-                "Optimized accuracy (%.4f) is worse than baseline (%.4f). Reverting to baseline thresholds.",
-                best_accuracy,
+                "Initial thresholds [%.2f, %.2f] already achieve the optimal accuracy %.4f.",
+                *initial_thresholds,
                 baseline_accuracy,
             )
             return baseline_accuracy, list(initial_thresholds)
 
         logger.info(
-            "Optimization complete. Best accuracy: %.4f with thresholds [%.2f, %.2f]", best_accuracy, *best_thresholds
+            "Optimization complete. Best accuracy: %.4f with thresholds [%.4f, %.4f]", best_accuracy, *best_thresholds
         )
-        return best_accuracy, list(best_thresholds)
+        return best_accuracy, best_thresholds
 
     def calculate_metrics(self, lower_threshold: float = 0.5, upper_threshold: float = 0.5) -> Dict[str, float]:
         """

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -311,5 +311,144 @@ class TestHistoryMetrics(unittest.TestCase):
         self.assertIn("binned", result)
 
 
+def _brute_force_best(history):
+    """Exhaustively evaluate every candidate threshold pair via calculate_metrics.
+
+    Returns the best accuracy reachable by any (lower, upper) pair.
+    """
+    probabilities = sorted({bout.predicted_outcome for bout in history.bouts if bout.predicted_outcome is not None})
+    candidates = (
+        [probabilities[0] - 0.1]
+        + [(probabilities[k - 1] + probabilities[k]) / 2 for k in range(1, len(probabilities))]
+        + [probabilities[-1] + 0.1]
+    )
+    return max(
+        history.calculate_metrics(lower, upper)["accuracy"]
+        for lower in candidates
+        for upper in candidates
+        if lower <= upper
+    )
+
+
+def _mixed_history():
+    """A history whose optimal thresholds are neither (0.5, 0.5) nor a pure split."""
+    history = History()
+    for probability, outcome in [
+        (0.08, "loss"),
+        (0.17, "loss"),
+        (0.24, "win"),
+        (0.31, "loss"),
+        (0.42, "draw"),
+        (0.46, "loss"),
+        (0.53, "draw"),
+        (0.57, "draw"),
+        (0.61, "win"),
+        (0.68, "draw"),
+        (0.74, "win"),
+        (0.79, "loss"),
+        (0.86, "win"),
+        (0.93, "win"),
+    ]:
+        history.add_bout(Bout("a", "b", probability, outcome))
+    return history
+
+
+def _narrow_band_history():
+    """A history whose only perfect thresholds are a narrow band far from (0.5, 0.5).
+
+    No bout has a probability between 0.34 and 0.62, so accuracy is constant in a wide
+    neighbourhood of the default starting point. The single perfect answer requires the
+    lower threshold in (0.28, 0.30) and the upper in (0.32, 0.34) -- two 2%-wide
+    windows, which only an exact sweep locates reliably.
+    """
+    history = History()
+    bouts = (
+        [(round(0.02 + 0.04 * step, 2), "loss") for step in range(7)]  # 0.02 .. 0.26
+        + [(0.28, "loss")]
+        + [(0.30, "draw")] * 8
+        + [(0.32, "draw")] * 8
+        + [(0.34, "win")]
+        + [(round(0.62 + 0.04 * step, 2), "win") for step in range(10)]  # 0.62 .. 0.98
+    )
+    for probability, outcome in bouts:
+        history.add_bout(Bout("a", "b", probability, outcome))
+        if outcome != "draw":
+            history.add_bout(Bout("a", "b", probability, outcome))
+    return history
+
+
+class TestOptimizeThresholds(unittest.TestCase):
+    def test_optimize_thresholds_is_deterministic(self):
+        """Repeated calls on one unchanged history return identical results."""
+        for name, history in [("mixed", _mixed_history()), ("narrow_band", _narrow_band_history())]:
+            with self.subTest(history=name):
+                results = [history.optimize_thresholds() for _ in range(5)]
+
+                for result in results[1:]:
+                    self.assertEqual(result, results[0])
+
+    def test_optimize_thresholds_matches_brute_force(self):
+        """The returned accuracy equals the exhaustively computed optimum."""
+        for name, history in [("mixed", _mixed_history()), ("narrow_band", _narrow_band_history())]:
+            with self.subTest(history=name):
+                accuracy, thresholds = history.optimize_thresholds()
+
+                self.assertEqual(accuracy, _brute_force_best(history))
+                self.assertEqual(accuracy, history.calculate_metrics(*thresholds)["accuracy"])
+
+    def test_optimize_thresholds_finds_draw_band(self):
+        """A history whose optimum is a draw band returns lower < upper."""
+        history = _narrow_band_history()
+
+        accuracy, thresholds = history.optimize_thresholds()
+
+        # Only a band with 0.28 < lower < 0.30 and 0.32 < upper < 0.34 classifies
+        # every bout correctly; a decisive split tops out below 1.0.
+        self.assertEqual(accuracy, 1.0)
+        self.assertLess(thresholds[0], thresholds[1])
+        self.assertTrue(0.28 < thresholds[0] < 0.30, thresholds)
+        self.assertTrue(0.32 < thresholds[1] < 0.34, thresholds)
+        self.assertLess(history.calculate_metrics(0.5, 0.5)["accuracy"], accuracy)
+
+    def test_optimize_thresholds_never_worse_than_initial(self):
+        """The optimum is never below the accuracy of the supplied thresholds."""
+        history = _mixed_history()
+
+        for initial in [(0.5, 0.5), (0.2, 0.8), (0.0, 1.0), (0.45, 0.46)]:
+            with self.subTest(initial_thresholds=initial):
+                baseline = history.calculate_metrics(*initial)["accuracy"]
+                accuracy, thresholds = history.optimize_thresholds(initial_thresholds=initial)
+
+                self.assertGreaterEqual(accuracy, baseline)
+                self.assertEqual(accuracy, history.calculate_metrics(*thresholds)["accuracy"])
+
+    def test_optimize_thresholds_handles_decisive_history(self):
+        """A history with no draws is optimized by a single split point."""
+        history = History()
+        for probability, outcome in [(0.1, "loss"), (0.2, "loss"), (0.7, "win"), (0.9, "win")]:
+            history.add_bout(Bout("a", "b", probability, outcome))
+
+        accuracy, thresholds = history.optimize_thresholds()
+
+        self.assertEqual(accuracy, 1.0)
+        self.assertEqual(accuracy, history.calculate_metrics(*thresholds)["accuracy"])
+
+    def test_optimize_thresholds_ignores_method_argument(self):
+        """The deprecated method argument no longer changes the answer."""
+        history = _mixed_history()
+
+        self.assertEqual(history.optimize_thresholds(method="Nelder-Mead"), history.optimize_thresholds())
+
+    def test_random_search_is_reproducible_with_seed(self):
+        """random_search returns identical results for a fixed seed."""
+        history = _mixed_history()
+
+        first = history.random_search(trials=50, seed=7)
+        second = history.random_search(trials=50, seed=7)
+
+        self.assertEqual(first, second)
+        self.assertLessEqual(first[1][0], first[1][1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #99

## What changed

`History.optimize_thresholds()` no longer samples. Accuracy is a step function of the
thresholds — it only changes at the distinct values of `Bout.predicted_outcome` — so the
optimum is computed exactly:

- `_labeled_predictions()` (new private helper) collects `(probability, label)` pairs using
  the *same* skip/coercion rules as `confusion_matrix`, so its length is exactly the
  denominator of `calculate_metrics()["accuracy"]`.
- Pairs are sorted and grouped by distinct probability; prefix counts of `a` / `b` / `draw`
  are built once.
- For a cut pair `(i, j)` the correct count is
  `b_prefix[i] + (d_prefix[j] - d_prefix[i]) + (a_total - a_prefix[j])`, which separates into
  `(b_prefix[i] - d_prefix[i]) + (d_prefix[j] - a_prefix[j]) + a_total`. The best `j` for every
  `i` is therefore a suffix maximum, and the whole optimum is one `O(n log n)` pass.
- Returned thresholds are the midpoints between adjacent distinct probabilities, plus a
  sentinel below the minimum and above the maximum, so no observed probability ever sits
  exactly on a threshold. (Where two adjacent probabilities have no representable midpoint,
  the lower/upper representatives fall back to the exact endpoints, which are still correct
  for their respective `<` / `<=` comparisons.)
- Existing tie-break kept: when `initial_thresholds` already achieve the optimal accuracy they
  are returned unchanged. This also guarantees the returned accuracy is never worse than
  `calculate_metrics(*initial_thresholds)["accuracy"]`.
- `method` is retained and accepted for backward compatibility but is now a no-op, documented
  as deprecated. The `scipy.optimize` import is gone from this method.

`History.random_search()` keeps its sampling behaviour but hoists the `min`/`max` over
`predicted_outcome` out of the trial loop (`O(trials * n)` → `O(n + trials)`) and gains an
optional `seed` argument. With no seed it still uses the global `random` module, exactly as
before.

`confusion_matrix`, `calculate_metrics`, and `calculate_metrics_with_draws` are untouched —
the sweep reproduces the accuracy they already define.

## Verification

All commands run as `env -u VIRTUAL_ENV uv run --extra dev ...` on this branch.

**Full suite** — `pytest -q --ignore=tests/test_examples.py`: **287 passed, 6 skipped** (280 on
the branch point + 7 new). `tests/test_examples.py` is excluded because it fails wholesale on
`master` for environmental reasons (it shells out to an interpreter without `elote` installed).
`tests/test_history_metrics.py::test_optimize_thresholds_evaluates_draws` and
`tests/test_History.py::test_random_search` pass unmodified.

**Lint / types** — `make lint` (`ruff check .`): all checks passed.
`ruff format --check` on both touched files: already formatted.
`mypy --python-version 3.12 elote`: success, no issues in 24 source files.

**Exact-optimum cross-check against brute force** — 400 randomly generated histories (1–40
bouts, mixed numeric/string outcomes, plus unusable bouts with `None` probabilities and
unparseable outcomes). For each: the sweep's accuracy equals an exhaustive scan over all
candidate `(lower, upper)` pairs via `calculate_metrics`, equals
`calculate_metrics(*returned_thresholds)["accuracy"]`, is never below the `(0.5, 0.5)` baseline,
and is identical across repeated calls. **0 failures.**

**Issue's measured scenario** — Elo at `initial_rating=1500` on
`SyntheticDataset(num_competitors=60, num_matchups=3000, seed=42).time_split(test_ratio=0.3)`,
900 evaluation bouts:

```
draw_prob=0.1  n=900  draws=16   baseline(0.5,0.5) = 0.876667
  optimize_thresholds x5 -> 1 distinct result: 0.878889 at [0.5133, 0.5133]   (1.1 ms/call)
draw_prob=0.4  n=900  draws=54   baseline(0.5,0.5) = 0.842222
  optimize_thresholds x5 -> 1 distinct result: 0.848889 at [0.5275, 0.5275]   (1.1 ms/call)
```

Both match the exact optima recorded in the issue, on every call.

**Benchmark reproducibility** — `benchmark_competitors(..., optimize_thresholds=True)` over Elo
/ DWZ / ECF on a draw-heavy synthetic split, run 3 times: byte-identical accuracies *and*
thresholds. (Glicko-1/Glicko-2 still vary in the last few digits of the *thresholds* — their RD
inflates from wall-clock `datetime.now()` during training, so the predicted probabilities
themselves differ run to run. Their optimized *accuracy* is now stable. That is pre-existing and
unrelated to this change.) DWZ and ECF both return non-degenerate bands (`lower < upper`) here,
so the draw region is genuinely searched end to end.

## Mutation check

Two mutations were applied to the merged code and the suite re-run; the fix was committed
first, so restoring it was verified to leave the diff intact (`pytest` back to 287 passed).

**Mutation A — reinstate the old scipy + `random.uniform` restart search.**

| test | fails with mutation A |
|---|---|
| `test_optimize_thresholds_is_deterministic` | 10 / 10 runs |
| `test_optimize_thresholds_finds_draw_band` | 10 / 10 runs |
| `test_optimize_thresholds_ignores_method_argument` | 10 / 10 runs |
| `test_optimize_thresholds_matches_brute_force` | 9 / 10 runs |

The determinism test is the deterministic catch: 30 calls of the old code on one unchanged
history produced **9 distinct accuracies**. The exact-optimum tests are the accuracy catch —
measured directly, the old search reaches the true optimum on the `_narrow_band_history`
fixture only **4 / 100** calls, so `matches_brute_force` and `finds_draw_band` catch it
essentially always but not by construction; that residual is stated rather than papered over.
The fixture is built so accuracy is *constant* in a wide neighbourhood of the `(0.5, 0.5)`
starting point (no bout has a probability in `(0.34, 0.62)`), which is what stops Nelder-Mead
from hill-climbing to the answer — an earlier fixture with the band at the default start was
found by the old code roughly half the time and was replaced.

**Mutation B — the plausible wrong fix: use the observed probabilities as candidate thresholds
instead of the midpoints between them.** Caught deterministically by
`test_optimize_thresholds_matches_brute_force`, `test_optimize_thresholds_finds_draw_band`, and
`test_optimize_thresholds_never_worse_than_initial` — ties land on the wrong side of the
`>` / `<` comparisons, so the returned thresholds no longer reproduce the returned accuracy.

`test_optimize_thresholds_never_worse_than_initial` is *not* caught by mutation A (the old code
guarded that too) — it documents the invariant rather than guarding the fix, and is the primary
guard only for mutation B.

## Note for reviewers

`optimize_thresholds` is public and existing callers will now get different (better, and
stable) thresholds. `random_search` is left behaviourally unchanged apart from the new optional
`seed`; `docs/source/advance_example.rst` still demonstrates `random_search`, which continues to
work — switching that example over to `optimize_thresholds` felt outside this issue's scope.