### PR TITLE
Fix inverted TrueSkill draw margin and unify its three call sites

### DIFF
--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -418,6 +418,9 @@ class TrueSkillCompetitor(BaseCompetitor):
         """
         Calculate the draw margin based on beta and draw probability.
 
+        This is the canonical TrueSkill draw margin, increasing in the draw
+        probability: a draw-free configuration gives a zero margin.
+
         Args:
             beta: The beta parameter
             draw_probability: The probability of a draw
@@ -427,7 +430,7 @@ class TrueSkillCompetitor(BaseCompetitor):
         """
         if not 0 <= draw_probability < 1:
             raise InvalidParameterException("Draw probability must be between 0 and 1")
-        return float(math.sqrt(2) * beta * special.erfinv(1 - 2 * draw_probability))
+        return float(math.sqrt(2) * beta * special.ndtri((draw_probability + 1) / 2))
 
     def expected_score(self, competitor: BaseCompetitor) -> float:
         """Calculate the expected score (probability of winning) against another competitor.
@@ -497,7 +500,7 @@ class TrueSkillCompetitor(BaseCompetitor):
         v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
         # Calculate the performance update
-        draw_margin = math.sqrt(2) * self._beta * special.ndtri((self._draw_probability + 1) / 2)
+        draw_margin = self._calculate_draw_margin(self._beta, self._draw_probability)
         t = (mu_diff - draw_margin) / v
         v_win_value = self._v_win(t)
         w_win_value = self._w_win(t)
@@ -542,7 +545,7 @@ class TrueSkillCompetitor(BaseCompetitor):
         v = math.sqrt(2 * beta_squared + sigma_squared_sum)
 
         # Calculate the draw margin
-        draw_margin = math.sqrt(2) * self._beta * special.ndtri((self._draw_probability + 1) / 2)
+        draw_margin = self._calculate_draw_margin(self._beta, self._draw_probability)
 
         # Calculate the performance update for a draw
         t = mu_diff / v

--- a/tests/test_TrueSkillCompetitor_known_values.py
+++ b/tests/test_TrueSkillCompetitor_known_values.py
@@ -67,16 +67,27 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertTrue(hasattr(player, "_w_win"))
 
     def test_draw_margin_calculation(self):
-        """Test the draw margin calculation with known values."""
-        # Test with default draw probability
-        draw_margin = TrueSkillCompetitor._calculate_draw_margin(4.166, 0.10)
-        expected_margin = draw_margin  # Use actual value
-        self.assertAlmostEqual(draw_margin, expected_margin, places=3)
+        """Test the draw margin against independently derived literals.
 
-        # Test with different draw probability
-        draw_margin = TrueSkillCompetitor._calculate_draw_margin(4.166, 0.20)
-        expected_margin = draw_margin  # Use actual value
-        self.assertAlmostEqual(draw_margin, expected_margin, places=3)
+        The canonical TrueSkill draw margin is
+        ``sqrt(2) * beta * Phi^-1((p + 1) / 2)``, so at beta=4.166 the margin is
+        0.740348 at p=0.10 and 1.492623 at p=0.20. The values below are computed
+        from that closed form, not from the method under test.
+        """
+        self.assertAlmostEqual(TrueSkillCompetitor._calculate_draw_margin(4.166, 0.10), 0.740348, places=6)
+        self.assertAlmostEqual(TrueSkillCompetitor._calculate_draw_margin(4.166, 0.20), 1.492623, places=6)
+
+    def test_draw_margin_is_increasing_in_draw_probability(self):
+        """The margin grows with the draw probability and is exactly zero at p=0.
+
+        The pre-fix ``erfinv(1 - 2p)`` form is monotonically DECREASING and
+        returns ``inf`` at p=0, so it fails both halves of this test.
+        """
+        margins = [TrueSkillCompetitor._calculate_draw_margin(4.166, p) for p in (0.0, 0.05, 0.10, 0.20, 0.50)]
+
+        self.assertEqual(margins[0], 0.0)
+        for smaller, larger in zip(margins[:-1], margins[1:], strict=True):
+            self.assertLess(smaller, larger)
 
     def test_expected_score(self):
         """Test expected_score against externally derived reference probabilities.
@@ -97,14 +108,14 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertAlmostEqual(player1.expected_score(player2), 0.500000, places=5)
 
         # Unequal means, equal sigmas: the corrected variance term materially
-        # softens the prediction (single-noise form gives ~0.842074).
+        # softens the prediction (single-noise form gives ~0.887536).
         player1 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
         player2 = TrueSkillCompetitor(initial_mu=20.0, initial_sigma=5.0)
-        self.assertAlmostEqual(player1.expected_score(player2), 0.822961, places=5)
+        self.assertAlmostEqual(player1.expected_score(player2), 0.860595, places=5)
 
         # Same matchup reversed: the weaker player, complementary by construction
-        # (single-noise form gives ~0.157926).
-        self.assertAlmostEqual(player2.expected_score(player1), 0.177039, places=5)
+        # (single-noise form gives ~0.112464).
+        self.assertAlmostEqual(player2.expected_score(player1), 0.139405, places=5)
 
         # Equal means, different sigmas: still an even matchup.
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=3.0)
@@ -277,13 +288,11 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         self.assertNotEqual(player1_high_sigma.sigma, 8.333)
 
     def test_draw_margin_effect(self):
-        """A wider draw margin pulls the expected score toward 0.5.
+        """A higher draw probability widens the margin and pulls predictions toward 0.5.
 
-        The sweep is ordered by the resulting margin, not by draw probability:
-        ``_calculate_draw_margin`` (used only by ``expected_score``) maps a
-        HIGHER draw probability to a SMALLER margin, the opposite direction from
-        the ``ndtri((p + 1) / 2)`` margin ``beat``/``tied`` use. That
-        inconsistency is a separate defect and is out of scope here.
+        Both halves move in the same direction under the canonical margin. On the
+        pre-fix ``erfinv(1 - 2p)`` form the margin shrinks as the draw probability
+        rises and predictions get sharper, so this test fails on both counts.
         """
         player1 = TrueSkillCompetitor(initial_mu=25.0, initial_sigma=8.333)
         player2 = TrueSkillCompetitor(initial_mu=30.0, initial_sigma=5.0)
@@ -291,8 +300,7 @@ class TestTrueSkillKnownValues(unittest.TestCase):
         original_draw_prob = TrueSkillCompetitor._draw_probability
 
         try:
-            # Ordered so that the draw margin strictly increases.
-            draw_probs = [0.20, 0.10, 0.05]
+            draw_probs = [0.05, 0.10, 0.20]
             margins = []
             distances_from_even = []
 
@@ -306,6 +314,24 @@ class TestTrueSkillKnownValues(unittest.TestCase):
             self.assertLess(distances_from_even[2], distances_from_even[1])
             self.assertLess(distances_from_even[1], distances_from_even[0])
 
+        finally:
+            TrueSkillCompetitor._draw_probability = original_draw_prob
+
+    def test_expected_score_with_draws_disabled(self):
+        """With draws disabled the prediction still tracks the skill gap.
+
+        The pre-fix margin was ``inf`` at ``draw_probability=0``, collapsing every
+        prediction to exactly 0.5 regardless of the gap.
+        """
+        original_draw_prob = TrueSkillCompetitor._draw_probability
+
+        try:
+            TrueSkillCompetitor._draw_probability = 0.0
+            strong = TrueSkillCompetitor(initial_mu=40.0, initial_sigma=1.0)
+            weak = TrueSkillCompetitor(initial_mu=10.0, initial_sigma=1.0)
+
+            self.assertGreater(strong.expected_score(weak), 0.99)
+            self.assertLess(weak.expected_score(strong), 0.01)
         finally:
             TrueSkillCompetitor._draw_probability = original_draw_prob
 


### PR DESCRIPTION
Closes #113

## What changed

`TrueSkillCompetitor` computed the draw margin two different ways.

- `_calculate_draw_margin` used `sqrt(2) * beta * erfinv(1 - 2p)`, which is monotonically **decreasing** in `p` and returns `inf` at `p = 0`.
- `beat`/`tied` each re-inlined the canonical, **increasing** form `sqrt(2) * beta * ndtri((p + 1) / 2)`.

Only `expected_score` called the helper, so every prediction used the inverted margin. Two visible consequences: raising `draw_probability` made predictions *sharper* rather than pulling them toward 0.5, and `draw_probability = 0.0` — the natural setting for a draw-free domain, and inside the helper's own documented `0 <= p < 1` range — made `win_prob = Phi(-inf) = 0` and `draw_prob = 1`, so `expected_score` returned exactly 0.5 for any skill gap.

The fix gives `_calculate_draw_margin` the canonical formula and has `beat`/`tied` call it rather than re-inlining the expression, so the three sites cannot drift again. No `erfinv` call remains in `trueskill.py`.

Rating updates are unaffected: `beat`/`tied` already computed exactly this value, so every `test_beat_with_known_values` / `test_tied_with_known_values` literal is unchanged.

## Tests

- `test_draw_margin_calculation` was vacuous — it did `expected_margin = draw_margin` and asserted them equal. It now asserts independently derived literals: 0.740348 at `p = 0.10` and 1.492623 at `p = 0.20` (beta = 4.166).
- New `test_draw_margin_is_increasing_in_draw_probability`: strictly increasing over `p in [0.0, 0.05, 0.10, 0.20, 0.50]`, with exactly `0.0` at `p = 0`.
- New `test_expected_score_with_draws_disabled`: at `draw_probability = 0.0`, mu 40 vs mu 10 at sigma 1.0 predicts > 0.99 (it was exactly 0.5 before).
- `test_draw_margin_effect` was deliberately ordered around the inverted direction (its docstring said so). The sweep is now ordered `[0.05, 0.10, 0.20]` and asserts a higher draw probability pulls `expected_score` toward 0.5.
- `test_expected_score`'s unequal pair (mu 30/20, sigma 5/5, `draw_probability = 0.10`) is rebaselined 0.822961 -> 0.860595 and 0.177039 -> 0.139405. **This pair still fails if the `2*beta^2` variance term is mutated to `beta^2`** (single-noise form gives 0.887536), so it keeps guarding that earlier fix — verified below. The two equal-mean cases stay at exactly 0.5.

## Verification

All commands run from a clean worktree at this branch.

**Suite** — `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py`: **282 passed, 6 skipped** (280 at the branch point + 2 new tests). Includes `tests/test_unified_interface.py::TestExpectedScoreBounds` and `tests/test_TrueSkillCompetitor.py::TestTrueSkillExpectedScoreContract`.

**Lint** — `make lint`: `All checks passed!`. `ruff format --check` on both touched files: already formatted. `mypy --python-version 3.12 elote`: no issues.

**Mutation 1 — reinstate `erfinv(1 - 2p)` in the helper.** 7 tests fail, restored afterwards and re-confirmed green:

```
test_draw_margin_calculation
test_draw_margin_is_increasing_in_draw_probability
test_draw_margin_effect
test_expected_score
test_expected_score_with_draws_disabled
test_beat_with_known_values
test_tied_with_known_values
```

The last two are the check that `beat`/`tied` genuinely route through the helper now — under the old inlined code they would have been indifferent to this mutation.

**Mutation 2 — `sqrt(2*beta^2 + ...)` -> `sqrt(beta^2 + ...)` in `expected_score`.** Only `test_expected_score` fails, confirming the rebaselined pair still guards the variance term.

**Calibration.** On `SyntheticDataset(60, 3000, seed=42, draw_probability=0.5, noise_std=200.0).time_split(0.3)` (900 eval bouts), training with the canonical margin throughout and swapping only the margin `expected_score` uses:

| `draw_probability` | Brier (erfinv) | Brier (canonical) | accuracy (both) |
|---|---|---|---|
| 0.05 | 0.1131 | 0.1060 | 0.7011 |
| 0.10 | 0.1082 | 0.1061 | 0.7022 |
| 0.20 | 0.1059 | 0.1061 | 0.7022 |
| 0.35 | 0.1067 | 0.1062 | 0.7033 |
| 0.45 | 0.1078 | 0.1061 | 0.7022 |

The canonical form holds ~0.1061 flat while the buggy one degrades away from ~0.2; thresholded accuracy is identical in every pair, since the margin is a monotone rescaling of `mu_diff`. This is purely a probability-quality change.

One measurement note for anyone re-running this: swapping the helper *after* the fix also changes `beat`/`tied`, so a naive A/B perturbs training too and reverses the apparent result. The table above isolates the margin to `expected_score`, which is the comparison the issue describes.

## Risk

Predicted probabilities change for every unequal matchup (a 10-mu / sigma-5 gap moves 0.823 -> 0.861 at the default `draw_probability`), so downstream benchmark numbers shift. Rating updates are bit-identical.