### PR TITLE
Add MasseyCompetitor — the least-squares classical rating system

### DIFF
--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -75,6 +75,15 @@ Colley Matrix Competitor
    :show-inheritance:
    :special-members: __init__
 
+Massey Competitor
+-----------------
+
+.. automodule:: elote.competitors.massey
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 Bradley-Terry Competitor
 -----------------------
 

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -43,6 +43,12 @@ Colley Matrix Competitor
 .. autoclass:: elote.competitors.colley.ColleyMatrixCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Massey Competitor
+-----------------
+
+.. autoclass:: elote.competitors.massey.MasseyCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
 Bradley-Terry Competitor
 ------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/ecf
    rating_systems/dwz
    rating_systems/colley
+   rating_systems/massey
    rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -58,6 +58,12 @@ Overview Comparison
      - No
      - Yes
      - Bias-free sports ranking
+   * - **Massey**
+     - Sports (1997)
+     - Medium
+     - No
+     - Yes
+     - Margin-scale sports ranking
    * - **Bradley-Terry**
      - Statistics (1952)
      - Medium
@@ -72,8 +78,8 @@ Overview Comparison
      - Complex domains
 
 Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ) update ratings incrementally after each
-result. Global-fit systems (Colley Matrix and Bradley-Terry) re-solve the whole connected group of
-competitors from the full set of results, which makes them order independent.
+result. Global-fit systems (Colley Matrix, Massey and Bradley-Terry) re-solve the whole connected
+group of competitors from the full set of results, which makes them order independent.
 
 Mathematical Formulation
 -----------------------
@@ -98,6 +104,8 @@ Mathematical Formulation
      - :math:`W_e = \frac{1}{1 + 10^{-(R_A - R_B) / 400}}`
    * - **Colley Matrix**
      - Ratings solve :math:`C r = b`; :math:`E_A = \frac{1}{1 + e^{-4 (r_A - r_B)}}`
+   * - **Massey**
+     - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B)}}`
    * - **Bradley-Terry**
      - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
    * - **Ensemble**
@@ -126,6 +134,8 @@ Key Parameters
      - Initial rating, Development coefficient (age-dependent)
    * - **Colley Matrix**
      - Initial rating (default 0.5)
+   * - **Massey**
+     - Initial rating (default 0.0), Expected-score scale
    * - **Bradley-Terry**
      - Initial rating, Scale, Regularization, Max iterations
    * - **Ensemble**
@@ -239,6 +249,21 @@ Colley Matrix
 - Ratings are on a [0, 1] scale, not the chess scale
 - Requires a connected schedule to compare competitors
 
+Massey
+^^^^^^
+
+**Strengths:**
+- Order independent: depends only on the set of results
+- Rating differences are directly interpretable as predicted margins
+- Clean least-squares interpretation with a unique zero-mean solution
+- Self-normalizing: the ratings of a connected group sum to zero
+
+**Weaknesses:**
+- Re-solves the whole connected group after each result
+- Unit margins only: the uniform API carries no score differential
+- Ratings are zero mean, so about half of them are negative
+- Requires a connected schedule to compare competitors
+
 Bradley-Terry
 ^^^^^^^^^^^^^
 
@@ -286,7 +311,7 @@ Consider the following factors when choosing a rating system:
    - General purpose: Elo or Glicko
 
 3. **Order Independence**: Do you need a ranking that ignores schedule order?
-   - Yes: Colley Matrix or Bradley-Terry
+   - Yes: Colley Matrix, Massey, or Bradley-Terry
    - No: any online system (Elo, Glicko, etc.)
 
 4. **Computational Resources**:
@@ -316,6 +341,7 @@ Here's a quick comparison of how to use each system in Elote:
         ECFCompetitor,
         DWZCompetitor,
         ColleyMatrixCompetitor,
+        MasseyCompetitor,
         BradleyTerryCompetitor,
         BlendedCompetitor,
     )
@@ -340,6 +366,9 @@ Here's a quick comparison of how to use each system in Elote:
 
     # Colley Matrix ([0, 1] scale)
     colley_player = ColleyMatrixCompetitor()
+
+    # Massey (zero-mean margin scale)
+    massey_player = MasseyCompetitor()
 
     # Bradley-Terry (Elo-compatible scale)
     bt_player = BradleyTerryCompetitor(initial_rating=1500)

--- a/docs/source/rating_systems/massey.rst
+++ b/docs/source/rating_systems/massey.rst
@@ -1,0 +1,134 @@
+Massey Ratings
+==============
+
+Overview
+--------
+
+The Massey method is the least-squares counterpart to the :doc:`Colley Matrix Method <colley>`.
+Introduced by Kenneth Massey in 1997 and used as one of the computer rankings in the college-football
+Bowl Championship Series, it fits every competitor a rating such that the *difference* between two
+ratings is a least-squares estimate of the margin by which one would beat the other. Like Colley it
+solves a single linear system over the whole match history rather than nudging ratings after each
+game, so it is **bias free**: the ratings depend only on the set of results, not on the order they
+were played in.
+
+Where Colley produces win-percentage-like ratings bounded to [0, 1], Massey produces zero-mean
+ratings on a signed *margin* scale. Roughly half of them are negative, and ``r_a - r_b`` reads
+directly as a predicted margin.
+
+How It Works
+-----------
+
+Massey's method builds the linear system
+
+.. math::
+
+   M\,r = p
+
+where :math:`M = D - A` is the match graph's Laplacian -- :math:`D_{ii}` is the number of games
+played by competitor :math:`i` and :math:`A_{ij}` is the number of games between :math:`i` and
+:math:`j` -- and :math:`p_i` is competitor :math:`i`'s cumulative margin.
+
+Because every row of :math:`M` sums to zero, the matrix is singular by construction: adding a
+constant to every rating leaves the system unchanged. The standard fix is applied here: the last row
+of :math:`M` is replaced with all ones and the last entry of :math:`p` with zero, which adds the
+constraint
+
+.. math::
+
+   \sum_i r_i = 0
+
+and makes the solution unique on a connected schedule. As with Colley, the fit is recomputed over the
+connected group of competitors after each recorded result, and the expected score between two
+competitors is a logistic function of their rating difference:
+
+.. math::
+
+   E_a = \frac{1}{1 + e^{-s\,(r_a - r_b)}}
+
+with a class-configurable scale :math:`s` (default 2.0).
+
+Unit Margins
+-----------
+
+.. important::
+
+   Elote implements **unit-margin** Massey. The uniform ``BaseCompetitor`` API exposes only
+   ``beat`` / ``lost_to`` / ``tied`` and has no channel for a score differential, so a win
+   contributes ``+1`` to the winner's cumulative margin and ``-1`` to the loser's, and a draw
+   contributes ``0`` to both while still counting as a game played for each.
+
+Genuine margin-of-victory Massey -- the form used in college-football rankings, where a 35-3 win
+counts for more than a 7-6 win -- would require carrying a score through the result methods, and is
+not implemented. In practice, unit-margin Massey is a close relative of Colley on a signed scale:
+both use only who beat whom, and neither can be gamed by running up the score.
+
+Advantages
+---------
+
+- **Order Independent**: the ratings depend only on the set of results, not the schedule order.
+- **Interpretable Differences**: a rating difference is a predicted margin, not just an ordering.
+- **Well Grounded**: a clean least-squares interpretation with a unique zero-mean solution.
+- **Self-Normalizing**: the ratings of a connected group always sum to zero.
+
+Limitations
+----------
+
+- **Recomputes Globally**: like Colley and Bradley-Terry, each result re-solves the whole connected
+  group, which is more expensive than Elo's constant-time update for very large populations.
+- **Unit Margins Only**: see above; the margin channel the classical method uses is not available
+  through the uniform API.
+- **Negative Ratings**: ratings are zero mean, which is unfamiliar next to a 1500-centered chess
+  scale (``_minimum_rating`` is therefore ``-inf`` for this system).
+- **Connectivity Needed**: groups of competitors that never play each other cannot be compared, and
+  are rated independently of one another.
+
+Implementation in Elote
+----------------------
+
+Elote implements Massey Ratings through the ``MasseyCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import MasseyCompetitor
+
+    # Every competitor starts at 0.0
+    team_a = MasseyCompetitor()
+    team_b = MasseyCompetitor()
+    team_c = MasseyCompetitor()
+
+    # Get win probability
+    print(f"Team A win probability: {team_a.expected_score(team_b):.2%}")
+
+    # Record results; the whole connected group is re-solved after each one
+    team_a.beat(team_b)
+    team_a.beat(team_c)
+    team_b.beat(team_c)
+
+    print(f"Team A: {team_a.rating:.3f}")   # 0.667
+    print(f"Team B: {team_b.rating:.3f}")   # 0.000
+    print(f"Team C: {team_c.rating:.3f}")   # -0.667
+
+Customization
+------------
+
+Key parameters:
+
+- **initial_rating**: starting rating value (default: 0.0).
+- **expected_score_scale**: class-level logistic scale used by ``expected_score`` (default: 2.0),
+  settable with ``MasseyCompetitor.configure_class(expected_score_scale=...)``.
+
+Real-World Applications
+---------------------
+
+- **College Football**: one of the computer polls used in the BCS era.
+- **Sports Rankings**: any competition where a predicted margin is more useful than a bare ordering.
+- **Tournament Seeding**: producing an order-independent ranking from recorded results.
+
+References
+---------
+
+1. Massey, K. (1997). "Statistical Models Applied to the Rating of Sports Teams".
+   Bluefield College undergraduate honors thesis. https://masseyratings.com/theory/massey97.pdf
+2. Langville, A. N., & Meyer, C. D. (2012). *Who's #1? The Science of Rating and Ranking*,
+   chapter 2. Princeton University Press.

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -25,6 +25,7 @@ Available rating systems:
 - ECF: The English Chess Federation rating system
 - DWZ: The Deutsche Wertungszahl (German evaluation number) system
 - Colley Matrix: A least-squares rating system that solves a system of linear equations
+- Massey: A least-squares rating system whose ratings live on a signed margin scale
 - Bradley-Terry: A maximum-likelihood paired-comparison model
 - Ensemble: A meta-rating system that combines multiple rating systems
 
@@ -46,6 +47,7 @@ from elote.competitors.trueskill import TrueSkillCompetitor
 from elote.competitors.ecf import ECFCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
+from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
@@ -81,6 +83,7 @@ __all__ = [
     "ECFCompetitor",
     "DWZCompetitor",
     "ColleyMatrixCompetitor",
+    "MasseyCompetitor",
     "BradleyTerryCompetitor",
     "BlendedCompetitor",
     # Arenas

--- a/elote/competitors/massey.py
+++ b/elote/competitors/massey.py
@@ -1,0 +1,407 @@
+"""
+Massey Ratings implementation for the Elote library.
+
+The Massey method is the least-squares counterpart to
+:class:`~elote.competitors.colley.ColleyMatrixCompetitor`. Where Colley solves a
+ridge-regularized win-percentage model whose ratings are bounded to [0, 1], Massey solves an
+unregularized least-squares system whose ratings live on a signed *margin* scale: the fitted
+rating difference ``r_i - r_j`` is the model's predicted margin when ``i`` plays ``j``.
+
+The system is
+
+.. math::
+
+   M r = p
+
+where ``M = D - A`` (``D_ii`` is the number of games played by ``i`` and ``A_ij`` the number of
+games between ``i`` and ``j``) and ``p_i`` is ``i``'s cumulative margin. ``M`` is a graph
+Laplacian, so its rows sum to zero and it is singular by construction. The standard fix is
+applied: the last row is replaced with all ones and the last entry of ``p`` with zero, which
+pins the ratings to zero mean and makes the solution unique on a connected schedule.
+
+References:
+- Massey, K. (1997). Statistical Models Applied to the Rating of Sports Teams.
+  Bluefield College undergraduate honors thesis.
+- Langville, A. N., & Meyer, C. D. (2012). Who's #1? The Science of Rating and Ranking.
+  Princeton University Press, chapter 2.
+"""
+
+from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
+
+import numpy as np
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException, InvalidRatingValueException
+from elote.logging import logger
+
+T = TypeVar("T", bound="MasseyCompetitor")
+
+
+class MasseyCompetitor(BaseCompetitor):
+    """Massey Ratings competitor.
+
+    Massey's method assigns every competitor a rating such that the difference between two
+    ratings is a least-squares estimate of the margin by which one would beat the other.
+    Like Colley and Bradley-Terry -- and unlike Elo -- ratings are not nudged after each
+    result; the whole connected group is re-fit from the complete match history, which makes
+    the method order independent.
+
+    **Unit margins.** The uniform ``BaseCompetitor`` API exposes only ``beat`` / ``lost_to`` /
+    ``tied`` and has no channel for a score differential, so this implementation is
+    *unit-margin* Massey: a win contributes ``+1`` to the winner's cumulative margin and
+    ``-1`` to the loser's, and a draw contributes ``0`` to both while still counting as a game
+    played for each. Genuine margin-of-victory Massey -- the form used in college football
+    rankings -- would require a base-class level decision about how to carry a score, and is
+    not implemented here.
+
+    Key characteristics:
+    - Global least-squares fit (does not depend on the order of results)
+    - Ratings are zero mean within a connected group, so roughly half of them are negative
+    - The rating difference is directly interpretable as a predicted margin
+
+    Class Attributes:
+        _minimum_rating (float): The minimum allowed rating value. Default: ``-inf``. Massey
+            ratings are zero mean and routinely negative, so no floor is imposed.
+        _default_initial_rating (float): Default initial rating. Default: 0.0.
+        _expected_score_scale (float): Logistic scale used by :meth:`expected_score` to turn a
+            rating difference into a win probability. Default: 2.0, chosen so that the widest
+            plausible unit-margin gap maps to roughly the same probability as the widest gap
+            under Colley's ``1 / (1 + exp(-4 * diff))``.
+        _round_decimals (int): Number of decimal places fitted ratings are canonicalized to, so
+            that solver noise cannot make mathematically identical records differ. Default: 13.
+    """
+
+    _minimum_rating: ClassVar[float] = float("-inf")
+    _default_initial_rating: ClassVar[float] = 0.0
+    _expected_score_scale: ClassVar[float] = 2.0
+    _round_decimals: ClassVar[int] = 13
+
+    def __init__(self, initial_rating: Optional[float] = None):
+        """Initialize a new Massey competitor.
+
+        Args:
+            initial_rating (float, optional): The initial rating of this competitor. Default: 0.0.
+        """
+        super().__init__()  # Call base class constructor
+
+        self._initial_rating = initial_rating if initial_rating is not None else self._default_initial_rating
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        # Cumulative margin -- the right-hand side ``p`` of the Massey system. With unit
+        # margins this is simply wins minus losses, but it is tracked separately because it is
+        # the quantity the algorithm actually consumes.
+        self._point_differential = 0.0
+        self._opponents: Dict["MasseyCompetitor", int] = {}  # Opponent -> num games
+        # Unique ID for hashing (instances are used as dict keys in the match graph).
+        self._id = id(self)
+        logger.debug("Initialized MasseyCompetitor %d with initial rating %.3f", self._id, self._initial_rating)
+
+    @property
+    def rating(self) -> float:
+        """Get the current rating of this competitor.
+
+        Returns:
+            float: The current rating.
+        """
+        return self._rating
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        """Set the current rating of this competitor.
+
+        Args:
+            value (float): The new rating value.
+
+        Raises:
+            InvalidRatingValueException: If the rating value is below the minimum rating.
+        """
+        if value < self._minimum_rating:
+            logger.warning(
+                "Attempted to set rating %.3f below minimum %.3f for %d", value, self._minimum_rating, self._id
+            )
+            raise InvalidRatingValueException(f"Rating cannot be below the minimum rating of {self._minimum_rating}")
+        self._rating = value
+
+    @property
+    def num_games(self) -> int:
+        """Get the total number of games played by this competitor.
+
+        Returns:
+            int: The total number of games played.
+        """
+        return self._wins + self._losses + self._ties
+
+    def expected_score(self, competitor: "BaseCompetitor") -> float:
+        """Calculate the expected score against another competitor.
+
+        Massey ratings are on a margin scale rather than a probability scale, so the predicted
+        margin ``r_self - r_competitor`` is squashed through a logistic function to obtain a
+        win probability. Two competitors with equal ratings give exactly 0.5, and the two
+        argument orders are exactly complementary.
+
+        Args:
+            competitor (BaseCompetitor): The competitor to compare against.
+
+        Returns:
+            float: The expected score (probability of winning).
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        rating_diff = self.rating - competitor.rating
+        # tanh form: symmetric in the sign of rating_diff, so the two argument orders sum to
+        # exactly 1.0 in floating point.
+        return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * rating_diff)))
+
+    def beat(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has won against the given competitor.
+
+        The result is recorded in the match graph and the whole connected group is re-fit.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that lost.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s beat %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        opponent = cast(MasseyCompetitor, competitor)
+
+        self._wins += 1
+        self._point_differential += 1.0
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+
+        opponent._losses += 1
+        opponent._point_differential -= 1.0
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+
+        logger.debug("Recorded win for %d, loss for %d", self._id, opponent._id)
+        self._recalculate_ratings()
+
+    def tied(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has tied with the given competitor.
+
+        A draw contributes nothing to either cumulative margin, but counts as a game played
+        for both competitors.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that tied.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s tied with %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        opponent = cast(MasseyCompetitor, competitor)
+
+        self._ties += 1
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+
+        opponent._ties += 1
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+
+        logger.debug("Recorded tie for %d and %d", self._id, opponent._id)
+        self._recalculate_ratings()
+
+    def lost_to(self, competitor: BaseCompetitor) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that won.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        logger.debug("Competitor %s lost to %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        competitor.beat(self)
+
+    def _get_connected_competitors(self) -> List["MasseyCompetitor"]:
+        """Get all competitors connected to this competitor in the match graph.
+
+        Returns:
+            List[MasseyCompetitor]: A list of all connected competitors.
+        """
+        visited: Set["MasseyCompetitor"] = set()
+        to_visit: List["MasseyCompetitor"] = [self]
+        all_competitors = []
+
+        while to_visit:
+            current = to_visit.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            all_competitors.append(current)
+            for opponent in current._opponents:
+                if opponent not in visited:
+                    to_visit.append(opponent)
+
+        logger.debug("Found %d connected competitors", len(all_competitors))
+        return all_competitors
+
+    def _recalculate_ratings(self) -> None:
+        """Re-fit the Massey ratings for all connected competitors.
+
+        Builds ``M = D - A`` and the cumulative-margin vector ``p``, replaces the last row of
+        ``M`` with all ones (and the last entry of ``p`` with zero) to remove the singularity,
+        and solves the resulting system. The constraint pins the ratings to zero mean.
+        """
+        competitors = self._get_connected_competitors()
+        n = len(competitors)
+        if n <= 1:
+            logger.debug("Only one competitor in network, skipping recalculation.")
+            return
+
+        idx = {comp: i for i, comp in enumerate(competitors)}
+
+        M = np.zeros((n, n), dtype=np.float64)
+        p = np.zeros(n, dtype=np.float64)
+        for i, comp in enumerate(competitors):
+            M[i, i] = comp.num_games
+            p[i] = comp._point_differential
+            for opponent, games in comp._opponents.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    M[i, j] = -games
+
+        # M is a graph Laplacian and therefore singular. Replacing one equation with the
+        # zero-sum constraint makes the system non-singular; the replaced equation is implied
+        # by the remaining ones, so the solution is unaffected by which row is chosen.
+        M[n - 1, :] = 1.0
+        p[n - 1] = 0.0
+
+        try:
+            r = np.linalg.solve(M, p)
+        except np.linalg.LinAlgError as e:
+            logger.warning(
+                "Massey matrix is singular (%s). Falling back to average-margin ratings for %d competitors.",
+                str(e),
+                n,
+            )
+            self._fallback_rating_calculation(competitors)
+            return
+
+        # The solver's pivoting depends on the row order, which is the order competitors were
+        # discovered in, so two runs over the same results can differ in the last few bits.
+        # Canonicalizing to _round_decimals places makes mathematically identical records
+        # compare exactly equal and makes the fit order independent.
+        r = np.round(r, decimals=self._round_decimals)
+
+        for i, comp in enumerate(competitors):
+            comp.rating = float(r[i])
+
+    def _fallback_rating_calculation(self, competitors: List["MasseyCompetitor"]) -> None:
+        """Assign average-margin ratings when the linear system cannot be solved.
+
+        Args:
+            competitors: The connected group of competitors to rate.
+        """
+        ratings = [(comp._point_differential / comp.num_games) if comp.num_games else 0.0 for comp in competitors]
+        mean_rating = sum(ratings) / len(ratings)
+        for comp, value in zip(competitors, ratings, strict=True):
+            comp.rating = value - mean_rating
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        """Export the parameters used to initialize this competitor.
+
+        Returns:
+            dict: A dictionary containing the initialization parameters.
+        """
+        return {
+            "initial_rating": self._initial_rating,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        """Export the current state variables of this competitor.
+
+        Returns:
+            dict: A dictionary containing the current state variables.
+        """
+        return {
+            "rating": self._rating,
+            "wins": self._wins,
+            "losses": self._losses,
+            "ties": self._ties,
+            "point_differential": self._point_differential,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        """Import parameters from a state dictionary.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+        """
+        self._initial_rating = parameters.get("initial_rating", self._default_initial_rating)
+        self._rating = self._initial_rating
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        """Import current state variables from a state dictionary.
+
+        Note: opponent references cannot be restored from serialization, so the match graph is
+        reset; the rating and aggregate counts are preserved.
+
+        Args:
+            state (dict): A dictionary containing state variables.
+        """
+        self._rating = state.get("rating", self._initial_rating)
+        self._wins = state.get("wins", 0)
+        self._losses = state.get("losses", 0)
+        self._ties = state.get("ties", 0)
+        self._point_differential = state.get("point_differential", float(self._wins - self._losses))
+        self._opponents = {}
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        """Create a new competitor instance from parameters.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Returns:
+            MasseyCompetitor: A new competitor instance.
+        """
+        return cls(initial_rating=parameters.get("initial_rating", cls._default_initial_rating))
+
+    def reset(self) -> None:
+        """Reset this competitor to its initial state."""
+        logger.info("Resetting MasseyCompetitor %d to initial state.", self._id)
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        self._point_differential = 0.0
+        self._opponents = {}
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        """Configure class-level parameters for this rating system.
+
+        Overrides the base implementation to validate the expected-score scale.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        if "expected_score_scale" in kwargs and kwargs["expected_score_scale"] <= 0:
+            raise InvalidParameterException("expected_score_scale must be positive")
+        super().configure_class(**kwargs)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<MasseyCompetitor: rating={self._rating:.3f}, W/L/T={self._wins}/{self._losses}/{self._ties}>"
+
+    def __str__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<MasseyCompetitor: rating={self._rating:.3f}>"
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if two competitors are the same object (by unique ID)."""
+        if not isinstance(other, MasseyCompetitor):
+            return NotImplemented
+        return self._id == other._id
+
+    def __hash__(self) -> int:
+        """Get a hash value for this competitor based on its unique ID."""
+        return hash(self._id)

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -12,6 +12,7 @@ from elote import (
     Glicko2Competitor,
     GlickoCompetitor,
     LambdaArena,
+    MasseyCompetitor,
     TrueSkillCompetitor,
 )
 
@@ -297,9 +298,10 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         DWZCompetitor,
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
+        MasseyCompetitor,
     )
 
-    # Colley and Bradley-Terry reset their opponent match graph on import by design
+    # Colley, Massey and Bradley-Terry reset their opponent match graph on import by design
     # (documented in their own docstrings), so only the incremental systems can be
     # expected to keep rating identically after a restore.
     INCREMENTAL_COMPETITORS = (

--- a/tests/test_MasseyCompetitor.py
+++ b/tests/test_MasseyCompetitor.py
@@ -1,0 +1,296 @@
+import json
+import unittest
+
+from elote import EloCompetitor, LambdaArena, MasseyCompetitor
+from elote.competitors.base import (
+    InvalidParameterException,
+    InvalidRatingValueException,
+    MissMatchedCompetitorTypesException,
+)
+
+
+class TestMassey(unittest.TestCase):
+    """Behavioural tests for MasseyCompetitor."""
+
+    def test_improvement(self):
+        """Beating fresh opponents drives a competitor's rating up."""
+        anchor = MasseyCompetitor()
+        previous = anchor.rating
+        for _ in range(5):
+            anchor.beat(MasseyCompetitor())
+            self.assertGreater(anchor.rating, previous)
+            previous = anchor.rating
+
+    def test_decay(self):
+        """Losing to fresh opponents drives a competitor's rating down."""
+        anchor = MasseyCompetitor()
+        previous = anchor.rating
+        for _ in range(5):
+            MasseyCompetitor().beat(anchor)
+            self.assertLess(anchor.rating, previous)
+            previous = anchor.rating
+
+    def test_lost_to_matches_beat(self):
+        """a.lost_to(b) must produce the same fit as b.beat(a)."""
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.lost_to(b)
+
+        c, d = MasseyCompetitor(), MasseyCompetitor()
+        d.beat(c)
+
+        self.assertEqual(a.rating, c.rating)
+        self.assertEqual(b.rating, d.rating)
+
+    def test_draw_leaves_both_competitors_level(self):
+        """A drawn game contributes no margin, so both ratings stay at zero."""
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.tied(b)
+
+        self.assertEqual(a.rating, 0.0)
+        self.assertEqual(b.rating, 0.0)
+        self.assertEqual(a.num_games, 1)
+        self.assertEqual(b.num_games, 1)
+
+    def test_type_mismatch_is_rejected(self):
+        """Massey competitors cannot be mixed with other rating systems."""
+        massey = MasseyCompetitor()
+        for call in ("expected_score", "beat", "tied", "lost_to"):
+            with self.subTest(call=call):
+                with self.assertRaises(MissMatchedCompetitorTypesException):
+                    getattr(massey, call)(EloCompetitor())
+
+
+class TestMasseyNegativeRatings(unittest.TestCase):
+    """Massey ratings are zero mean, so negative ratings must be legal."""
+
+    def test_minimum_rating_is_unbounded_below(self):
+        """The class must override the inherited floor of 100."""
+        self.assertEqual(MasseyCompetitor._minimum_rating, float("-inf"))
+
+    def test_losing_run_produces_a_negative_rating(self):
+        """A competitor that only loses ends below zero without raising.
+
+        This is the guard on the ``_minimum_rating`` override: ``_recalculate_ratings``
+        assigns through the ``rating`` property, so with the inherited floor of 100 the
+        very first fit would raise InvalidRatingValueException.
+        """
+        loser = MasseyCompetitor()
+        winners = [MasseyCompetitor() for _ in range(4)]
+
+        winners[0].beat(loser)
+        loser.lost_to(winners[1])
+        winners[2].beat(loser)
+        loser.lost_to(winners[3])
+
+        self.assertLess(loser.rating, 0.0)
+        # And the winners, who only ever played the loser, sit above it.
+        for winner in winners:
+            self.assertGreater(winner.rating, loser.rating)
+
+    def test_explicit_assignment_below_zero_is_allowed(self):
+        """The rating setter must accept negative values."""
+        competitor = MasseyCompetitor()
+        competitor.rating = -12.5
+        self.assertEqual(competitor.rating, -12.5)
+
+    def test_negative_initial_rating_is_allowed(self):
+        """A negative starting rating is a legal Massey configuration."""
+        self.assertEqual(MasseyCompetitor(initial_rating=-3.0).rating, -3.0)
+
+
+class TestMasseyInvariants(unittest.TestCase):
+    """Structural properties of the Massey fit."""
+
+    def test_ratings_of_a_connected_component_sum_to_zero(self):
+        """The pinned constraint row forces zero-mean ratings."""
+        competitors = [MasseyCompetitor() for _ in range(6)]
+        schedule = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 0), (0, 2), (1, 4), (3, 5)]
+        for winner, loser in schedule:
+            competitors[winner].beat(competitors[loser])
+        competitors[2].tied(competitors[5])
+
+        self.assertAlmostEqual(sum(c.rating for c in competitors), 0.0, places=12)
+
+    def test_identical_records_produce_one_single_rating(self):
+        """A five-player circular schedule leaves everyone 1-1 and equally rated."""
+        competitors = [MasseyCompetitor() for _ in range(5)]
+        for i in range(5):
+            competitors[i].beat(competitors[(i + 1) % 5])
+
+        ratings = {c.rating for c in competitors}
+        self.assertEqual(len(ratings), 1, f"expected one tied rating, got {sorted(ratings)}")
+        self.assertAlmostEqual(next(iter(ratings)), 0.0, places=12)
+
+    # A five-competitor schedule chosen by search, not by eye: the raw solver output for
+    # this fixture differs in its last bits between the two orderings below, so the test
+    # fails if _recalculate_ratings stops canonicalizing the solution.
+    ORDER_INDEPENDENCE_SCHEDULE = [
+        ("d", "a", False),
+        ("e", "d", False),
+        ("c", "d", False),
+        ("b", "e", False),
+        ("a", "c", False),
+        ("e", "b", False),
+        ("a", "c", False),
+        ("a", "c", False),
+        ("e", "b", False),
+        ("d", "e", False),
+        ("c", "a", False),
+        ("e", "a", True),
+    ]
+
+    def test_ratings_are_order_independent(self):
+        """The same results applied in two different orders give identical ratings."""
+        schedule = self.ORDER_INDEPENDENCE_SCHEDULE
+
+        def fit(order, results):
+            competitors = {name: MasseyCompetitor() for name in order}
+            for winner, loser, drawn in results:
+                if drawn:
+                    competitors[winner].tied(competitors[loser])
+                else:
+                    competitors[winner].beat(competitors[loser])
+            return {name: competitor.rating for name, competitor in competitors.items()}
+
+        forwards = fit("abcde", schedule)
+        backwards = fit("edcba", list(reversed(schedule)))
+
+        self.assertEqual(forwards, backwards)
+        # Guard against the fixture silently degenerating into an all-zero schedule.
+        self.assertGreater(max(abs(rating) for rating in forwards.values()), 0.1)
+
+    def test_fallback_rating_calculation_is_zero_mean(self):
+        """The defensive singular-matrix fallback rates by average margin, zero mean.
+
+        The constrained system is non-singular for any connected component, so this branch
+        is unreachable in normal play; it is exercised directly so it is not dead code.
+        """
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        b.beat(c)
+        a.beat(c)
+
+        a._fallback_rating_calculation([a, b, c])
+
+        # a is 2-0 (+2/2), b is 1-1 (0/2), c is 0-2 (-2/2); mean 0, so ratings are +1, 0, -1.
+        self.assertAlmostEqual(a.rating, 1.0, places=12)
+        self.assertAlmostEqual(b.rating, 0.0, places=12)
+        self.assertAlmostEqual(c.rating, -1.0, places=12)
+
+    def test_disconnected_groups_are_rated_independently(self):
+        """A result in one component leaves an unrelated component untouched."""
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        c, d = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        ratings_before = (a.rating, b.rating)
+
+        c.beat(d)
+
+        self.assertEqual((a.rating, b.rating), ratings_before)
+
+
+class TestMasseyExpectedScore(unittest.TestCase):
+    """Probability contract specifics for MasseyCompetitor."""
+
+    def test_fresh_competitors_give_exactly_one_half(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        self.assertEqual(a.expected_score(b), 0.5)
+
+    def test_expected_scores_are_exactly_complementary(self):
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        a.beat(c)
+        b.tied(c)
+
+        for first, second in ((a, b), (b, c), (a, c)):
+            with self.subTest(pair=(first.rating, second.rating)):
+                self.assertEqual(first.expected_score(second) + second.expected_score(first), 1.0)
+
+    def test_scale_is_class_configurable(self):
+        """A larger scale sharpens the predicted probability."""
+        strong = MasseyCompetitor(initial_rating=0.5)
+        weak = MasseyCompetitor(initial_rating=-0.5)
+        default = strong.expected_score(weak)
+
+        try:
+            MasseyCompetitor.configure_class(expected_score_scale=8.0)
+            self.assertGreater(strong.expected_score(weak), default)
+        finally:
+            MasseyCompetitor.configure_class(expected_score_scale=2.0)
+
+        self.assertEqual(strong.expected_score(weak), default)
+
+    def test_non_positive_scale_is_rejected(self):
+        with self.assertRaises(InvalidParameterException):
+            MasseyCompetitor.configure_class(expected_score_scale=0.0)
+        self.assertEqual(MasseyCompetitor._expected_score_scale, 2.0)
+
+
+class TestMasseySerialization(unittest.TestCase):
+    """State export/import for MasseyCompetitor."""
+
+    def test_state_round_trip_preserves_rating_and_record(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        a.beat(b)
+        b.tied(a)
+
+        restored = MasseyCompetitor.from_state(json.loads(json.dumps(a.export_state())))
+
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual(restored._wins, a._wins)
+        self.assertEqual(restored._losses, a._losses)
+        self.assertEqual(restored._ties, a._ties)
+        self.assertEqual(restored._point_differential, a._point_differential)
+
+    def test_export_reports_the_concrete_type(self):
+        state = MasseyCompetitor().export_state()
+        self.assertEqual(state["type"], "MasseyCompetitor")
+        self.assertIn("initial_rating", state)
+
+    def test_class_is_registered(self):
+        self.assertIn("MasseyCompetitor", MasseyCompetitor.list_competitor_types())
+        self.assertIs(MasseyCompetitor.get_competitor_class("MasseyCompetitor"), MasseyCompetitor)
+
+    def test_reset_restores_a_fresh_competitor(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        a.reset()
+
+        self.assertEqual(a.rating, 0.0)
+        self.assertEqual(a.num_games, 0)
+        self.assertEqual(a._point_differential, 0.0)
+        self.assertEqual(a._opponents, {})
+
+    def test_arena_state_round_trip_reproduces_the_leaderboard(self):
+        """A JSON round trip through LambdaArena reproduces the leaderboard exactly."""
+        arena = LambdaArena(lambda a, b: a > b, base_competitor=MasseyCompetitor)
+        for a, b in (("1", "2"), ("2", "3"), ("3", "1"), ("1", "4"), ("4", "2"), ("3", "4")):
+            arena.matchup(a, b)
+
+        state = json.loads(json.dumps(arena.export_state()))
+        restored = LambdaArena(lambda a, b: a > b, initial_state=state)
+
+        self.assertEqual(arena.leaderboard(), restored.leaderboard())
+        for competitor in restored.competitors.values():
+            self.assertIsInstance(competitor, MasseyCompetitor)
+
+
+class TestMasseyRatingSetterValidation(unittest.TestCase):
+    """The floor is unbounded by default but the setter still honours it if configured."""
+
+    def test_setter_raises_when_a_floor_is_configured(self):
+        competitor = MasseyCompetitor()
+        try:
+            MasseyCompetitor.configure_class(minimum_rating=0.0)
+            with self.assertRaises(InvalidRatingValueException):
+                competitor.rating = -1.0
+        finally:
+            MasseyCompetitor.configure_class(minimum_rating=float("-inf"))
+
+        competitor.rating = -1.0
+        self.assertEqual(competitor.rating, -1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_MasseyCompetitor_known_values.py
+++ b/tests/test_MasseyCompetitor_known_values.py
@@ -1,0 +1,126 @@
+import unittest
+
+from elote import MasseyCompetitor
+
+
+class TestMasseyKnownValues(unittest.TestCase):
+    """Numeric references for MasseyCompetitor, hand-solved from the linear system."""
+
+    def test_initial_rating(self):
+        """A fresh competitor sits at the zero-mean origin unless told otherwise."""
+        self.assertEqual(MasseyCompetitor().rating, 0.0)
+        self.assertEqual(MasseyCompetitor(initial_rating=-2.5).rating, -2.5)
+
+    def test_expected_score(self):
+        """expected_score is the documented logistic on the rating difference."""
+        # scale = 2.0, so a rating difference d gives 1 / (1 + exp(-2 d)).
+        # d = 0.5  ->  1 / (1 + exp(-1)) = 0.7310585786300049
+        strong = MasseyCompetitor(initial_rating=0.25)
+        weak = MasseyCompetitor(initial_rating=-0.25)
+
+        self.assertAlmostEqual(strong.expected_score(weak), 0.7310585786300049, places=12)
+        self.assertAlmostEqual(weak.expected_score(strong), 0.2689414213699951, places=12)
+
+    def test_three_competitor_transitive_schedule(self):
+        """A > B, A > C, B > C solves to (2/3, 0, -2/3).
+
+        Every competitor plays two games, so D = diag(2, 2, 2), and each pair meets once,
+        giving
+
+            M = D - A = [[ 2, -1, -1],
+                         [-1,  2, -1],
+                         [-1, -1,  2]]
+
+        Unit margins give p = (+2, 0, -2): A wins twice, B splits, C loses twice.
+        Replacing the last row of M with ones and the last entry of p with 0 pins the
+        ratings to zero mean, so with a + b + c = 0:
+
+            row 1:  2a - b - c = 2  ->  2a + a = 3a = 2  ->  a =  2/3
+            row 2: -a + 2b - c = 0  -> -a + 2b + a + b = 3b = 0  ->  b =  0
+            zero mean:                                             c = -2/3
+        """
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        a.beat(c)
+        b.beat(c)
+
+        self.assertAlmostEqual(a.rating, 2.0 / 3.0, places=9)
+        self.assertAlmostEqual(b.rating, 0.0, places=9)
+        self.assertAlmostEqual(c.rating, -2.0 / 3.0, places=9)
+
+    def test_four_competitor_schedule_with_a_draw(self):
+        """A > B, A > C, B ~ C, C > D, D > A solves to (1/4, -3/8, 0, 1/8).
+
+        Games played: A three (B, C, D), B two (A, C), C three (A, B, D), D two (C, A),
+        so D = diag(3, 2, 3, 2). Every listed pair meets once and B never plays D:
+
+            M = D - A = [[ 3, -1, -1, -1],
+                         [-1,  2, -1,  0],
+                         [-1, -1,  3, -1],
+                         [-1,  0, -1,  2]]
+
+        Unit margins, with the draw contributing 0 to both sides but still counting as a
+        game played, give p = (+1, -1, 0, 0).  Replacing the last row with ones and the
+        last entry of p with 0 gives, with a + b + c + d = 0:
+
+            row 1:  3a - b - c - d = 1  ->  3a + a = 4a = 1        ->  a =  1/4
+            row 3: -a - b + 3c - d = 0  -> -a - b + 3c + a + b + c
+                                        =  4c = 0                 ->  c =  0
+            row 2:   -a + 2b - c   = -1 ->  -1/4 + 2b = -1         ->  b = -3/8
+            zero mean:                                               d =  1/8
+        """
+        a, b, c, d = (MasseyCompetitor() for _ in range(4))
+        a.beat(b)
+        a.beat(c)
+        b.tied(c)
+        c.beat(d)
+        d.beat(a)
+
+        self.assertAlmostEqual(a.rating, 0.25, places=9)
+        self.assertAlmostEqual(b.rating, -0.375, places=9)
+        self.assertAlmostEqual(c.rating, 0.0, places=9)
+        self.assertAlmostEqual(d.rating, 0.125, places=9)
+
+    def test_a_draw_counts_as_a_game_played(self):
+        """A > B, A ~ C solves to (1/3, -2/3, 1/3).
+
+        This is the case that pins the draw semantics: a draw adds nothing to either
+        cumulative margin but still counts as a game played, so it appears in D and A but
+        not in p.  Games played: A two, B one, C one; A meets each of B and C once:
+
+            M = D - A = [[ 2, -1, -1],
+                         [-1,  1,  0],
+                         [-1,  0,  1]]
+
+        and p = (+1, -1, 0).  With a + b + c = 0:
+
+            row 1:  2a - b - c = 1  ->  2a + a = 3a = 1  ->  a =  1/3
+            row 2:      -a + b  = -1                     ->  b = -2/3
+            zero mean:                                      c =  1/3
+
+        Note C ends level with A rather than at zero: drawing the eventual leader is worth
+        more than beating nobody, which is exactly what the least-squares fit encodes.
+        """
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+        a.tied(c)
+
+        self.assertAlmostEqual(a.rating, 1.0 / 3.0, places=9)
+        self.assertAlmostEqual(b.rating, -2.0 / 3.0, places=9)
+        self.assertAlmostEqual(c.rating, 1.0 / 3.0, places=9)
+
+    def test_single_game_splits_the_unit_margin(self):
+        """One game between two competitors gives ratings of +1/2 and -1/2.
+
+        M = [[1, -1], [-1, 1]], p = (+1, -1).  The constraint row makes this
+        [[1, -1], [1, 1]] r = (1, 0), so a - b = 1 and a + b = 0, i.e. a = 1/2, b = -1/2.
+        """
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b)
+
+        self.assertAlmostEqual(a.rating, 0.5, places=9)
+        self.assertAlmostEqual(b.rating, -0.5, places=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -9,6 +9,7 @@ from elote import (
     BlendedCompetitor,
     ColleyMatrixCompetitor,
     BradleyTerryCompetitor,
+    MasseyCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -433,6 +434,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
         DWZCompetitor,
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
+        MasseyCompetitor,
     )
 
     # A lopsided run: long enough that a one-sided rating gap opens up, with


### PR DESCRIPTION
Closes #118

Adds `MasseyCompetitor`, the least-squares counterpart to the Colley Matrix method and the second of the two canonical linear-algebra sports rating systems. It follows the global-fit pattern already established by `elote/competitors/colley.py` and `elote/competitors/bradley_terry.py` — a match graph keyed by competitor objects (`__eq__`/`__hash__` on `_id`), a connected-component BFS, and a re-fit at the end of `beat`/`tied`. **No changes to `BaseCompetitor`.**

## The algorithm

The fit solves `M r = p`, where `M = D - A` (`D_ii` = games played by *i*, `A_ij` = games between *i* and *j*) and `p_i` is *i*'s cumulative margin. `M` is a graph Laplacian, so its rows sum to zero and it is singular by construction. The standard fix is applied: the last row of `M` is replaced with all ones and the last entry of `p` with zero, which adds the constraint `sum(r) == 0` and makes the solution unique on a connected schedule. Because the replaced equation is implied by the remaining ones (given that the margins sum to zero), the solution does not depend on which row is chosen.

**Unit margins.** `BaseCompetitor` exposes only `beat` / `lost_to` / `tied` and has no channel for a score differential, so this is unit-margin Massey: a win contributes `+1` to the winner's cumulative margin and `-1` to the loser's; a draw contributes `0` to both while still counting as a game played for each. This is stated in the class docstring and called out in an `.. important::` block on the docs page. Genuine margin-of-victory support is deliberately out of scope here.

**`_minimum_rating`** is overridden to `float("-inf")` — Massey ratings are zero mean and routinely negative, and the inherited default is 100. Note this PR does **not** simply declare the override: `_recalculate_ratings` writes each result through the `rating` property rather than assigning `_rating` directly (as Colley does), so the floor is genuinely enforced and the override is load-bearing. Reinstating the inherited floor of 100 fails 16 tests.

**`expected_score`** is a logistic on the rating difference with a class-configurable scale (`expected_score_scale`, default 2.0 — chosen so the widest plausible unit-margin gap maps to about the same probability as the widest gap under Colley's `1 / (1 + exp(-4 * diff))`). It is written in `tanh` form specifically so that the two argument orders sum to **exactly** 1.0 in floating point, and returns exactly 0.5 for two fresh competitors.

**Solver-noise canonicalization.** `np.linalg.solve`'s pivoting depends on row order, which is the order competitors were discovered in, so two runs over the same results can differ in the last few bits. Ratings are rounded to 13 decimal places (`_round_decimals`), which is what makes the fit order independent and makes mathematically identical records compare exactly equal. Colley's existing choice of 15 places is **not** sufficient here — measured over 400 random schedules it left 69 order-dependent results, while 13 places left 0 out of 293 and still keeps the zero-sum invariant inside 3.1e-13. I also tried re-centering after rounding; it makes things worse (1727/2853 mismatches), because `np.mean` over a permuted array of O(0.5) values carries its own ~1e-16 rounding error.

## Refit cost (requested in the issue)

Seeded `LambdaArena`, 50 competitors / 500 matchups, outcomes from a fixed latent strength, best of 3 runs on this machine:

| System | Wall clock |
|---|---|
| `EloCompetitor` | 0.001 s |
| `ColleyMatrixCompetitor` | 0.072 s |
| `MasseyCompetitor` | **0.062 s** |

Massey is marginally *faster* than Colley at this size (one `np.linalg.solve` per result either way), so no perf-budget test was added. Absolute numbers are machine-dependent; re-measure both sides before quoting.

## Notes for the reviewer

- **Continued play after a state restore may diverge.** Like Colley and Bradley-Terry, `_import_current_state` cannot rebuild the match graph from a serialized document, so it resets `_opponents` and preserves only the rating and aggregate counts. `MasseyCompetitor` is therefore added to `TestArenaStateRoundTrip.ALL_COMPETITORS` (leaderboard round trip) but **not** to `INCREMENTAL_COMPETITORS` (identical continued play), matching how the two existing global-fit systems are treated.
- **`class_vars` carries `-Infinity` through JSON.** `export_state()` reflects `_minimum_rating` into `class_vars`, and `json.dumps` renders `float("-inf")` as the non-standard `-Infinity` literal. Python's own `json.loads` round-trips it, and `class_vars` is exported-then-discarded on import, so the arena round trip is unaffected — but it is worth knowing if a non-Python consumer ever reads these documents.
- **`_fallback_rating_calculation` is defensive, not reachable.** The constrained system is non-singular for any connected component, so the `LinAlgError` branch mirrors Colley's structure without being reachable in normal play. It is unit-tested directly rather than left as untested dead code.
- Issue #16 (the 2025 Massey stub) was already closed as superseded, referencing #118, so no action was needed there.
- `elote/__init__.py` is non-conformant with `ruff format` on `master` already; that was left alone rather than absorbed into this PR. Only `ruff check` is a gate, and it passes. Every file this PR adds is `ruff format` clean.

## Verification

All commands run from the branch worktree with `env -u VIRTUAL_ENV`.

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` → **328 passed, 6 skipped**. Baseline on this branch point (measured via `git stash`) is 298 passed / 6 skipped, so this adds 30 tests. `tests/test_examples.py` is excluded because it fails wholesale in a fresh worktree for environmental reasons unrelated to any diff.
- `make lint` (`ruff check .`) → **All checks passed!**
- `uv run mypy --python-version 3.12 elote` → **Success: no issues found in 25 source files**.
- `python -m sphinx -b html docs/source` → **build succeeded**; `rating_systems/massey.html` renders. The new module's docstring warnings are the same `References:` / `Key characteristics:` bare-list pattern the existing competitor modules produce (massey 13, bradley_terry 11, colley 7, in a build with 425 pre-existing warnings).

### Mutation testing

The new tests are the substance of this PR, so each was checked against a mutation of the code it claims to guard. All ten were caught; the source was restored byte-identical afterwards and the control run re-confirmed green (56 passed over the four affected test files). `__pycache__` was cleared between every run so no result came from stale bytecode.

| # | Mutation | Result |
|---|---|---|
| — | control, unmutated | 56 passed |
| M1 | `_minimum_rating` override removed (back to the inherited 100) | 16 failed |
| M2 | zero-mean constraint right-hand side `0.0` → `1.0` | 9 failed |
| M3 | constraint row never installed (`M` left singular) | 8 failed |
| M4 | `D_ii` = wins instead of games played | 3 failed |
| M5 | draws excluded from games played | 2 failed |
| M6 | draw contributes a margin instead of zero | 2 failed |
| M7 | loser's margin sign flipped | 6 failed |
| M8 | solver-noise canonicalization removed | 1 failed |
| M9 | `expected_score` sign flipped | 2 failed |
| M10 | floor restored **and** the `rating` setter bypassed (the plausible wrong shape) | 3 failed |

Two findings from that pass are worth recording, because both started out as tests that guarded nothing:

- **The order-independence fixture was vacuous on the first attempt.** A hand-picked schedule passed with M8 (the canonicalization) removed — the solve happened to be exact for it. The fixture shipped here was instead *selected programmatically*: a search over 200k random 5-competitor schedules for one whose raw solver output genuinely differs between the two orderings while the canonicalized output agrees. It now fails on M8, and carries an assertion against silently degenerating into an all-zero schedule.
- **The four-competitor known-value fixture is insensitive to the draw-counts-in-`D` semantic.** Its DFS order happens to drop exactly the equation the mutation touches, so it passes on M5. `test_a_draw_counts_as_a_game_played` (`A > B`, `A ~ C` → `1/3, -2/3, 1/3`) was added specifically to pin that, and is what catches M5 alongside the `num_games` assertion.

All known values in `tests/test_MasseyCompetitor_known_values.py` are derived by hand from the linear system in each test's own docstring — the row reductions are written out — not captured from a run of the implementation.