### PR TITLE
Fix calibration outcome normalization

### DIFF
--- a/elote/arenas/base.py
+++ b/elote/arenas/base.py
@@ -671,11 +671,13 @@ class History:
         and prepares them for calibration curve plotting.
 
         Args:
-            n_bins (int): Number of bins to use for calibration curve.
+            n_bins (int): Retained for backward compatibility but unused. Binning is
+                performed by ``visualization.compute_calibration_data``.
 
         Returns:
             tuple: (y_true, y_prob) where:
-                - y_true: List of actual outcomes (1.0 for wins, 0.0 for losses)
+                - y_true: List of actual scores (1.0 for wins, 0.5 for draws,
+                  0.0 for losses)
                 - y_prob: List of predicted probabilities
         """
         # Extract predicted probabilities and actual outcomes
@@ -685,12 +687,12 @@ class History:
         logger.info("Extracting calibration data for %d bouts.", len(self.bouts))
 
         for bout in self.bouts:
-            if bout.predicted_outcome is None or bout.outcome is None:
+            label = bout._normalized_outcome()
+            if bout.predicted_outcome is None or label is None:
                 skipped_bouts += 1
                 continue
             y_prob.append(bout.predicted_outcome)
-            # Convert outcomes to binary format (1.0 for wins, 0.0 for losses/draws)
-            y_true.append(1.0 if bout.outcome == 1.0 else 0.0)
+            y_true.append({"a": 1.0, "draw": 0.5, "b": 0.0}[label])
 
         if skipped_bouts > 0:
             logger.warning("Skipped %d bouts while extracting calibration data due to missing values.", skipped_bouts)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,8 +1,11 @@
 import unittest
 import os
 import tempfile
+
 import matplotlib.pyplot as plt
 import numpy as np
+
+from elote import LambdaArena
 from elote.arenas.base import History, Bout
 from elote.visualization import (
     compute_calibration_data,
@@ -100,11 +103,58 @@ class TestCalibration(unittest.TestCase):
             self.assertEqual(len(y_true), len(history.bouts))
             self.assertEqual(len(y_prob), len(history.bouts))
 
-            # Check that y_true contains only 0s and 1s
-            self.assertTrue(all(y in [0.0, 1.0] for y in y_true))
+            # Check that y_true contains only valid outcome scores
+            self.assertTrue(all(y in [0.0, 0.5, 1.0] for y in y_true))
 
             # Check that y_prob contains values between 0 and 1
             self.assertTrue(all(0 <= p <= 1 for p in y_prob))
+
+    def test_arena_history_calibration_uses_string_outcomes(self):
+        """Test calibration for the string outcomes produced by a real arena."""
+        arena = LambdaArena(lambda a, b: a > b, base_competitor_kwargs={"initial_rating": 1500})
+
+        for _ in range(20):
+            for a in range(10):
+                for b in range(10):
+                    if a != b:
+                        arena.matchup(a, b)
+
+        y_true, _ = arena.history.get_calibration_data()
+        prob_true, prob_pred = compute_calibration_data(arena.history, n_bins=5)
+
+        self.assertGreater(sum(y_true), 0)
+        self.assertGreater(len(prob_true), 1)
+        self.assertTrue(
+            all(
+                current_true <= next_true for current_true, next_true in zip(prob_true[:-1], prob_true[1:], strict=True)
+            )
+        )
+        self.assertLess(prob_true[0], prob_true[-1])
+        self.assertTrue(
+            all(current_pred < next_pred for current_pred, next_pred in zip(prob_pred[:-1], prob_pred[1:], strict=True))
+        )
+
+    def test_draw_is_scored_as_half(self):
+        """Test that a draw contributes half a point to calibration."""
+        history = History()
+        history.add_bout(Bout("a", "b", 0.5, 0.5))
+
+        y_true, y_prob = history.get_calibration_data()
+
+        self.assertEqual(y_true, [0.5])
+        self.assertEqual(y_prob, [0.5])
+
+    def test_unrecognized_outcome_is_skipped(self):
+        """Test that outcomes which cannot be normalized are omitted."""
+        history = History()
+        history.add_bout(Bout("a", "b", 0.6, "???"))
+        history.add_bout(Bout("c", "d", 0.7, "win"))
+
+        y_true, y_prob = history.get_calibration_data()
+
+        self.assertEqual(y_true, [1.0])
+        self.assertEqual(y_prob, [0.7])
+        self.assertEqual(len(y_true), len(y_prob))
 
     def test_compute_calibration_data(self):
         """Test that compute_calibration_data returns the expected data format."""


### PR DESCRIPTION
Closes #117

## Summary

- normalize every calibration outcome through `Bout._normalized_outcome()`
- score wins, draws, and losses as 1.0, 0.5, and 0.0, and skip outcomes that cannot be normalized
- document that `n_bins` remains accepted for compatibility but binning is performed by `compute_calibration_data`
- add real-arena, draw, and invalid-outcome regressions

## Regression coverage

- The arena test fails if the raw `bout.outcome == 1.0` comparison is reinstated: real `LambdaArena.matchup()` string outcomes otherwise produce no positive labels.
- The draw test fails if strings are normalized but draws are still mapped to 0.0.
- The invalid-outcome test fails if an unrecognized outcome is emitted as a loss instead of skipped.

Each mutation was applied locally and the named test failed before the committed implementation was restored.

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q tests/test_calibration.py tests/test_visualization.py` — 13 passed
- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 301 passed, 6 skipped
- `make lint` — passed
- `env -u VIRTUAL_ENV uv run --extra dev ruff format --check elote/arenas/base.py tests/test_calibration.py` — passed after formatting the touched test file
