### PR TITLE
Add an optional score channel to the result API

### DIFF
--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -84,6 +84,15 @@ Massey Competitor
    :show-inheritance:
    :special-members: __init__
 
+Keener Competitor
+-----------------
+
+.. automodule:: elote.competitors.keener
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 Bradley-Terry Competitor
 -----------------------
 

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -49,6 +49,12 @@ Massey Competitor
 .. autoclass:: elote.competitors.massey.MasseyCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Keener Competitor
+-----------------
+
+.. autoclass:: elote.competitors.keener.KeenerCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
 Bradley-Terry Competitor
 ------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/dwz
    rating_systems/colley
    rating_systems/massey
+   rating_systems/keener
    rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -56,6 +56,38 @@ Elote also supports recording draws between competitors:
     print(f"Player 1 new rating: {player1.rating}")
     print(f"Player 2 new rating: {player2.rating}")
 
+Recording Scores
+---------------
+
+``beat``, ``lost_to`` and ``tied`` all take an optional ``scores`` keyword: the two
+competitors' scores **in the argument order of the call**, whichever of them won.
+
+.. code-block:: python
+
+    from elote import MasseyCompetitor
+
+    team_a, team_b = MasseyCompetitor(), MasseyCompetitor()
+
+    team_a.beat(team_b, scores=(35, 3))
+    # The same game from the loser's side -- the pair is not reordered:
+    # team_b.lost_to(team_a, scores=(3, 35))
+
+Through an arena, pass the pair in ``(a, b)`` order along with an explicit ``outcome``:
+
+.. code-block:: python
+
+    from elote import LambdaArena, MasseyCompetitor
+
+    arena = LambdaArena(lambda a, b: True, base_competitor=MasseyCompetitor)
+    arena.matchup("Team A", "Team B", outcome=1.0, scores=(35, 3))
+    arena.matchup("Team A", "Team C", outcome=0.0, scores=(7, 24))   # C won; order unchanged
+
+Scores must be non-negative, finite, and consistent with the result being recorded --
+anything else raises ``ValueError`` before any rating or history changes. Rating systems
+that model margin of victory (currently :doc:`Massey <rating_systems/massey>`) consume the
+payload; the rest validate and ignore it. Omitting ``scores`` leaves every system on its
+existing unit-score behaviour, so the argument is fully backward compatible.
+
 Using Different Rating Systems
 ----------------------------
 

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -64,6 +64,12 @@ Overview Comparison
      - No
      - Yes
      - Margin-scale sports ranking
+   * - **Keener**
+     - Sports (1993)
+     - Medium
+     - No
+     - Yes
+     - Score-based eigenvector ranking
    * - **Bradley-Terry**
      - Statistics (1952)
      - Medium
@@ -78,8 +84,10 @@ Overview Comparison
      - Complex domains
 
 Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ) update ratings incrementally after each
-result. Global-fit systems (Colley Matrix, Massey and Bradley-Terry) re-solve the whole connected
-group of competitors from the full set of results, which makes them order independent.
+result. Global-fit systems (Colley Matrix, Massey, Keener and Bradley-Terry) re-solve the whole
+connected group of competitors from the full set of results, which makes them order independent.
+Massey and Keener are the two that read the optional score payload; the rest use only who beat
+whom.
 
 Mathematical Formulation
 -----------------------
@@ -106,6 +114,8 @@ Mathematical Formulation
      - Ratings solve :math:`C r = b`; :math:`E_A = \frac{1}{1 + e^{-4 (r_A - r_B)}}`
    * - **Massey**
      - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B)}}`
+   * - **Keener**
+     - Ratings are the dominant eigenvector of :math:`H_{ij} = h(a_{ij}) / g_i + \varepsilon` with :math:`a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}` and :math:`h(x) = \frac{1}{2} + \frac{1}{2}\mathrm{sgn}(x - \frac{1}{2})\sqrt{|2x - 1|}`; :math:`E_A = \frac{r_A}{r_A + r_B}`
    * - **Bradley-Terry**
      - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
    * - **Ensemble**
@@ -136,6 +146,8 @@ Key Parameters
      - Initial rating (default 0.5)
    * - **Massey**
      - Initial rating (default 0.0), Expected-score scale
+   * - **Keener**
+     - Initial rating (default 1.0), Perturbation, Expected-score scale
    * - **Bradley-Terry**
      - Initial rating, Scale, Regularization, Max iterations
    * - **Ensemble**
@@ -265,6 +277,22 @@ Massey
 - Ratings are zero mean, so about half of them are negative
 - Requires a connected schedule to compare competitors
 
+Keener
+^^^^^^
+
+**Strengths:**
+- Reads real scores through a bounded, concave transform, so blowouts inform without dominating
+- Order independent: depends only on the set of results
+- The eigenvector recursion values a win in proportion to the opponent's own rating
+- Perron-Frobenius guarantees a unique positive solution on any connected schedule
+- Ratings are strictly positive and average exactly 1.0
+
+**Weaknesses:**
+- Re-solves the whole connected group after each result
+- Much weaker on outcome-only data, where the unit-score fallback discards its main input
+- The stabilizing perturbation is an extra knob that quietly couples competitors who never met
+- Requires a connected schedule to compare competitors
+
 Bradley-Terry
 ^^^^^^^^^^^^^
 
@@ -312,7 +340,8 @@ Consider the following factors when choosing a rating system:
    - General purpose: Elo or Glicko
 
 3. **Order Independence**: Do you need a ranking that ignores schedule order?
-   - Yes: Colley Matrix, Massey, or Bradley-Terry
+   - Yes: Colley Matrix, Massey, Keener, or Bradley-Terry
+   - Yes, and you have real scores: Massey (linear margin) or Keener (bounded score share)
    - No: any online system (Elo, Glicko, etc.)
 
 4. **Computational Resources**:
@@ -343,6 +372,7 @@ Here's a quick comparison of how to use each system in Elote:
         DWZCompetitor,
         ColleyMatrixCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
         BradleyTerryCompetitor,
         BlendedCompetitor,
     )
@@ -371,6 +401,9 @@ Here's a quick comparison of how to use each system in Elote:
     # Massey (zero-mean margin scale)
     massey_player = MasseyCompetitor()
 
+    # Keener (strictly positive, mean 1.0; reads real scores)
+    keener_player = KeenerCompetitor()
+
     # Bradley-Terry (Elo-compatible scale)
     bt_player = BradleyTerryCompetitor(initial_rating=1500)
 
@@ -387,6 +420,10 @@ Here's a quick comparison of how to use each system in Elote:
     opponent = EloCompetitor(initial_rating=1400)
     print(f"Expected score: {player.expected_score(opponent):.2%}")
     player.beat(opponent)  # record a win
+
+    # Score-based systems additionally accept the optional scores payload
+    home, away = KeenerCompetitor(), KeenerCompetitor()
+    home.beat(away, scores=(35, 3))
 
 Empirical Comparison
 -------------------

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -254,13 +254,14 @@ Massey
 
 **Strengths:**
 - Order independent: depends only on the set of results
+- Consumes the optional ``scores`` payload, so real margins of victory are used when available
 - Rating differences are directly interpretable as predicted margins
 - Clean least-squares interpretation with a unique zero-mean solution
 - Self-normalizing: the ratings of a connected group sum to zero
 
 **Weaknesses:**
 - Re-solves the whole connected group after each result
-- Unit margins only: the uniform API carries no score differential
+- Needs real scores to be at its best; falls back to unit margins when they are omitted
 - Ratings are zero mean, so about half of them are negative
 - Requires a connected schedule to compare competitors
 

--- a/docs/source/rating_systems/keener.rst
+++ b/docs/source/rating_systems/keener.rst
@@ -1,0 +1,254 @@
+Keener Ratings
+==============
+
+Overview
+--------
+
+Keener's method, introduced by James Keener in 1993, is the score-based member of the classical
+global-fit family that also contains the :doc:`Colley Matrix Method <colley>`, :doc:`Massey
+<massey>` and :doc:`Bradley-Terry <bradley_terry>`. Where those three solve a linear system or
+maximize a likelihood, Keener builds a square **preference matrix** from the points competitors
+have scored on one another and reads the ratings off that matrix's dominant eigenvector.
+
+The eigenvector construction is what gives the method its character: a competitor's rating is
+proportional to a weighted average of its opponents' ratings, weighted by how strongly it
+outscored them. Beating a strong opponent is therefore worth more than beating a weak one, and
+the recursion resolves itself globally rather than through a chain of pairwise updates. Like the
+other global-fit systems, the whole connected group is re-solved after every recorded result, so
+the ratings depend only on the set of results and not on the order they arrived in.
+
+How It Works
+------------
+
+Let :math:`S_{ij}` be the total number of points competitor :math:`i` has scored against
+competitor :math:`j` across all their meetings, and :math:`g_i` the number of games :math:`i` has
+played.
+
+**1. Smoothed preference.** Raw score shares are unstable for lopsided or barely-played pairs --
+a single 3-0 result would read as total dominance -- so Keener applies Laplace smoothing:
+
+.. math::
+
+   a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}
+
+**2. Skew transform.** The smoothed share is pushed away from the middle by Keener's skew
+function
+
+.. math::
+
+   h(x) = \frac{1}{2} + \frac{1}{2}\,\mathrm{sgn}\!\left(x - \frac{1}{2}\right)
+          \sqrt{\left|2x - 1\right|}
+
+which is monotone, fixes :math:`0`, :math:`\tfrac{1}{2}` and :math:`1`, and satisfies
+:math:`h(x) + h(1 - x) = 1`, so the matrix stays antisymmetric about :math:`\tfrac{1}{2}`. The
+square root is the point: it damps the influence of very large margins, so running up the score
+has sharply diminishing returns.
+
+**3. Games-played normalization.** Row :math:`i` is divided by :math:`g_i`, making each entry an
+average preference *per game* so that a competitor cannot accumulate rating merely by playing
+more often. Pairs that never met contribute nothing to the row rather than the "no evidence"
+value :math:`h(\tfrac{1}{2}) = \tfrac{1}{2}`; on a sparse schedule those entries would otherwise
+outnumber the real ones and the fit would degenerate into a ranking by :math:`1/g_i`.
+
+**4. Stabilization.** A small positive constant :math:`\varepsilon` (Keener's :math:`\varepsilon
+E` perturbation, default ``1e-4``) is added to every entry:
+
+.. math::
+
+   H_{ij} = \frac{h(a_{ij})\,[\,i \text{ played } j\,]}{g_i} + \varepsilon
+
+This makes :math:`H` strictly positive, so by the Perron-Frobenius theorem its dominant
+eigenvalue is real and simple and the corresponding eigenvector is strictly positive and unique
+up to scale. Without it, a schedule whose match graph is bipartite or otherwise imprimitive has
+no single dominant eigenvector to read, and disconnected sub-groups would have no relation at
+all.
+
+The ratings of a connected group are then that dominant eigenvector, scaled so that they average
+exactly :math:`1.0`:
+
+.. math::
+
+   H\,r = \lambda_{\max}\,r, \qquad \frac{1}{n}\sum_i r_i = 1
+
+Because they are a positive strength scale rather than a probability scale, the expected score is
+the natural share
+
+.. math::
+
+   E_a = \frac{r_a}{r_a + r_b}
+
+computed internally as a logistic of the log rating ratio with a class-configurable scale
+(default 1.0, which is exactly the share above). Two equal ratings give exactly 0.5 and the two
+argument orders sum to exactly 1.0.
+
+Scores
+------
+
+Keener is a score-based method, so supplying real scores is what it is built for. ``beat`` /
+``lost_to`` / ``tied`` accept the common optional ``scores`` payload -- the two competitors'
+scores **in the argument order of the call**:
+
+.. code-block:: python
+
+    from elote import KeenerCompetitor
+
+    team_a, team_b = KeenerCompetitor(), KeenerCompetitor()
+
+    team_a.beat(team_b, scores=(35, 3))
+    # The same game from the loser's side -- the pair is not reordered:
+    # team_b.lost_to(team_a, scores=(3, 35))
+
+Through an arena the pair is always given in ``(a, b)`` order, whichever competitor won, together
+with an explicit ``outcome`` so the two can be checked for agreement:
+
+.. code-block:: python
+
+    from elote import LambdaArena, KeenerCompetitor
+
+    arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+    arena.matchup("Team A", "Team B", outcome=1.0, scores=(35, 3))
+    arena.matchup("Team A", "Team C", outcome=0.0, scores=(7, 24))   # C won; order unchanged
+
+.. note::
+
+   When ``scores`` is omitted, the same unit-score fallback the rest of the library uses applies:
+   the winner is credited ``1`` and the loser ``0``, and a draw credits each side ``0.5``. That
+   keeps Keener usable on outcome-only data and keeps it consistent with every other system, but
+   it discards exactly the information the method is built on -- on win/loss-only data, Colley or
+   Massey will generally be the better choice.
+
+Advantages
+----------
+
+- **Uses Scores**: the only shipped system that reads margin of victory through a nonlinear,
+  bounded transform, so large wins count for more without dominating.
+- **Order Independent**: the ratings depend only on the set of results, not the schedule order.
+- **Strength of Schedule**: the eigenvector recursion values a win in proportion to the opponent's
+  own rating.
+- **Well Grounded**: Perron-Frobenius guarantees a unique positive solution on any connected
+  schedule.
+- **Positive Scale**: ratings are strictly positive and average exactly 1.0, so a rating reads
+  directly as "this many times the population average".
+
+Limitations
+-----------
+
+- **Recomputes Globally**: like Colley, Massey and Bradley-Terry, each result re-solves the whole
+  connected group, which is more expensive than Elo's constant-time update for very large
+  populations.
+- **Weaker Without Scores**: the unit-score fallback keeps it usable on outcome-only data, but it
+  throws away the method's main input.
+- **Perturbation Is a Knob**: the ``eps`` that makes the matrix positive also quietly couples
+  competitors who never met; very small or very large values change the fit.
+- **Connectivity Needed**: groups of competitors that never play each other are rated
+  independently of one another.
+- **No Uncertainty**: like Colley, Massey and Bradley-Terry, the rating is a point estimate with
+  no confidence measure attached.
+
+Comparison with the Other Global-Fit Systems
+--------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+
+   * - System
+     - Uses scores
+     - Rating scale
+     - Fitted by
+   * - **Colley**
+     - No
+     - Bounded [0, 1], mean 0.5
+     - Solving a regularized linear system
+   * - **Massey**
+     - Yes (margin)
+     - Signed, zero mean
+     - Least squares on cumulative margins
+   * - **Bradley-Terry**
+     - No
+     - Elo-compatible
+     - Maximum likelihood over paired outcomes
+   * - **Keener**
+     - Yes (score share)
+     - Strictly positive, mean 1.0
+     - Dominant eigenvector of a preference matrix
+
+Keener and Massey are the two score-based systems, and they use scores very differently. Massey is
+**linear** in the margin: a 35-3 win contributes exactly 32, and a 70-6 win contributes exactly
+64, so a single blowout can move a rating a long way. Keener is **bounded and concave**: the score
+enters only as a share, and the square root in the skew transform means the difference between a
+comfortable win and a rout is small. If you want ratings whose differences read as predicted
+margins, use Massey; if you want scores to inform the ranking without letting one blowout
+dominate it, use Keener.
+
+Against Colley and Bradley-Terry, which see only who beat whom, Keener will usually separate
+evenly-matched records that those two must call equal -- but only when real scores are supplied.
+On outcome-only data Keener's unit-score fallback is strictly less informative than Colley's
+win-percentage model, because the skew transform compresses the single bit of information that is
+left.
+
+Implementation in Elote
+-----------------------
+
+Elote implements Keener Ratings through the ``KeenerCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import KeenerCompetitor
+
+    # Every competitor starts at 1.0, the mean the fitted ratings are normalized to
+    team_a = KeenerCompetitor()
+    team_b = KeenerCompetitor()
+    team_c = KeenerCompetitor()
+
+    # Get win probability
+    print(f"Team A win probability: {team_a.expected_score(team_b):.2%}")
+
+    # Record results; the whole connected group is re-solved after each one
+    team_a.beat(team_b, scores=(28, 7))
+    team_b.beat(team_c, scores=(14, 7))
+    team_a.beat(team_c, scores=(35, 3))
+
+    print(f"Team A: {team_a.rating:.4f}")   # 1.7379
+    print(f"Team B: {team_b.rating:.4f}")   # 0.8349
+    print(f"Team C: {team_c.rating:.4f}")   # 0.4272
+
+Parameters
+^^^^^^^^^^
+
+- ``initial_rating`` (constructor): the rating of a competitor that has not played yet.
+  Default ``1.0``, the mean the fitted ratings are normalized to, so an unplayed competitor sits
+  exactly at the population average. Must be strictly positive.
+
+Class-level parameters, set through ``KeenerCompetitor.configure_class(...)``:
+
+- ``perturbation``: Keener's :math:`\varepsilon`, added to every matrix entry. Default ``1e-4``.
+  Must be positive.
+- ``expected_score_scale``: the logistic scale applied to the log rating ratio by
+  ``expected_score``. Default ``1.0``, which is the plain Keener share; larger values sharpen
+  predictions. Must be positive.
+- ``round_decimals``: the number of decimal places fitted ratings are canonicalized to. Default
+  ``10``. The eigen-solve's row-order noise is around ``5e-15``, five orders of magnitude below
+  this grid, so canonicalizing here is what makes the fit exactly order independent.
+
+State and Serialization
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``export_state()`` records the fitted rating, the win/loss/tie counts, and the aggregate score
+totals ``points_for`` and ``points_against``.
+
+.. warning::
+
+   As with Colley, Massey and Bradley-Terry, the per-opponent match graph holds live object
+   references and cannot be serialized, so it is reset on import. A restored competitor keeps its
+   rating and score totals, but continued play re-fits it from the new results alone rather than
+   from the full history. To resume a population exactly, keep the original competitor objects
+   alive, or re-apply the recorded results to a fresh set.
+
+References
+----------
+
+1. Keener, J. P. (1993). "The Perron-Frobenius Theorem and the Ranking of Football Teams".
+   *SIAM Review*, 35(1), 80-93.
+2. Langville, A. N., & Meyer, C. D. (2012). *Who's #1? The Science of Rating and Ranking*,
+   chapter 4. Princeton University Press.

--- a/docs/source/rating_systems/massey.rst
+++ b/docs/source/rating_systems/massey.rst
@@ -48,20 +48,43 @@ competitors is a logistic function of their rating difference:
 
 with a class-configurable scale :math:`s` (default 2.0).
 
-Unit Margins
------------
+Margins
+-------
 
-.. important::
+``beat`` / ``lost_to`` / ``tied`` accept the common optional ``scores`` payload -- the two
+competitors' scores **in the argument order of the call**. When it is supplied, this is genuine
+margin-of-victory Massey, the form used in college-football rankings, where a 35-3 win counts for
+more than a 7-6 win: the margin a game contributes is ``self_score - competitor_score``.
 
-   Elote implements **unit-margin** Massey. The uniform ``BaseCompetitor`` API exposes only
-   ``beat`` / ``lost_to`` / ``tied`` and has no channel for a score differential, so a win
-   contributes ``+1`` to the winner's cumulative margin and ``-1`` to the loser's, and a draw
-   contributes ``0`` to both while still counting as a game played for each.
+.. code-block:: python
 
-Genuine margin-of-victory Massey -- the form used in college-football rankings, where a 35-3 win
-counts for more than a 7-6 win -- would require carrying a score through the result methods, and is
-not implemented. In practice, unit-margin Massey is a close relative of Colley on a signed scale:
-both use only who beat whom, and neither can be gamed by running up the score.
+    from elote import MasseyCompetitor
+
+    team_a, team_b = MasseyCompetitor(), MasseyCompetitor()
+
+    team_a.beat(team_b, scores=(35, 3))          # +32 for A, -32 for B
+    # The same game recorded from the loser's side -- scores stay in caller order:
+    # team_b.lost_to(team_a, scores=(3, 35))
+
+Through an arena the pair is always given in ``(a, b)`` order, whichever competitor won, together
+with an explicit ``outcome`` so the two can be checked for agreement:
+
+.. code-block:: python
+
+    from elote import LambdaArena, MasseyCompetitor
+
+    arena = LambdaArena(lambda a, b: True, base_competitor=MasseyCompetitor)
+    arena.matchup("Team A", "Team B", outcome=1.0, scores=(35, 3))
+    arena.matchup("Team A", "Team C", outcome=0.0, scores=(7, 24))   # C won, order unchanged
+
+When ``scores`` is omitted the implementation falls back to **unit margins**: a win contributes
+``+1`` to the winner's cumulative margin and ``-1`` to the loser's. A draw contributes ``0`` either
+way -- the payload for a draw must have two equal scores -- while still counting as a game played
+for both. Unit-margin Massey is a close relative of Colley on a signed scale: both use only who
+beat whom, and neither can be gamed by running up the score.
+
+Scores must be non-negative and finite, and must agree with the result being recorded; anything
+else raises ``ValueError`` before either competitor is touched.
 
 Advantages
 ---------
@@ -76,8 +99,9 @@ Limitations
 
 - **Recomputes Globally**: like Colley and Bradley-Terry, each result re-solves the whole connected
   group, which is more expensive than Elo's constant-time update for very large populations.
-- **Unit Margins Only**: see above; the margin channel the classical method uses is not available
-  through the uniform API.
+- **Scores Are Optional**: margin-of-victory Massey needs a score for every game. Where scores are
+  unavailable the fit falls back to unit margins, which discards exactly the information the
+  classical method is built on.
 - **Negative Ratings**: ratings are zero mean, which is unfamiliar next to a 1500-centered chess
   scale (``_minimum_rating`` is therefore ``-inf`` for this system).
 - **Connectivity Needed**: groups of competitors that never play each other cannot be compared, and

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -26,6 +26,7 @@ Available rating systems:
 - DWZ: The Deutsche Wertungszahl (German evaluation number) system
 - Colley Matrix: A least-squares rating system that solves a system of linear equations
 - Massey: A least-squares rating system whose ratings live on a signed margin scale
+- Keener: A score-based rating system built on the dominant eigenvector of a preference matrix
 - Bradley-Terry: A maximum-likelihood paired-comparison model
 - Ensemble: A meta-rating system that combines multiple rating systems
 
@@ -48,6 +49,7 @@ from elote.competitors.ecf import ECFCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
 from elote.competitors.massey import MasseyCompetitor
+from elote.competitors.keener import KeenerCompetitor
 from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
@@ -84,6 +86,7 @@ __all__ = [
     "DWZCompetitor",
     "ColleyMatrixCompetitor",
     "MasseyCompetitor",
+    "KeenerCompetitor",
     "BradleyTerryCompetitor",
     "BlendedCompetitor",
     # Arenas

--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type
 
 from tqdm import tqdm
 from elote import EloCompetitor
@@ -77,14 +77,17 @@ class LambdaArena(BaseArena):
         """
         setattr(self.base_competitor, name, value)
 
-    def tournament(self, matchups: List[Tuple[Any, Any]]) -> None:
+    def tournament(self, matchups: List[Tuple[Any, ...]]) -> None:
         """Run a tournament with the given matchups.
 
         Process multiple matchups between competitors, updating ratings
         after each matchup.
 
         Args:
-            matchups (list): A list of (competitor_a, competitor_b) tuples.
+            matchups (list): A list of tuples, each unpacked into :meth:`matchup`. The
+                first two entries are the competitors; further entries follow that
+                method's signature, so a tuple may carry
+                ``(a, b, attributes, match_time, outcome, scores)``.
         """
         for data in tqdm(matchups):
             self.matchup(*data)
@@ -96,6 +99,7 @@ class LambdaArena(BaseArena):
         attributes: Optional[Dict[str, Any]] = None,
         match_time: Optional[datetime.datetime] = None,
         outcome: Optional[float] = None,
+        scores: Optional[Sequence[float]] = None,
     ) -> None:
         """Process a single matchup between two competitors.
 
@@ -111,12 +115,24 @@ class LambdaArena(BaseArena):
             outcome (float, optional): A known result for this matchup, expressed from
                 a's perspective as ``1.0`` (a wins), ``0.0`` (b wins) or ``0.5`` (draw).
                 When supplied, the comparison function is not called.
+            scores (sequence of float, optional): The two scores as ``(a_score, b_score)`` --
+                always in the argument order of this call, regardless of who won. They are
+                forwarded to the competitors' result methods in whatever order those methods
+                require. Requires ``outcome`` to be supplied, since the scores must be checked
+                against a known result.
 
         Raises:
-            ValueError: If ``outcome`` is supplied and is not one of 1.0, 0.0 or 0.5.
+            ValueError: If ``outcome`` is supplied and is not one of 1.0, 0.0 or 0.5, if
+                ``scores`` is supplied without ``outcome``, or if ``scores`` is malformed,
+                negative, non-finite, or disagrees with ``outcome``.
         """
         if outcome is not None and outcome not in (1.0, 0.0, 0.5):
             raise ValueError(f"outcome must be one of 1.0, 0.0 or 0.5, got {outcome!r}")
+        if scores is not None and outcome is None:
+            raise ValueError("scores requires an explicit outcome so the two can be checked for agreement")
+        # Validated before any competitor is created or any history is recorded, so a bad
+        # score payload leaves the arena completely unchanged.
+        validated_scores = BaseCompetitor._validate_scores(scores, outcome) if outcome is not None else None
 
         if a not in self.competitors:
             self.competitors[a] = self.base_competitor(**self.base_competitor_kwargs)
@@ -141,26 +157,31 @@ class LambdaArena(BaseArena):
         # Check if the competitor supports time-based ratings
         supports_time = hasattr(self.competitors[a], "_last_activity")
 
+        # Scores are supplied in (a, b) order. The draw and a-wins branches call through
+        # competitor a, so they keep that order; the b-wins branch reverses the call, so the
+        # score pair has to be reversed with it.
+        reversed_scores = None if validated_scores is None else (validated_scores[1], validated_scores[0])
+
         if res is None:
             if supports_time:
                 # type: ignore[call-arg]
-                self.competitors[a].tied(self.competitors[b], match_time=match_time)
+                self.competitors[a].tied(self.competitors[b], match_time=match_time, scores=validated_scores)
             else:
-                self.competitors[a].tied(self.competitors[b])
+                self.competitors[a].tied(self.competitors[b], scores=validated_scores)
             self.history.add_bout(Bout(a, b, predicted_outcome, outcome="tie", attributes=attributes))
         elif res is True:
             if supports_time:
                 # type: ignore[call-arg]
-                self.competitors[a].beat(self.competitors[b], match_time=match_time)
+                self.competitors[a].beat(self.competitors[b], match_time=match_time, scores=validated_scores)
             else:
-                self.competitors[a].beat(self.competitors[b])
+                self.competitors[a].beat(self.competitors[b], scores=validated_scores)
             self.history.add_bout(Bout(a, b, predicted_outcome, outcome="win", attributes=attributes))
         else:
             if supports_time:
                 # type: ignore[call-arg]
-                self.competitors[b].beat(self.competitors[a], match_time=match_time)
+                self.competitors[b].beat(self.competitors[a], match_time=match_time, scores=reversed_scores)
             else:
-                self.competitors[b].beat(self.competitors[a])
+                self.competitors[b].beat(self.competitors[a], scores=reversed_scores)
             self.history.add_bout(Bout(a, b, predicted_outcome, outcome="loss", attributes=attributes))
 
     def expected_score(self, a: Any, b: Any) -> float:

--- a/elote/competitors/base.py
+++ b/elote/competitors/base.py
@@ -1,7 +1,8 @@
 import abc
 import json
+import math
 import uuid
-from typing import Dict, Any, TypeVar, Type, ClassVar, List, cast
+from typing import Dict, Any, Optional, Sequence, Tuple, TypeVar, Type, ClassVar, List, cast
 
 from elote.logging import logger
 
@@ -51,6 +52,56 @@ T = TypeVar("T", bound="BaseCompetitor")
 
 # Registry to store competitor types
 _competitor_registry: Dict[str, Type["BaseCompetitor"]] = {}
+
+
+def validate_scores(scores: Optional[Sequence[float]], outcome: float) -> Optional[Tuple[float, float]]:
+    """Validate an optional score payload against the outcome it is supposed to describe.
+
+    The score payload is always the two competitors' scores **in caller order**: for
+    ``a.beat(b, scores=(x, y))`` ``x`` is ``a``'s score and ``y`` is ``b``'s. The same
+    ordering holds for ``lost_to``, ``tied`` and :meth:`elote.LambdaArena.matchup`, so a
+    caller never has to reorder a score pair to match the method it is calling.
+
+    Args:
+        scores (sequence of float, optional): The two scores in caller order, or ``None``.
+        outcome (float): The declared result from the first score's perspective --
+            ``1.0`` (first competitor won), ``0.0`` (first competitor lost) or ``0.5`` (draw).
+
+    Returns:
+        tuple of float, or None: The validated scores as floats, or ``None`` when no score
+        payload was supplied.
+
+    Raises:
+        ValueError: If the payload is malformed, contains a negative or non-finite value, or
+            disagrees with the declared outcome.
+    """
+    if scores is None:
+        return None
+
+    if isinstance(scores, (str, bytes)) or not isinstance(scores, Sequence):
+        raise ValueError(f"scores must be a sequence of two numbers, got {scores!r}")
+    if len(scores) != 2:
+        raise ValueError(f"scores must contain exactly two values, got {len(scores)}")
+
+    validated: List[float] = []
+    for value in scores:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"scores must contain only numbers, got {value!r}")
+        if not math.isfinite(value):
+            raise ValueError(f"scores must be finite, got {value!r}")
+        if value < 0:
+            raise ValueError(f"scores must be non-negative, got {value!r}")
+        validated.append(float(value))
+
+    first, second = validated
+    if outcome == 1.0 and not first > second:
+        raise ValueError(f"scores {tuple(validated)} do not describe a win for the first competitor")
+    if outcome == 0.0 and not first < second:
+        raise ValueError(f"scores {tuple(validated)} do not describe a loss for the first competitor")
+    if outcome == 0.5 and first != second:
+        raise ValueError(f"scores {tuple(validated)} do not describe a draw")
+
+    return first, second
 
 
 class BaseCompetitor(abc.ABC):
@@ -154,8 +205,10 @@ class BaseCompetitor(abc.ABC):
         """
         pass
 
+    _validate_scores = staticmethod(validate_scores)
+
     @abc.abstractmethod
-    def beat(self, competitor: "BaseCompetitor") -> None:
+    def beat(self, competitor: "BaseCompetitor", *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -163,29 +216,42 @@ class BaseCompetitor(abc.ABC):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two non-negative, finite scores in
+                caller order -- ``(self_score, competitor_score)``. Rating systems that model
+                margin of victory (such as :class:`~elote.competitors.massey.MasseyCompetitor`)
+                consume it; the rest validate and ignore it. When omitted, every system falls
+                back to its documented unit-score behaviour.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` is malformed, negative, non-finite, or does not describe
+                a win for this competitor.
         """
         pass
 
-    def lost_to(self, competitor: "BaseCompetitor") -> None:
+    def lost_to(self, competitor: "BaseCompetitor", *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has lost to the given competitor.
 
         This is a convenience method that calls beat() on the winning competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order --
+                ``(self_score, competitor_score)``. They are reversed before being handed to
+                the winner's :meth:`beat`, so the caller never reorders them.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` is malformed, negative, non-finite, or does not describe
+                a loss for this competitor.
         """
         logger.debug("Competitor %s lost to %s. Calling beat() on winner.", self, competitor)
         self.verify_competitor_types(competitor)
-        competitor.beat(self)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
 
     @abc.abstractmethod
-    def tied(self, competitor: "BaseCompetitor") -> None:
+    def tied(self, competitor: "BaseCompetitor", *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -193,9 +259,13 @@ class BaseCompetitor(abc.ABC):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order --
+                ``(self_score, competitor_score)``. They must be equal, since the result is
+                declared a draw.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` is malformed, negative, non-finite, or is not a draw.
         """
         pass
 

--- a/elote/competitors/bradley_terry.py
+++ b/elote/competitors/bradley_terry.py
@@ -24,7 +24,7 @@ References:
 """
 
 import math
-from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
+from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set, Sequence
 
 import numpy as np
 
@@ -136,7 +136,7 @@ class BradleyTerryCompetitor(BaseCompetitor):
         other = cast(BradleyTerryCompetitor, competitor)
         return 1.0 / (1.0 + math.exp(-(self._beta - other._beta)))
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         The result is recorded on both competitors and the strengths of the entire connected
@@ -144,12 +144,16 @@ class BradleyTerryCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s beat %s", self, competitor)
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         opponent = cast(BradleyTerryCompetitor, competitor)
 
         self._wins += 1
@@ -163,19 +167,23 @@ class BradleyTerryCompetitor(BaseCompetitor):
         logger.debug("Recorded win for %d, loss for %d", self._id, opponent._id)
         self._recalculate_ratings()
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         A tie is counted as half a win for each side.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s tied with %s", self, competitor)
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         opponent = cast(BradleyTerryCompetitor, competitor)
 
         self._ties += 1
@@ -189,18 +197,22 @@ class BradleyTerryCompetitor(BaseCompetitor):
         logger.debug("Recorded tie for %d and %d", self._id, opponent._id)
         self._recalculate_ratings()
 
-    def lost_to(self, competitor: BaseCompetitor) -> None:
+    def lost_to(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has lost to the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Reversed before being passed to the
+                winner's :meth:`beat`.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s lost to %s", self, competitor)
         self.verify_competitor_types(competitor)
-        competitor.beat(self)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
 
     def _get_connected_competitors(self) -> List["BradleyTerryCompetitor"]:
         """Get all competitors connected to this competitor in the match graph.

--- a/elote/competitors/colley.py
+++ b/elote/competitors/colley.py
@@ -11,7 +11,7 @@ References:
 """
 
 import numpy as np
-from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
+from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set, Sequence
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException
 import datetime
 
@@ -115,7 +115,7 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         rating_diff = self.rating - competitor.rating
         return float(1 / (1 + np.exp(-4 * rating_diff)))
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         In Colley Matrix Method, we store the match result and recalculate ratings for all
@@ -123,12 +123,16 @@ class ColleyMatrixCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s beat %s", self, competitor)
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         competitor_colley = cast(ColleyMatrixCompetitor, competitor)
 
         # Record the win for this competitor
@@ -147,17 +151,21 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         # Recalculate ratings for all connected competitors
         self._recalculate_ratings()
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s tied with %s", self, competitor)
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         competitor_colley = cast(ColleyMatrixCompetitor, competitor)
 
         # Record the tie for this competitor
@@ -173,17 +181,21 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         # Recalculate ratings for all connected competitors
         self._recalculate_ratings()
 
-    def lost_to(self, competitor: BaseCompetitor) -> None:
+    def lost_to(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has lost to the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Reversed before being passed to the
+                winner's :meth:`beat`.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s lost to %s", self, competitor)
-        competitor.beat(self)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
 
     def _get_connected_competitors(self) -> List["ColleyMatrixCompetitor"]:
         """Get all competitors connected to this competitor in the match graph.

--- a/elote/competitors/dwz.py
+++ b/elote/competitors/dwz.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Any, ClassVar, Optional, Type, TypeVar, cast
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, cast
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
 from elote.logging import logger  # Import directly from the logging submodule
@@ -325,11 +325,16 @@ class DWZCompetitor(BaseCompetitor):
         logger.debug("New rating calculated: %.1f (Clamped: %.1f)", new_rating, new_rating_clamped)
         return new_rating_clamped
 
-    def beat(self, competitor: BaseCompetitor, age: Optional[int] = None) -> None:
+    def beat(
+        self, competitor: BaseCompetitor, age: Optional[int] = None, *, scores: Optional[Sequence[float]] = None
+    ) -> None:
         """Update ratings after this competitor wins against another.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
             age (Optional[int]): The age of this competitor at the time of the match.
                                  Used for DWZ calculation. Defaults to 26 (adult).
 
@@ -337,6 +342,7 @@ class DWZCompetitor(BaseCompetitor):
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         competitor_dwz = cast(DWZCompetitor, competitor)
         logger.debug("%s beat %s (age=%s)", self, competitor_dwz, age)
 
@@ -350,11 +356,16 @@ class DWZCompetitor(BaseCompetitor):
         self._count += 1
         competitor_dwz._count += 1
 
-    def tied(self, competitor: BaseCompetitor, age: Optional[int] = None) -> None:
+    def tied(
+        self, competitor: BaseCompetitor, age: Optional[int] = None, *, scores: Optional[Sequence[float]] = None
+    ) -> None:
         """Update ratings after this competitor ties with another.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
             age (Optional[int]): The age of this competitor at the time of the match.
                                  Used for DWZ calculation. Defaults to 26 (adult).
 
@@ -362,6 +373,7 @@ class DWZCompetitor(BaseCompetitor):
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         competitor_dwz = cast(DWZCompetitor, competitor)
         logger.debug("%s tied with %s (age=%s)", self, competitor_dwz, age)
 

--- a/elote/competitors/ecf.py
+++ b/elote/competitors/ecf.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, ClassVar, Optional, Type, TypeVar, cast, Deque
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, cast, Deque
 from collections import deque
 import statistics
 
@@ -338,7 +338,7 @@ class ECFCompetitor(BaseCompetitor):
     def _clamp_opponent_rating(self, own_rating: float, opponent_rating: float) -> float:
         return max(own_rating - self._delta, min(own_rating + self._delta, opponent_rating))
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -346,11 +346,15 @@ class ECFCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         competitor_ecf = cast(ECFCompetitor, competitor)
         logger.debug("%s beat %s", self, competitor_ecf)
 
@@ -371,7 +375,7 @@ class ECFCompetitor(BaseCompetitor):
         self._update(performance_rating_self)
         competitor_ecf._update(performance_rating_competitor)
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -379,11 +383,15 @@ class ECFCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         competitor_ecf = cast(ECFCompetitor, competitor)
         logger.debug("%s tied with %s", self, competitor_ecf)
 

--- a/elote/competitors/elo.py
+++ b/elote/competitors/elo.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, ClassVar, Optional, Type, TypeVar, cast
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, cast
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
 from elote.logging import logger  # Import directly from the logging submodule
@@ -267,7 +267,7 @@ class EloCompetitor(BaseCompetitor):
         self.verify_competitor_types(competitor)
         return float(self.transformed_rating / (self.transformed_rating + competitor.transformed_rating))
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -275,11 +275,15 @@ class EloCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         competitor_elo = cast(EloCompetitor, competitor)
         logger.debug("%s beat %s", self, competitor_elo)
 
@@ -292,7 +296,7 @@ class EloCompetitor(BaseCompetitor):
         self.rating = my_new_rating
         competitor_elo.rating = opponent_new_rating
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -300,11 +304,15 @@ class EloCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         competitor_elo = cast(EloCompetitor, competitor)
         logger.debug("%s tied with %s", self, competitor_elo)
 

--- a/elote/competitors/ensemble.py
+++ b/elote/competitors/ensemble.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Type, TypeVar
+from typing import Dict, Any, List, Optional, Sequence, Type, TypeVar
 
 from elote.competitors.base import (
     BaseCompetitor,
@@ -361,38 +361,46 @@ class BlendedCompetitor(BaseCompetitor):
             logger.error("Unsupported blend mode used in expected_score: %s", self.blend_mode)
             raise NotImplementedError(f"Blend mode {self.blend_mode} not supported")
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method updates the ratings of all sub-competitors based on the match outcome.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Forwarded unchanged to every
+                sub-competitor.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 1.0)
         logger.debug("%s beat %s. Updating %d sub-competitors.", self, competitor, len(self.sub_competitors))
 
         for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=True):
             logger.debug("Updating sub-competitors via beat: %s vs %s", c, other_c)
-            c.beat(other_c)
+            c.beat(other_c, scores=validated)
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method updates the ratings of all sub-competitors based on the drawn match outcome.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Forwarded unchanged
+                to every sub-competitor.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.5)
         logger.debug("%s tied with %s. Updating %d sub-competitors.", self, competitor, len(self.sub_competitors))
 
         for c, other_c in zip(self.sub_competitors, competitor.sub_competitors, strict=True):
             logger.debug("Updating sub-competitors via tied: %s vs %s", c, other_c)
-            c.tied(other_c)  # Fixed: was using beat() instead of tied()
+            c.tied(other_c, scores=validated)  # Fixed: was using beat() instead of tied()

--- a/elote/competitors/glicko.py
+++ b/elote/competitors/glicko.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Any, ClassVar, Tuple, Type, TypeVar, Optional
+from typing import Dict, Any, ClassVar, Sequence, Tuple, Type, TypeVar, Optional
 from datetime import datetime
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
@@ -307,7 +307,13 @@ class GlickoCompetitor(BaseCompetitor):
         E = 1 / (1 + 10 ** ((-1 * g_term * (self._rating - competitor.rating)) / 400))
         return E
 
-    def beat(self, competitor: "GlickoCompetitor", match_time: Optional[datetime] = None) -> None:
+    def beat(
+        self,
+        competitor: "GlickoCompetitor",
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -315,16 +321,26 @@ class GlickoCompetitor(BaseCompetitor):
 
         Args:
             competitor (GlickoCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
             match_time (datetime, optional): The time when the match occurred. Default: current time.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         logger.debug("%s beat %s (time=%s)", self, competitor, match_time)
         self._compute_match_result(competitor, s=1, match_time=match_time)
 
-    def tied(self, competitor: "GlickoCompetitor", match_time: Optional[datetime] = None) -> None:
+    def tied(
+        self,
+        competitor: "GlickoCompetitor",
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method updates the ratings of both this competitor and the opponent
@@ -332,12 +348,16 @@ class GlickoCompetitor(BaseCompetitor):
 
         Args:
             competitor (GlickoCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
             match_time (datetime, optional): The time when the match occurred. Default: current time.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         logger.debug("%s tied with %s (time=%s)", self, competitor, match_time)
         self._compute_match_result(competitor, s=0.5, match_time=match_time)
 

--- a/elote/competitors/glicko2.py
+++ b/elote/competitors/glicko2.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Any, ClassVar, NamedTuple, Type, TypeVar, Optional, List, cast
+from typing import Dict, Any, ClassVar, NamedTuple, Sequence, Type, TypeVar, Optional, List, cast
 from datetime import datetime
 
 from elote.competitors.base import BaseCompetitor, InvalidRatingValueException, InvalidParameterException
@@ -658,7 +658,13 @@ class Glicko2Competitor(BaseCompetitor):
             self._sigma,
         )
 
-    def beat(self, competitor: BaseCompetitor, match_time: Optional[datetime] = None) -> None:
+    def beat(
+        self,
+        competitor: BaseCompetitor,
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         This method records the match result for later processing during the rating period update.
@@ -666,6 +672,9 @@ class Glicko2Competitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
             match_time (datetime, optional): The time when the match occurred. Default: current time.
 
         Raises:
@@ -673,10 +682,17 @@ class Glicko2Competitor(BaseCompetitor):
             InvalidParameterException: If the match time is before either competitor's last activity.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         logger.debug("%s beat %s (time=%s). Recording result.", self, competitor, match_time)
         self._compute_match_result(cast(Glicko2Competitor, competitor), s=1.0, match_time=match_time)
 
-    def tied(self, competitor: BaseCompetitor, match_time: Optional[datetime] = None) -> None:
+    def tied(
+        self,
+        competitor: BaseCompetitor,
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         This method records the match result for later processing during the rating period update.
@@ -684,6 +700,9 @@ class Glicko2Competitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
             match_time (datetime, optional): The time when the match occurred. Default: current time.
 
         Raises:
@@ -691,6 +710,7 @@ class Glicko2Competitor(BaseCompetitor):
             InvalidParameterException: If the match time is before either competitor's last activity.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         logger.debug("%s tied with %s (time=%s). Recording result.", self, competitor, match_time)
         self._compute_match_result(cast(Glicko2Competitor, competitor), s=0.5, match_time=match_time)
 

--- a/elote/competitors/keener.py
+++ b/elote/competitors/keener.py
@@ -1,0 +1,542 @@
+"""Keener Ratings implementation for the Elote library.
+
+Keener's method is the score-based member of the classical global-fit family. Where
+:class:`~elote.competitors.colley.ColleyMatrixCompetitor` and
+:class:`~elote.competitors.massey.MasseyCompetitor` solve a linear system, Keener builds a
+square *preference matrix* from the points competitors have scored on one another and reads
+the ratings off that matrix's dominant eigenvector.
+
+The construction has four steps. Let ``S_ij`` be the total number of points ``i`` has scored
+against ``j`` across all their meetings.
+
+1. **Smoothed preference.** Raw score shares are unstable for lopsided or barely-played
+   pairs, so Keener applies Laplace smoothing:
+
+   .. math::
+
+      a_{ij} = \\frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}
+
+   A pair that has never met gives ``a_ij = 1/2`` -- no evidence either way.
+
+2. **Skew transform.** ``a_ij`` is pushed away from the middle by Keener's skew function
+
+   .. math::
+
+      h(x) = \\frac{1}{2} + \\frac{1}{2}\\,\\mathrm{sgn}\\!\\left(x - \\frac{1}{2}\\right)
+             \\sqrt{\\left|2x - 1\\right|}
+
+   which is monotone, fixes ``0``, ``1/2`` and ``1``, and satisfies ``h(x) + h(1 - x) = 1``,
+   so the matrix stays antisymmetric about ``1/2``. Its square root damps the influence of
+   very large margins, which is what stops the method rewarding running up the score without
+   limit.
+
+3. **Games-played normalization.** Row ``i`` is divided by the number of games ``i`` played,
+   so a competitor cannot accumulate rating merely by playing more often.
+
+4. **Stabilization.** A small positive constant is added to every entry. Keener's own
+   ``A + eps * E`` perturbation makes the matrix strictly positive, so Perron-Frobenius
+   applies: the dominant eigenvalue is real and simple and its eigenvector is strictly
+   positive and unique up to scale. Without it a schedule whose graph is bipartite or
+   otherwise imprimitive has no single dominant eigenvector to read.
+
+The ratings of a connected group are then that dominant eigenvector, scaled so they average
+exactly ``1.0``.
+
+References:
+- Keener, J. P. (1993). The Perron-Frobenius Theorem and the Ranking of Football Teams.
+  SIAM Review, 35(1), 80-93.
+- Langville, A. N., & Meyer, C. D. (2012). Who's #1? The Science of Rating and Ranking.
+  Princeton University Press, chapter 4.
+"""
+
+import math
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, List, cast, Set
+
+import numpy as np
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException, InvalidRatingValueException
+from elote.logging import logger
+
+T = TypeVar("T", bound="KeenerCompetitor")
+
+
+class KeenerCompetitor(BaseCompetitor):
+    """Keener Ratings competitor.
+
+    Keener rates a connected population from the dominant eigenvector of a pairwise
+    preference matrix built from points scored. Like Colley, Massey and Bradley-Terry -- and
+    unlike Elo -- ratings are not nudged after each result; the whole connected group is
+    re-fit from the complete match history, which makes the method order independent.
+
+    **Scores.** ``beat`` / ``lost_to`` / ``tied`` accept the common optional ``scores``
+    payload, the two competitors' scores in caller order. Keener is a score-based method, so
+    supplying real scores is what it is built for. When they are omitted the implementation
+    falls back to the same unit scores the rest of the library uses: the winner is credited
+    ``1`` and the loser ``0``, and a draw credits each side ``0.5``. Unit-score Keener still
+    produces a sensible ranking, but it only sees who beat whom.
+
+    Key characteristics:
+    - Global eigenvector fit (does not depend on the order of results)
+    - Ratings are strictly positive and average exactly 1.0 within a connected group
+    - Large margins have a damped, not linear, influence thanks to the skew transform
+
+    Class Attributes:
+        _minimum_rating (float): The minimum allowed rating value. Default: 0.0. Keener
+            ratings are strictly positive, so no Elo-style floor applies.
+        _default_initial_rating (float): Default initial rating. Default: 1.0, which is the
+            mean the fitted ratings are normalized to, so an unplayed competitor sits exactly
+            at the population average.
+        _perturbation (float): Keener's ``eps``, added to every matrix entry so the matrix is
+            strictly positive and Perron-Frobenius applies. Default: 1e-4.
+        _expected_score_scale (float): Logistic scale applied to the log rating ratio by
+            :meth:`expected_score`. Default: 1.0, which is the plain Keener share
+            ``r_a / (r_a + r_b)``.
+        _round_decimals (int): Number of decimal places fitted ratings are canonicalized to,
+            so that solver noise cannot make mathematically identical records differ.
+            Default: 10, chosen because the eigen-solve's row-order noise is around 5e-15 --
+            five orders of magnitude below the rounding grid.
+    """
+
+    _minimum_rating: ClassVar[float] = 0.0
+    _default_initial_rating: ClassVar[float] = 1.0
+    _perturbation: ClassVar[float] = 1e-4
+    _expected_score_scale: ClassVar[float] = 1.0
+    _round_decimals: ClassVar[int] = 10
+
+    # Ratings are strictly positive by construction; this only guards expected_score against
+    # a rating a caller has explicitly set to zero.
+    _probability_floor: ClassVar[float] = 1e-300
+
+    def __init__(self, initial_rating: Optional[float] = None):
+        """Initialize a new Keener competitor.
+
+        Args:
+            initial_rating (float, optional): The initial rating of this competitor.
+                Default: 1.0.
+
+        Raises:
+            InvalidRatingValueException: If the initial rating is not positive.
+        """
+        super().__init__()
+
+        self._initial_rating = initial_rating if initial_rating is not None else self._default_initial_rating
+        if self._initial_rating <= 0:
+            raise InvalidRatingValueException("Keener ratings are strictly positive; initial_rating must be > 0")
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        # Aggregate score totals across every game played. These are the serializable
+        # summary of the score history; the per-opponent breakdown below is not.
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._opponents: Dict["KeenerCompetitor", int] = {}  # Opponent -> num games
+        # Opponent -> total points this competitor has scored against that opponent. This is
+        # the S_ij the preference matrix is built from.
+        self._scores_for: Dict["KeenerCompetitor", float] = {}
+        # Unique ID for hashing (instances are used as dict keys in the match graph).
+        self._id = id(self)
+        logger.debug("Initialized KeenerCompetitor %d with initial rating %.6f", self._id, self._initial_rating)
+
+    @property
+    def rating(self) -> float:
+        """Get the current rating of this competitor.
+
+        Returns:
+            float: The current rating.
+        """
+        return self._rating
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        """Set the current rating of this competitor.
+
+        Args:
+            value (float): The new rating value.
+
+        Raises:
+            InvalidRatingValueException: If the rating value is below the minimum rating.
+        """
+        if value < self._minimum_rating:
+            logger.warning(
+                "Attempted to set rating %.6f below minimum %.6f for %d", value, self._minimum_rating, self._id
+            )
+            raise InvalidRatingValueException(f"Rating cannot be below the minimum rating of {self._minimum_rating}")
+        self._rating = value
+
+    @property
+    def num_games(self) -> int:
+        """Get the total number of games played by this competitor.
+
+        Returns:
+            int: The total number of games played.
+        """
+        return self._wins + self._losses + self._ties
+
+    def expected_score(self, competitor: "BaseCompetitor") -> float:
+        """Calculate the expected score against another competitor.
+
+        Keener ratings are positive strengths rather than probabilities, so the natural
+        mapping is the share ``r_self / (r_self + r_competitor)``. That share is computed
+        here as a logistic of the log rating ratio, which is the same quantity written in a
+        form that is exactly complementary in floating point: two equal ratings give exactly
+        0.5, and the two argument orders sum to exactly 1.0.
+
+        Args:
+            competitor (BaseCompetitor): The competitor to compare against.
+
+        Returns:
+            float: The expected score (probability of winning).
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        mine = max(self.rating, self._probability_floor)
+        theirs = max(competitor.rating, self._probability_floor)
+        log_ratio = math.log(mine) - math.log(theirs)
+        return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * log_ratio)))
+
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has won against the given competitor.
+
+        The scores are recorded in the match graph and the whole connected group is re-fit.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. When omitted the unit scores ``1`` and
+                ``0`` are recorded.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a win for this competitor.
+        """
+        logger.debug("Competitor %s beat %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 1.0)
+        opponent = cast(KeenerCompetitor, competitor)
+        mine, theirs = (1.0, 0.0) if validated is None else validated
+
+        self._wins += 1
+        opponent._losses += 1
+        self._record_game(opponent, mine, theirs)
+
+        logger.debug("Recorded win for %d (%.3f-%.3f), loss for %d", self._id, mine, theirs, opponent._id)
+        self._recalculate_ratings()
+
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has tied with the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They must be equal. When omitted each
+                side is credited the unit draw score ``0.5``.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a draw.
+        """
+        logger.debug("Competitor %s tied with %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.5)
+        opponent = cast(KeenerCompetitor, competitor)
+        mine, theirs = (0.5, 0.5) if validated is None else validated
+
+        self._ties += 1
+        opponent._ties += 1
+        self._record_game(opponent, mine, theirs)
+
+        logger.debug("Recorded tie for %d and %d (%.3f-%.3f)", self._id, opponent._id, mine, theirs)
+        self._recalculate_ratings()
+
+    def lost_to(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Reversed before being passed to the
+                winner's :meth:`beat`.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a loss for this competitor.
+        """
+        logger.debug("Competitor %s lost to %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
+
+    def _record_game(self, opponent: "KeenerCompetitor", mine: float, theirs: float) -> None:
+        """Record one game's scores on both sides of the match graph.
+
+        Args:
+            opponent: The other competitor in the game.
+            mine: The points this competitor scored.
+            theirs: The points the opponent scored.
+        """
+        self._points_for += mine
+        self._points_against += theirs
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._scores_for[opponent] = self._scores_for.get(opponent, 0.0) + mine
+
+        opponent._points_for += theirs
+        opponent._points_against += mine
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._scores_for[self] = opponent._scores_for.get(self, 0.0) + theirs
+
+    def _get_connected_competitors(self) -> List["KeenerCompetitor"]:
+        """Get all competitors connected to this competitor in the match graph.
+
+        Returns:
+            List[KeenerCompetitor]: A list of all connected competitors.
+        """
+        visited: Set["KeenerCompetitor"] = set()
+        to_visit: List["KeenerCompetitor"] = [self]
+        all_competitors = []
+
+        while to_visit:
+            current = to_visit.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            all_competitors.append(current)
+            for opponent in current._opponents:
+                if opponent not in visited:
+                    to_visit.append(opponent)
+
+        logger.debug("Found %d connected competitors", len(all_competitors))
+        return all_competitors
+
+    @classmethod
+    def _preference_matrix(cls, scores: "np.ndarray", pair_games: "np.ndarray", games: "np.ndarray") -> "np.ndarray":
+        """Build Keener's stabilized preference matrix from a raw score matrix.
+
+        Args:
+            scores: ``S``, where ``S[i, j]`` is the total number of points ``i`` scored
+                against ``j``.
+            pair_games: ``G``, where ``G[i, j]`` is the number of games ``i`` played
+                against ``j``.
+            games: The number of games each competitor played in total.
+
+        Returns:
+            numpy.ndarray: The strictly positive preference matrix.
+        """
+        totals = scores + scores.T
+        # Laplace-smoothed score share.
+        proportions = (scores + 1.0) / (totals + 2.0)
+
+        # Keener's skew transform: monotone, fixes 1/2, and h(x) + h(1 - x) == 1.
+        centered = 2.0 * proportions - 1.0
+        preferences = 0.5 + 0.5 * np.sign(centered) * np.sqrt(np.abs(centered))
+
+        # A pair that never met expresses no preference, and neither does a competitor
+        # against itself. Leaving unplayed pairs at the "no evidence" value h(1/2) = 1/2
+        # instead would swamp the row: on a sparse schedule the n - games_i entries for
+        # opponents never faced dominate the games_i real ones, and the fit degenerates
+        # into a ranking by 1 / games_played.
+        preferences = np.where(pair_games > 0, preferences, 0.0)
+        np.fill_diagonal(preferences, 0.0)
+
+        # Divide by games played, making each row the competitor's average preference per
+        # game, so a longer schedule is not itself worth rating.
+        preferences = preferences / np.maximum(games, 1.0)[:, None]
+
+        # Keener's eps * E perturbation: makes the matrix strictly positive, so its dominant
+        # eigenvalue is simple and its eigenvector strictly positive. This is also what
+        # connects competitors who never met, which the mask above disconnected.
+        return cast("np.ndarray", preferences + cls._perturbation)
+
+    def _recalculate_ratings(self) -> None:
+        """Re-fit the Keener ratings for all connected competitors.
+
+        Builds the preference matrix for the connected group, takes the eigenvector of its
+        dominant eigenvalue, and scales the result so the group's ratings average 1.0.
+        """
+        competitors = self._get_connected_competitors()
+        n = len(competitors)
+        if n <= 1:
+            logger.debug("Only one competitor in network, skipping recalculation.")
+            return
+
+        idx = {comp: i for i, comp in enumerate(competitors)}
+
+        scores = np.zeros((n, n), dtype=np.float64)
+        pair_games = np.zeros((n, n), dtype=np.float64)
+        games = np.zeros(n, dtype=np.float64)
+        for i, comp in enumerate(competitors):
+            games[i] = comp.num_games
+            for opponent, points in comp._scores_for.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    scores[i, j] = points
+            for opponent, count in comp._opponents.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    pair_games[i, j] = count
+
+        matrix = self._preference_matrix(scores, pair_games, games)
+
+        try:
+            eigenvalues, eigenvectors = np.linalg.eig(matrix)
+        except np.linalg.LinAlgError as e:
+            logger.warning(
+                "Keener eigenvector solve failed (%s). Falling back to mean-preference ratings for %d competitors.",
+                str(e),
+                n,
+            )
+            self._fallback_rating_calculation(competitors, matrix)
+            return
+
+        # The matrix is strictly positive, so by Perron-Frobenius the eigenvalue of largest
+        # magnitude is real, simple and positive, and its eigenvector can be taken positive.
+        dominant = int(np.argmax(eigenvalues.real))
+        vector = np.real(eigenvectors[:, dominant])
+        if vector.sum() < 0:
+            # LAPACK returns eigenvectors up to sign; orient the Perron vector positive.
+            vector = -vector
+
+        if not np.all(np.isfinite(vector)) or vector.sum() <= 0:
+            logger.warning("Keener eigenvector was degenerate for %d competitors; falling back.", n)
+            self._fallback_rating_calculation(competitors, matrix)
+            return
+
+        vector = np.maximum(vector, self._probability_floor)
+        ratings = vector * (n / vector.sum())
+
+        # LAPACK's pivoting follows row order, and row order is the order competitors were
+        # discovered in, so two runs over the same results can differ in the last few bits.
+        # Canonicalizing makes mathematically identical records compare exactly equal and
+        # makes the fit order independent.
+        ratings = np.round(ratings, decimals=self._round_decimals)
+
+        for i, comp in enumerate(competitors):
+            comp.rating = float(ratings[i])
+
+    def _fallback_rating_calculation(self, competitors: List["KeenerCompetitor"], matrix: "np.ndarray") -> None:
+        """Assign mean-preference ratings when the eigenvector cannot be computed.
+
+        Args:
+            competitors: The connected group of competitors to rate.
+            matrix: The preference matrix that was built for them.
+        """
+        means = matrix.sum(axis=1)
+        total = float(means.sum())
+        n = len(competitors)
+        if total <= 0:
+            values = np.full(n, 1.0)
+        else:
+            values = means * (n / total)
+        for comp, value in zip(competitors, values, strict=True):
+            comp.rating = float(max(value, self._probability_floor))
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        """Export the parameters used to initialize this competitor.
+
+        Returns:
+            dict: A dictionary containing the initialization parameters.
+        """
+        return {
+            "initial_rating": self._initial_rating,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        """Export the current state variables of this competitor.
+
+        Returns:
+            dict: A dictionary containing the current state variables.
+        """
+        return {
+            "rating": self._rating,
+            "wins": self._wins,
+            "losses": self._losses,
+            "ties": self._ties,
+            "points_for": self._points_for,
+            "points_against": self._points_against,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        """Import parameters from a state dictionary.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+        """
+        self._initial_rating = parameters.get("initial_rating", self._default_initial_rating)
+        self._rating = self._initial_rating
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        """Import current state variables from a state dictionary.
+
+        Note: opponent references cannot be restored from serialization, so the match graph is
+        reset; the rating and the aggregate score totals are preserved.
+
+        Args:
+            state (dict): A dictionary containing state variables.
+        """
+        self._rating = state.get("rating", self._initial_rating)
+        self._wins = state.get("wins", 0)
+        self._losses = state.get("losses", 0)
+        self._ties = state.get("ties", 0)
+        self._points_for = state.get("points_for", 0.0)
+        self._points_against = state.get("points_against", 0.0)
+        self._opponents = {}
+        self._scores_for = {}
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        """Create a new competitor instance from parameters.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Returns:
+            KeenerCompetitor: A new competitor instance.
+        """
+        return cls(initial_rating=parameters.get("initial_rating", cls._default_initial_rating))
+
+    def reset(self) -> None:
+        """Reset this competitor to its initial state."""
+        logger.info("Resetting KeenerCompetitor %d to initial state.", self._id)
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._opponents = {}
+        self._scores_for = {}
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        """Configure class-level parameters for this rating system.
+
+        Overrides the base implementation to validate the Keener-specific parameters.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        if "expected_score_scale" in kwargs and kwargs["expected_score_scale"] <= 0:
+            raise InvalidParameterException("expected_score_scale must be positive")
+        if "perturbation" in kwargs and kwargs["perturbation"] <= 0:
+            raise InvalidParameterException("perturbation must be positive")
+        super().configure_class(**kwargs)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<KeenerCompetitor: rating={self._rating:.4f}, W/L/T={self._wins}/{self._losses}/{self._ties}>"
+
+    def __str__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<KeenerCompetitor: rating={self._rating:.4f}>"
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if two competitors are the same object (by unique ID)."""
+        if not isinstance(other, KeenerCompetitor):
+            return NotImplemented
+        return self._id == other._id
+
+    def __hash__(self) -> int:
+        """Get a hash value for this competitor based on its unique ID."""
+        return hash(self._id)

--- a/elote/competitors/massey.py
+++ b/elote/competitors/massey.py
@@ -26,7 +26,7 @@ References:
   Princeton University Press, chapter 2.
 """
 
-from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set
+from typing import Dict, Any, ClassVar, Type, TypeVar, List, Optional, cast, Set, Sequence
 
 import numpy as np
 
@@ -45,13 +45,13 @@ class MasseyCompetitor(BaseCompetitor):
     result; the whole connected group is re-fit from the complete match history, which makes
     the method order independent.
 
-    **Unit margins.** The uniform ``BaseCompetitor`` API exposes only ``beat`` / ``lost_to`` /
-    ``tied`` and has no channel for a score differential, so this implementation is
-    *unit-margin* Massey: a win contributes ``+1`` to the winner's cumulative margin and
-    ``-1`` to the loser's, and a draw contributes ``0`` to both while still counting as a game
-    played for each. Genuine margin-of-victory Massey -- the form used in college football
-    rankings -- would require a base-class level decision about how to carry a score, and is
-    not implemented here.
+    **Margins.** ``beat`` / ``lost_to`` / ``tied`` accept the common optional ``scores``
+    payload, the two competitors' scores in caller order. When it is supplied this is genuine
+    margin-of-victory Massey -- the form used in college football rankings -- and the margin
+    contributed by a game is ``self_score - competitor_score``. When it is omitted the
+    implementation falls back to *unit margins*: a win contributes ``+1`` to the winner's
+    cumulative margin and ``-1`` to the loser's. A draw contributes ``0`` either way, while
+    still counting as a game played for both.
 
     Key characteristics:
     - Global least-squares fit (does not depend on the order of results)
@@ -89,8 +89,8 @@ class MasseyCompetitor(BaseCompetitor):
         self._losses = 0
         self._ties = 0
         # Cumulative margin -- the right-hand side ``p`` of the Massey system. With unit
-        # margins this is simply wins minus losses, but it is tracked separately because it is
-        # the quantity the algorithm actually consumes.
+        # margins this is simply wins minus losses; with real scores it is the sum of
+        # ``self_score - opponent_score`` over every game played.
         self._point_differential = 0.0
         self._opponents: Dict["MasseyCompetitor", int] = {}  # Opponent -> num games
         # Unique ID for hashing (instances are used as dict keys in the match graph).
@@ -155,33 +155,39 @@ class MasseyCompetitor(BaseCompetitor):
         # exactly 1.0 in floating point.
         return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * rating_diff)))
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         The result is recorded in the match graph and the whole connected group is re-fit.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. When supplied, the margin contributed to
+                the Massey system is the real ``self_score - competitor_score``; when
+                omitted the unit margin ``+1 / -1`` is used.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s beat %s", self, competitor)
         self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 1.0)
         opponent = cast(MasseyCompetitor, competitor)
+        margin = 1.0 if validated is None else validated[0] - validated[1]
 
         self._wins += 1
-        self._point_differential += 1.0
+        self._point_differential += margin
         self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
 
         opponent._losses += 1
-        opponent._point_differential -= 1.0
+        opponent._point_differential -= margin
         opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
 
         logger.debug("Recorded win for %d, loss for %d", self._id, opponent._id)
         self._recalculate_ratings()
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         A draw contributes nothing to either cumulative margin, but counts as a game played
@@ -189,12 +195,16 @@ class MasseyCompetitor(BaseCompetitor):
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They must be equal, so a drawn game
+                contributes a zero margin whether or not scores are supplied.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s tied with %s", self, competitor)
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         opponent = cast(MasseyCompetitor, competitor)
 
         self._ties += 1
@@ -206,18 +216,22 @@ class MasseyCompetitor(BaseCompetitor):
         logger.debug("Recorded tie for %d and %d", self._id, opponent._id)
         self._recalculate_ratings()
 
-    def lost_to(self, competitor: BaseCompetitor) -> None:
+    def lost_to(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has lost to the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Reversed before being passed to the
+                winner's :meth:`beat`.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         logger.debug("Competitor %s lost to %s", self, competitor)
         self.verify_competitor_types(competitor)
-        competitor.beat(self)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
 
     def _get_connected_competitors(self) -> List["MasseyCompetitor"]:
         """Get all competitors connected to this competitor in the match graph.

--- a/elote/competitors/trueskill.py
+++ b/elote/competitors/trueskill.py
@@ -1,6 +1,6 @@
 import math
 from scipy import special
-from typing import Dict, Any, ClassVar, Tuple, Type, TypeVar, List
+from typing import Dict, Any, ClassVar, Optional, Sequence, Tuple, Type, TypeVar, List
 
 from elote.competitors.base import BaseCompetitor, InvalidParameterException
 from elote.logging import logger  # Import directly from the logging submodule
@@ -474,16 +474,20 @@ class TrueSkillCompetitor(BaseCompetitor):
         )
         return expected
 
-    def beat(self, competitor: BaseCompetitor) -> None:
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Validated but not otherwise used by
+                this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
         logger.debug("%s beat %s", self, competitor)
         competitor_ts = competitor  # type: TrueSkillCompetitor
 
@@ -519,16 +523,20 @@ class TrueSkillCompetitor(BaseCompetitor):
             "Loser update (%s): new_mu=%.2f, new_sigma=%.2f", competitor_ts, competitor_ts._mu, competitor_ts._sigma
         )
 
-    def tied(self, competitor: BaseCompetitor) -> None:
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has tied with the given competitor.
 
         Args:
             competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Must be equal. Validated but not
+                otherwise used by this rating system.
 
         Raises:
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
         logger.debug("%s tied with %s", self, competitor)
         competitor_ts = competitor  # type: TrueSkillCompetitor
 

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -11,6 +11,7 @@ from elote import (
     EloCompetitor,
     Glicko2Competitor,
     GlickoCompetitor,
+    KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
     TrueSkillCompetitor,
@@ -299,9 +300,10 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
     )
 
-    # Colley, Massey and Bradley-Terry reset their opponent match graph on import by design
+    # Colley, Massey, Bradley-Terry and Keener reset their opponent match graph on import by design
     # (documented in their own docstrings), so only the incremental systems can be
     # expected to keep rating identically after a restore.
     INCREMENTAL_COMPETITORS = (

--- a/tests/test_KeenerCompetitor.py
+++ b/tests/test_KeenerCompetitor.py
@@ -1,0 +1,291 @@
+"""Behavioural tests for KeenerCompetitor.
+
+Numeric reference values live in tests/test_KeenerCompetitor_known_values.py.
+"""
+
+import json
+import unittest
+
+from elote import KeenerCompetitor, LambdaArena
+from elote.competitors.base import (
+    BaseCompetitor,
+    InvalidParameterException,
+    InvalidRatingValueException,
+    MissMatchedCompetitorTypesException,
+)
+
+
+def _play(schedule, count=3):
+    """Apply a schedule of ``(i, j, score_i, score_j)`` tuples to ``count`` fresh competitors."""
+    competitors = [KeenerCompetitor() for _ in range(count)]
+    for i, j, score_i, score_j in schedule:
+        if score_i > score_j:
+            competitors[i].beat(competitors[j], scores=(score_i, score_j))
+        elif score_i < score_j:
+            competitors[i].lost_to(competitors[j], scores=(score_i, score_j))
+        else:
+            competitors[i].tied(competitors[j], scores=(score_i, score_j))
+    return competitors
+
+
+class TestKeenerBasics(unittest.TestCase):
+    def test_defaults(self):
+        competitor = KeenerCompetitor()
+        self.assertEqual(competitor.rating, 1.0)
+        self.assertEqual(competitor.num_games, 0)
+        self.assertEqual(competitor._points_for, 0.0)
+        self.assertEqual(competitor._points_against, 0.0)
+
+    def test_custom_initial_rating(self):
+        self.assertEqual(KeenerCompetitor(initial_rating=2.5).rating, 2.5)
+
+    def test_non_positive_initial_rating_rejected(self):
+        for bad in (0.0, -1.0):
+            with self.subTest(initial_rating=bad):
+                with self.assertRaises(InvalidRatingValueException):
+                    KeenerCompetitor(initial_rating=bad)
+
+    def test_rating_setter_rejects_values_below_the_floor(self):
+        competitor = KeenerCompetitor()
+        with self.assertRaises(InvalidRatingValueException):
+            competitor.rating = -0.5
+
+    def test_type_mismatch_is_rejected(self):
+        from elote import EloCompetitor
+
+        competitor = KeenerCompetitor()
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.expected_score(EloCompetitor())
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.beat(EloCompetitor())
+
+    def test_registered_for_state_reconstruction(self):
+        self.assertIn("KeenerCompetitor", BaseCompetitor.list_competitor_types())
+        self.assertIs(BaseCompetitor.get_competitor_class("KeenerCompetitor"), KeenerCompetitor)
+
+    def test_configure_class_validates_parameters(self):
+        with self.assertRaises(InvalidParameterException):
+            KeenerCompetitor.configure_class(expected_score_scale=0)
+        with self.assertRaises(InvalidParameterException):
+            KeenerCompetitor.configure_class(perturbation=0)
+
+
+class TestKeenerExpectedScore(unittest.TestCase):
+    def test_two_fresh_competitors_predict_one_half(self):
+        self.assertEqual(KeenerCompetitor().expected_score(KeenerCompetitor()), 0.5)
+
+    def test_predictions_are_exactly_complementary(self):
+        a, b, c = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        for first, second in ((a, b), (b, a), (a, c), (c, b)):
+            with self.subTest(pair=(first.rating, second.rating)):
+                self.assertEqual(first.expected_score(second) + second.expected_score(first), 1.0)
+
+    def test_predictions_stay_in_the_unit_interval_after_lopsided_results(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        for _ in range(12):
+            a.beat(b, scores=(99.0, 0.0))
+            for first, second in ((a, b), (b, a)):
+                score = first.expected_score(second)
+                self.assertGreaterEqual(score, 0.0)
+                self.assertLessEqual(score, 1.0)
+
+    def test_stronger_competitor_is_favoured(self):
+        a, b, _ = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        self.assertGreater(a.rating, b.rating)
+        self.assertGreater(a.expected_score(b), 0.5)
+
+
+class TestKeenerResults(unittest.TestCase):
+    def test_win_updates_both_sides(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+
+        self.assertEqual((a._wins, a._losses, a._ties), (1, 0, 0))
+        self.assertEqual((b._wins, b._losses, b._ties), (0, 1, 0))
+        self.assertEqual((a._points_for, a._points_against), (28.0, 7.0))
+        self.assertEqual((b._points_for, b._points_against), (7.0, 28.0))
+        self.assertGreater(a.rating, b.rating)
+
+    def test_lost_to_records_the_same_game_as_beat(self):
+        winner_first = KeenerCompetitor(), KeenerCompetitor()
+        winner_first[0].beat(winner_first[1], scores=(28.0, 7.0))
+
+        loser_first = KeenerCompetitor(), KeenerCompetitor()
+        loser_first[1].lost_to(loser_first[0], scores=(7.0, 28.0))
+
+        self.assertEqual(loser_first[0].rating, winner_first[0].rating)
+        self.assertEqual(loser_first[1].rating, winner_first[1].rating)
+        self.assertEqual(loser_first[0]._points_for, 28.0)
+        self.assertEqual(loser_first[1]._points_for, 7.0)
+
+    def test_draw_is_symmetric(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.tied(b, scores=(17.0, 17.0))
+
+        self.assertEqual(a.rating, b.rating)
+        self.assertEqual((a._ties, b._ties), (1, 1))
+        self.assertEqual((a._points_for, b._points_for), (17.0, 17.0))
+
+    def test_omitted_scores_fall_back_to_unit_scores(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b)
+        self.assertEqual((a._points_for, a._points_against), (1.0, 0.0))
+
+        c, d = KeenerCompetitor(), KeenerCompetitor()
+        c.tied(d)
+        self.assertEqual((c._points_for, d._points_for), (0.5, 0.5))
+
+    def test_unit_scores_reproduce_the_omitted_score_path(self):
+        plain = KeenerCompetitor(), KeenerCompetitor()
+        plain[0].beat(plain[1])
+        plain[0].tied(plain[1])
+
+        scored = KeenerCompetitor(), KeenerCompetitor()
+        scored[0].beat(scored[1], scores=(1.0, 0.0))
+        scored[0].tied(scored[1], scores=(0.5, 0.5))
+
+        self.assertEqual(plain[0].rating, scored[0].rating)
+        self.assertEqual(plain[1].rating, scored[1].rating)
+
+    def test_margins_matter(self):
+        """A blowout and a one-point win over the same schedule must not fit the same ratings."""
+        blowout = _play([(0, 1, 50, 0), (1, 2, 3, 2)])
+        narrow = _play([(0, 1, 3, 2), (1, 2, 3, 2)])
+        self.assertNotAlmostEqual(blowout[0].rating, narrow[0].rating, places=6)
+
+    def test_ratings_are_positive_and_average_one(self):
+        competitors = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        for competitor in competitors:
+            self.assertGreater(competitor.rating, 0.0)
+        self.assertAlmostEqual(sum(c.rating for c in competitors) / len(competitors), 1.0, places=9)
+
+    def test_disconnected_groups_are_rated_independently(self):
+        a, b, c, d = (KeenerCompetitor() for _ in range(4))
+        a.beat(b, scores=(30.0, 10.0))
+        first_pair = (a.rating, b.rating)
+
+        c.beat(d, scores=(4.0, 3.0))
+        # The second group shares no opponent with the first, so the first is untouched.
+        self.assertEqual((a.rating, b.rating), first_pair)
+        self.assertNotEqual(c.rating, a.rating)
+
+    def test_reset_restores_a_fresh_competitor(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        a.reset()
+
+        fresh = KeenerCompetitor()
+        self.assertEqual(a.rating, fresh.rating)
+        self.assertEqual(a.num_games, 0)
+        self.assertEqual((a._points_for, a._points_against), (0.0, 0.0))
+        self.assertEqual(a._scores_for, {})
+
+
+class TestKeenerOrderIndependence(unittest.TestCase):
+    """The fit must depend on the set of results, not the order they arrived in.
+
+    The fixture below was selected programmatically rather than by hand: a search over
+    random scored schedules kept only one whose RAW solver output differs between the two
+    replay orders (by 5.6e-16 here) while the canonicalized output agrees. A hand-picked
+    schedule usually solves bit-identically in both orders, so the test would pass with the
+    canonicalization deleted and guard nothing.
+    """
+
+    SCHEDULE = [(2, 1, 28, 32), (2, 0, 11, 32), (1, 0, 6, 28), (1, 0, 5, 34)]
+    REPLAY = [(1, 0, 5, 34), (2, 0, 11, 32), (1, 0, 6, 28), (2, 1, 28, 32)]
+
+    def test_replaying_in_a_different_order_gives_identical_ratings(self):
+        first = [c.rating for c in _play(self.SCHEDULE)]
+        second = [c.rating for c in _play(self.REPLAY)]
+        self.assertEqual(first, second)
+
+    def test_the_fixture_is_order_sensitive_without_canonicalization(self):
+        """Guards the guard: with rounding effectively off, the two orders must disagree."""
+        original = KeenerCompetitor._round_decimals
+        try:
+            KeenerCompetitor._round_decimals = 17
+            first = [c.rating for c in _play(self.SCHEDULE)]
+            second = [c.rating for c in _play(self.REPLAY)]
+            self.assertNotEqual(first, second)
+        finally:
+            KeenerCompetitor._round_decimals = original
+
+
+class TestKeenerSerialization(unittest.TestCase):
+    def test_state_round_trip_restores_ratings_and_score_aggregates(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+        a.tied(b, scores=(10.0, 10.0))
+
+        restored = KeenerCompetitor.from_state(a.export_state())
+
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual((restored._wins, restored._losses, restored._ties), (1, 0, 1))
+        self.assertEqual(restored._points_for, 45.0)
+        self.assertEqual(restored._points_against, 13.0)
+
+    def test_json_round_trip(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+
+        restored = KeenerCompetitor.from_json(a.to_json())
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual(restored._points_for, 21.0)
+
+    def test_exported_state_is_json_serializable(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+        self.assertIsInstance(json.dumps(a.export_state()), str)
+
+    def test_match_graph_is_not_restored(self):
+        """Documented limitation, shared with Colley, Massey and Bradley-Terry.
+
+        The opponent graph holds live object references, so it cannot be serialized. A
+        restored competitor keeps its rating and score totals but has no opponents, so
+        continued play re-fits it against only the new results.
+        """
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        restored_a = KeenerCompetitor.from_state(a.export_state())
+        restored_b = KeenerCompetitor.from_state(b.export_state())
+        self.assertEqual(restored_a._scores_for, {})
+        self.assertEqual(restored_a._opponents, {})
+
+        # Continuing play on the restored pair does not reproduce the original pair's fit.
+        restored_a.beat(restored_b, scores=(35.0, 3.0))
+        a.beat(b, scores=(35.0, 3.0))
+        self.assertNotAlmostEqual(restored_a.rating, a.rating, places=6)
+
+
+class TestKeenerArena(unittest.TestCase):
+    def test_arena_round_trip_preserves_the_leaderboard(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b", outcome=1.0, scores=(28.0, 7.0))
+        arena.matchup("b", "c", outcome=1.0, scores=(14.0, 7.0))
+        arena.matchup("a", "c", outcome=0.0, scores=(3.0, 35.0))
+
+        restored = LambdaArena(
+            lambda a, b: True,
+            base_competitor=KeenerCompetitor,
+            initial_state=json.loads(json.dumps(arena.export_state())),
+        )
+        self.assertEqual(restored.leaderboard(), arena.leaderboard())
+
+    def test_arena_forwards_scores_in_competitor_order(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+
+        self.assertEqual(arena.competitors["b"]._points_for, 35.0)
+        self.assertEqual(arena.competitors["a"]._points_for, 3.0)
+        self.assertEqual(arena.competitors["b"]._wins, 1)
+
+    def test_arena_without_scores_uses_unit_fallback(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b")
+        self.assertEqual(arena.competitors["a"]._points_for, 1.0)
+        self.assertEqual(len(arena.history.bouts), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_KeenerCompetitor_known_values.py
+++ b/tests/test_KeenerCompetitor_known_values.py
@@ -1,0 +1,146 @@
+"""Numeric reference values for KeenerCompetitor.
+
+Every value below was calculated independently of ``elote``: the two-competitor cases have a
+closed form (recomputed here from the documented formula), and the three-competitor cases
+were produced by a 60-digit ``decimal`` power iteration written separately from the shipped
+implementation, which uses ``numpy.linalg.eig``.
+
+Recall the construction for a connected group, with ``S_ij`` the points ``i`` scored on ``j``:
+
+    a_ij = (S_ij + 1) / (S_ij + S_ji + 2)                  Laplace-smoothed score share
+    h(x) = 1/2 + 1/2 * sgn(x - 1/2) * sqrt(|2x - 1|)       Keener's skew transform
+    H_ij = h(a_ij) / games_i + eps                         row-normalized, eps = 1e-4
+    r    = dominant eigenvector of H, scaled to mean 1.0
+
+Ratings are canonicalized to ``_round_decimals`` (10) places, so assertions use 9 places.
+"""
+
+import math
+import unittest
+
+from elote import KeenerCompetitor
+
+
+PLACES = 9
+EPS = KeenerCompetitor._perturbation
+
+
+def _skew(share):
+    """Keener's skew transform, written out independently of the implementation."""
+    centered = 2.0 * share - 1.0
+    return 0.5 + 0.5 * math.copysign(math.sqrt(abs(centered)), centered)
+
+
+class TestKeenerKnownValues(unittest.TestCase):
+    def test_single_scored_game_matches_the_two_by_two_closed_form(self):
+        """One 35-3 game between two competitors.
+
+        S = [[0, 35], [3, 0]], so a_01 = 36/40 = 0.9 and a_10 = 4/40 = 0.1, and
+
+            h(0.9) = 1/2 + 1/2*sqrt(0.8),   h(0.1) = 1/2 - 1/2*sqrt(0.8).
+
+        Both played one game, so the row normalization is a no-op and
+
+            H = [[eps, p], [q, eps]]  with  p = h(0.9) + eps, q = h(0.1) + eps.
+
+        For that shape the eigenvalues are eps +/- sqrt(p*q) and the dominant eigenvector is
+        proportional to (sqrt(p), sqrt(q)); scaling to mean 1.0 over n = 2 gives
+
+            r = (2*sqrt(p) / (sqrt(p) + sqrt(q)),  2*sqrt(q) / (sqrt(p) + sqrt(q))).
+        """
+        p = _skew(0.9) + EPS
+        q = _skew(0.1) + EPS
+        root_p, root_q = math.sqrt(p), math.sqrt(q)
+        expected_a = 2.0 * root_p / (root_p + root_q)
+        expected_b = 2.0 * root_q / (root_p + root_q)
+        # Guards the arithmetic above against a silent change in the closed form.
+        self.assertAlmostEqual(expected_a, 1.617757795347885, places=12)
+        self.assertAlmostEqual(expected_b, 0.382242204652116, places=12)
+
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, expected_a, places=PLACES)
+        self.assertAlmostEqual(b.rating, expected_b, places=PLACES)
+
+    def test_single_drawn_game_leaves_both_at_the_population_mean(self):
+        """A drawn game gives a_01 = a_10 = 1/2, so h = 1/2 on both sides and H is symmetric.
+
+        The dominant eigenvector of a symmetric 2x2 with equal off-diagonals is (1, 1),
+        which scales to (1.0, 1.0).
+        """
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.tied(b, scores=(14.0, 14.0))
+
+        self.assertAlmostEqual(a.rating, 1.0, places=PLACES)
+        self.assertAlmostEqual(b.rating, 1.0, places=PLACES)
+
+    def test_asymmetric_scored_schedule(self):
+        """A beat B 28-7, B beat C 14-7, A beat C 35-3.
+
+        Score matrix (rows A, B, C):
+
+            S = [[ 0, 28, 35],
+                 [ 7,  0, 14],
+                 [ 3,  7,  0]]
+
+        so a_AB = 29/37, a_BA = 8/37, a_AC = 36/40, a_CA = 4/40, a_BC = 15/23, a_CB = 8/23.
+        Games played: A two, B two, C two.  Reference ratings from a 60-digit power
+        iteration on the resulting H:
+
+            A = 1.73792467527929154, B = 0.83492367232361227, C = 0.42715165239709619
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        b.beat(c, scores=(14.0, 7.0))
+        a.beat(c, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, 1.73792467527929154, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.83492367232361227, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.42715165239709619, places=PLACES)
+
+    def test_scored_schedule_containing_a_draw(self):
+        """A beat B 30-10, B drew C 14-14, A beat C 21-14.
+
+        The drawn game contributes a_BC = a_CB = 1/2, i.e. h = 1/2 in both directions, and
+        still counts as a game played for both -- which is what pulls C above B here despite
+        C never winning.  Reference ratings from the same 60-digit power iteration:
+
+            A = 1.40226342754892460, B = 0.73428336424082162, C = 0.86345320821025379
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(30.0, 10.0))
+        b.tied(c, scores=(14.0, 14.0))
+        a.beat(c, scores=(21.0, 14.0))
+
+        self.assertAlmostEqual(a.rating, 1.40226342754892460, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.73428336424082162, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.86345320821025379, places=PLACES)
+
+    def test_unit_score_fallback_schedule(self):
+        """A beat B, B beat C, with no score payload at all.
+
+        The unit fallback records 1-0 for each win, so a_AB = 2/3 and h(2/3) = 1/2 +
+        sqrt(1/3)/2 = 0.7886751345948129, with h(1/3) the complement.  A and C never met, so
+        their entries are 0 before the eps perturbation, and B's row is halved because B
+        played twice:
+
+            H = [[eps,      0.7886751 + eps,  eps            ],
+                 [0.1056624 + eps, eps,       0.3943376 + eps],
+                 [eps,      0.2114249 + eps,  eps            ]]
+
+        Reference ratings from the same independent power iteration over that matrix:
+
+            A = 1.67957399744031952, B = 0.86984806605940995, C = 0.45057793650027053
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b)
+        b.beat(c)
+
+        self.assertAlmostEqual(a.rating, 1.67957399744031952, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.86984806605940995, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.45057793650027053, places=PLACES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_MasseyCompetitor_known_values.py
+++ b/tests/test_MasseyCompetitor_known_values.py
@@ -121,6 +121,41 @@ class TestMasseyKnownValues(unittest.TestCase):
         self.assertAlmostEqual(a.rating, 0.5, places=9)
         self.assertAlmostEqual(b.rating, -0.5, places=9)
 
+    def test_single_game_splits_a_real_margin(self):
+        """With scores supplied, one 35-3 game gives ratings of +16 and -16.
+
+        The structure is identical to the unit-margin case above, only p = (+32, -32)
+        instead of (+1, -1), so a - b = 32 and a + b = 0.
+        """
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, 16.0, places=9)
+        self.assertAlmostEqual(b.rating, -16.0, places=9)
+
+    def test_three_team_schedule_with_real_margins(self):
+        """A beats B by 21, B beats C by 7.
+
+        Games played: A one, B two, C one; A meets B once and B meets C once:
+
+            M = D - A = [[ 1, -1,  0],
+                         [-1,  2, -1],
+                         [ 0, -1,  1]]
+
+        and p = (+21, -21 + 7, -7) = (+21, -14, -7).  With a + b + c = 0:
+
+            row 1:  a - b = 21
+            row 2:  -a + 2b - c = -14, and c = -a - b, so -a + 2b + a + b = 3b = -14
+                    ->  b = -14/3, a = 21 - 14/3 = 49/3, c = -a - b = -35/3
+        """
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        b.beat(c, scores=(14.0, 7.0))
+
+        self.assertAlmostEqual(a.rating, 49.0 / 3.0, places=9)
+        self.assertAlmostEqual(b.rating, -14.0 / 3.0, places=9)
+        self.assertAlmostEqual(c.rating, -35.0 / 3.0, places=9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -6,6 +6,8 @@ from elote.competitors.elo import EloCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.glicko import GlickoCompetitor
 from elote.competitors.trueskill import TrueSkillCompetitor
+from elote.competitors.colley import ColleyMatrixCompetitor
+from elote.competitors.keener import KeenerCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
 from elote.datasets.synthetic import SyntheticDataset
@@ -408,6 +410,46 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
         ratings = [team["rating"] for team in result["top_teams"]]
         self.assertEqual(ratings, sorted(ratings, reverse=True))
         self.assertGreater(ratings[0], ratings[-1])
+
+    def test_keener_runs_end_to_end_through_the_benchmark(self):
+        """Keener is a global-fit system, so the benchmark must not force an initial rating.
+
+        evaluate_competitor detects global-fit classes by the presence of
+        _recalculate_ratings and skips the common start for them; forcing 1500 on a system
+        whose ratings average 1.0 would give degenerate first-bout predictions.
+        """
+        result = evaluate_competitor(
+            competitor_class=KeenerCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=True,
+        )
+
+        competitors = list(result["arena"].competitors.values())
+        self.assertGreater(len(competitors), 0)
+        for competitor in competitors:
+            self.assertEqual(competitor._initial_rating, KeenerCompetitor._default_initial_rating)
+            self.assertGreater(competitor.rating, 0.0)
+
+        self.assertGreater(result["accuracy"], 0.5)
+        self.assertGreaterEqual(result["accuracy_opt"], result["accuracy"])
+
+    def test_keener_can_be_compared_against_another_global_fit_system(self):
+        """benchmark_competitors must accept Keener alongside its siblings."""
+        results = benchmark_competitors(
+            [
+                {"class": KeenerCompetitor, "name": "Keener", "params": {}},
+                {"class": ColleyMatrixCompetitor, "name": "Colley", "params": {}},
+            ],
+            self.data_split,
+            _always_true,
+            optimize_thresholds=False,
+        )
+
+        self.assertEqual([entry["name"] for entry in results], ["Keener", "Colley"])
+        for entry in results:
+            with self.subTest(system=entry["name"]):
+                self.assertGreater(entry["accuracy"], 0.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -1,0 +1,247 @@
+"""Tests for the optional score payload on the common result API.
+
+The score channel is cross-cutting: every competitor class must accept it, malformed
+payloads must be rejected before anything mutates, and the arena must forward the pair in
+the right competitor order. Systems that actually consume a score (currently Massey) are
+covered here for the plumbing and in their own known-value file for the numbers.
+"""
+
+import unittest
+
+from elote import (
+    BradleyTerryCompetitor,
+    ColleyMatrixCompetitor,
+    DWZCompetitor,
+    ECFCompetitor,
+    EloCompetitor,
+    Glicko2Competitor,
+    GlickoCompetitor,
+    LambdaArena,
+    MasseyCompetitor,
+    TrueSkillCompetitor,
+)
+
+
+def _always_true(a, b, attributes=None):
+    """Comparison function for arenas that are always driven by an explicit outcome."""
+    return True
+
+
+COMPETITOR_CLASSES = (
+    EloCompetitor,
+    GlickoCompetitor,
+    Glicko2Competitor,
+    TrueSkillCompetitor,
+    ECFCompetitor,
+    DWZCompetitor,
+    ColleyMatrixCompetitor,
+    BradleyTerryCompetitor,
+    MasseyCompetitor,
+)
+
+# A win, a draw and a loss, with the unit scores each result implies.
+UNIT_SCHEDULE = (
+    ("beat", (1.0, 0.0)),
+    ("tied", (0.5, 0.5)),
+    ("lost_to", (0.0, 1.0)),
+)
+
+
+class TestScoreValidation(unittest.TestCase):
+    """Malformed score payloads are rejected before any state changes."""
+
+    BAD_PAYLOADS = (
+        ("not a sequence", 5),
+        ("string", "3-1"),
+        ("too short", (3.0,)),
+        ("too long", (3.0, 1.0, 0.0)),
+        ("non numeric", (3.0, "1")),
+        ("boolean", (True, False)),
+        ("negative", (3.0, -1.0)),
+        ("infinite", (float("inf"), 1.0)),
+        ("nan", (float("nan"), 1.0)),
+    )
+
+    def test_malformed_scores_rejected_for_every_competitor(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            for label, payload in self.BAD_PAYLOADS:
+                with self.subTest(competitor=competitor_class.__name__, payload=label):
+                    a = competitor_class()
+                    b = competitor_class()
+                    with self.assertRaises(ValueError):
+                        a.beat(b, scores=payload)
+
+    def test_scores_must_agree_with_the_declared_outcome(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                a = competitor_class()
+                b = competitor_class()
+                # beat() requires the caller's score to be the larger one.
+                with self.assertRaises(ValueError):
+                    a.beat(b, scores=(1.0, 3.0))
+                with self.assertRaises(ValueError):
+                    a.beat(b, scores=(2.0, 2.0))
+                # lost_to() requires the opposite.
+                with self.assertRaises(ValueError):
+                    a.lost_to(b, scores=(3.0, 1.0))
+                # tied() requires equality.
+                with self.assertRaises(ValueError):
+                    a.tied(b, scores=(3.0, 1.0))
+
+    def test_rejected_scores_leave_both_competitors_untouched(self):
+        """A ValueError must fire before either side of the pair is mutated."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                a = competitor_class()
+                b = competitor_class()
+                before = (a.export_state()["state"], b.export_state()["state"])
+                with self.assertRaises(ValueError):
+                    a.beat(b, scores=(-1.0, -2.0))
+                self.assertEqual((a.export_state()["state"], b.export_state()["state"]), before)
+
+
+class TestUnitScoreEquivalence(unittest.TestCase):
+    """Supplying the unit scores a result implies must reproduce the no-score behaviour."""
+
+    def test_unit_scores_match_the_omitted_score_path(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                plain_a, plain_b = competitor_class(), competitor_class()
+                scored_a, scored_b = competitor_class(), competitor_class()
+
+                for method, unit_scores in UNIT_SCHEDULE:
+                    getattr(plain_a, method)(plain_b)
+                    getattr(scored_a, method)(scored_b, scores=unit_scores)
+
+                # Not exact equality: Glicko-1/Glicko-2 inflate RD from wall-clock elapsed
+                # time, so the two runs differ by ~1e-10 for reasons unrelated to scores.
+                self.assertAlmostEqual(plain_a.rating, scored_a.rating, places=6)
+                self.assertAlmostEqual(plain_b.rating, scored_b.rating, places=6)
+
+
+class TestMasseyConsumesScores(unittest.TestCase):
+    """Massey is the first system to actually read the score payload."""
+
+    def test_win_contributes_the_real_margin(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        self.assertEqual(a._point_differential, 32.0)
+        self.assertEqual(b._point_differential, -32.0)
+        self.assertEqual((a._wins, b._losses), (1, 1))
+
+    def test_lost_to_reverses_the_score_pair(self):
+        winner_first_a, winner_first_b = MasseyCompetitor(), MasseyCompetitor()
+        winner_first_a.beat(winner_first_b, scores=(35.0, 3.0))
+
+        loser_first_a, loser_first_b = MasseyCompetitor(), MasseyCompetitor()
+        # Same game, called from the loser: scores stay in caller order.
+        loser_first_b.lost_to(loser_first_a, scores=(3.0, 35.0))
+
+        self.assertEqual(loser_first_a._point_differential, winner_first_a._point_differential)
+        self.assertEqual(loser_first_b._point_differential, winner_first_b._point_differential)
+        self.assertEqual(loser_first_a.rating, winner_first_a.rating)
+        self.assertEqual(loser_first_b.rating, winner_first_b.rating)
+
+    def test_equal_score_draw_contributes_no_margin_but_counts_the_game(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.tied(b, scores=(17.0, 17.0))
+
+        self.assertEqual(a._point_differential, 0.0)
+        self.assertEqual(b._point_differential, 0.0)
+        self.assertEqual((a.num_games, b.num_games), (1, 1))
+
+    def test_real_margins_change_the_fit(self):
+        """A blowout and a narrow win over the same schedule must not fit the same ratings."""
+        blowout = [MasseyCompetitor() for _ in range(3)]
+        blowout[0].beat(blowout[1], scores=(50.0, 0.0))
+        blowout[1].beat(blowout[2], scores=(3.0, 2.0))
+
+        narrow = [MasseyCompetitor() for _ in range(3)]
+        narrow[0].beat(narrow[1], scores=(3.0, 2.0))
+        narrow[1].beat(narrow[2], scores=(3.0, 2.0))
+
+        self.assertNotAlmostEqual(blowout[0].rating, narrow[0].rating, places=6)
+
+    def test_score_derived_differential_survives_state_round_trip(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        restored = MasseyCompetitor.from_state(a.export_state())
+        self.assertEqual(restored._point_differential, 32.0)
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual((restored._wins, restored._losses, restored._ties), (1, 0, 0))
+
+
+class TestArenaScoreForwarding(unittest.TestCase):
+    """LambdaArena forwards the (a, b)-ordered pair in whichever order the call needs."""
+
+    def _arena(self):
+        return LambdaArena(_always_true, base_competitor=MasseyCompetitor)
+
+    def test_a_wins_branch(self):
+        arena = self._arena()
+        arena.matchup("a", "b", outcome=1.0, scores=(35.0, 3.0))
+        self.assertEqual(arena.competitors["a"]._point_differential, 32.0)
+        self.assertEqual(arena.competitors["b"]._point_differential, -32.0)
+
+    def test_b_wins_branch_reverses_the_pair(self):
+        arena = self._arena()
+        # Scores stay in (a, b) order even though b won and the call is reversed internally.
+        arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+        self.assertEqual(arena.competitors["b"]._point_differential, 32.0)
+        self.assertEqual(arena.competitors["a"]._point_differential, -32.0)
+        self.assertEqual(arena.competitors["b"]._wins, 1)
+        self.assertEqual(arena.competitors["a"]._losses, 1)
+
+    def test_draw_branch(self):
+        arena = self._arena()
+        arena.matchup("a", "b", outcome=0.5, scores=(17.0, 17.0))
+        self.assertEqual(arena.competitors["a"]._point_differential, 0.0)
+        self.assertEqual(arena.competitors["a"]._ties, 1)
+        self.assertEqual(arena.competitors["b"]._ties, 1)
+
+    def test_bout_is_still_recorded(self):
+        arena = self._arena()
+        arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+        self.assertEqual(len(arena.history.bouts), 1)
+        self.assertEqual(arena.history.bouts[0].outcome, "loss")
+
+    def test_scores_require_an_explicit_outcome(self):
+        arena = self._arena()
+        with self.assertRaises(ValueError):
+            arena.matchup("a", "b", scores=(35.0, 3.0))
+        self.assertEqual(arena.competitors, {})
+        self.assertEqual(len(arena.history.bouts), 0)
+
+    def test_invalid_scores_create_no_competitors_and_no_bout(self):
+        for label, payload in (
+            ("inconsistent with outcome", (3.0, 35.0)),
+            ("negative", (35.0, -3.0)),
+            ("non finite", (float("inf"), 3.0)),
+            ("wrong length", (35.0,)),
+        ):
+            with self.subTest(payload=label):
+                arena = self._arena()
+                with self.assertRaises(ValueError):
+                    arena.matchup("a", "b", outcome=1.0, scores=payload)
+                self.assertEqual(arena.competitors, {})
+                self.assertEqual(len(arena.history.bouts), 0)
+
+    def test_tournament_carries_a_score_payload(self):
+        arena = self._arena()
+        arena.tournament([("a", "b", None, None, 1.0, (35.0, 3.0))])
+        self.assertEqual(arena.competitors["a"]._point_differential, 32.0)
+
+    def test_every_competitor_class_accepts_arena_scores(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                arena = LambdaArena(_always_true, base_competitor=competitor_class)
+                arena.matchup("a", "b", outcome=1.0, scores=(35.0, 3.0))
+                arena.matchup("a", "b", outcome=0.5, scores=(7.0, 7.0))
+                arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+                self.assertEqual(len(arena.history.bouts), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -2,7 +2,7 @@
 
 The score channel is cross-cutting: every competitor class must accept it, malformed
 payloads must be rejected before anything mutates, and the arena must forward the pair in
-the right competitor order. Systems that actually consume a score (currently Massey) are
+the right competitor order. Systems that actually consume a score (Massey and Keener) are
 covered here for the plumbing and in their own known-value file for the numbers.
 """
 
@@ -16,6 +16,7 @@ from elote import (
     EloCompetitor,
     Glicko2Competitor,
     GlickoCompetitor,
+    KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
     TrueSkillCompetitor,
@@ -37,6 +38,7 @@ COMPETITOR_CLASSES = (
     ColleyMatrixCompetitor,
     BradleyTerryCompetitor,
     MasseyCompetitor,
+    KeenerCompetitor,
 )
 
 # A win, a draw and a loss, with the unit scores each result implies.

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -10,6 +10,7 @@ from elote import (
     ColleyMatrixCompetitor,
     BradleyTerryCompetitor,
     MasseyCompetitor,
+    KeenerCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -435,6 +436,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
     )
 
     # A lopsided run: long enough that a one-sided rating gap opens up, with


### PR DESCRIPTION
Closes #122

Adds one optional keyword-only score payload to the common result contract, so
score-based classical systems can be implemented without inventing a private
score path. The default path is explicitly behaviour-preserving.

## What changed

**`BaseCompetitor`** — `beat`, `lost_to` and `tied` take `scores`: the two
competitors' scores **in caller order**, `(self_score, competitor_score)`. A new
module-level `validate_scores(scores, outcome)` (exposed as
`BaseCompetitor._validate_scores`) rejects anything that is not a two-element
sequence of finite, non-negative numbers, or that disagrees with the declared
result, raising `ValueError` **before either competitor is mutated**. `lost_to`
reverses the pair before handing it to the winner's `beat`, so the caller never
reorders it.

**Every concrete class** accepts the payload. `MasseyCompetitor` consumes it —
the margin a game contributes is the real `self_score - competitor_score`
instead of the hardcoded `+1/-1`. `BlendedCompetitor` forwards it to its
children. The rest validate and ignore it.

**`LambdaArena.matchup(..., scores=)`** takes the pair in `(a, b)` order
whichever competitor won, and requires an explicit `outcome` so the two can be
checked for agreement. Validation runs before any competitor is created or any
`Bout` recorded, so a bad payload leaves the arena completely unchanged. The
b-wins branch reverses the call, so it reverses the score pair with it.
`tournament` unpacks tuples into `matchup`, so a 6-tuple can carry scores.

Omitting `scores` leaves every system on its existing unit-score behaviour.

## Verification

Ran from a clean worktree with `env -u VIRTUAL_ENV uv run --extra dev`:

- `pytest -q --ignore=tests/test_examples.py` → **350 passed, 6 skipped**
  (331 on the branch point + 19 new). `tests/test_examples.py` is the
  repository's documented environment-only failure and was excluded.
- `ruff check elote tests` → All checks passed.
- `mypy --python-version 3.12 elote` → Success, no issues in 25 source files.
  (`make typecheck` still aborts in `scipy-stubs` under its 3.10 target, which is
  pre-existing and unrelated.)
- `ruff format --check` on every file this PR touches: only
  `elote/competitors/bradley_terry.py` and `elote/competitors/colley.py` are
  non-conformant, and both already were on `master`. Their remaining diff is
  unrelated to this change (a wrapped `logger.debug`, an f-string, trailing
  whitespace).

### Behaviour preservation

`tests/test_score_channel.py::TestUnitScoreEquivalence` runs a win, a draw and a
loss through all nine classes twice — once with no payload, once with the unit
scores each result implies — and asserts identical ratings. All existing
known-value tests pass unmodified.

### Mutation checks

Both halves of the score-ordering logic were reverted in turn, and each fails a
**disjoint** set of tests:

| Mutation | Tests that fail |
| --- | --- |
| Arena b-wins branch forwards `validated_scores` instead of `reversed_scores` | 3 (`test_b_wins_branch_reverses_the_pair`, `test_bout_is_still_recorded`, `test_every_competitor_class_accepts_arena_scores`) |
| `lost_to` forwards `validated` instead of the reversed pair | 2 (`test_lost_to_reverses_the_score_pair`, `test_unit_scores_match_the_omitted_score_path`) |

### Docs

`docs/source/quickstart.rst` gains a "Recording Scores" section with one direct
and one arena example; `massey.rst` and `comparison.rst` no longer claim the
margin channel is unavailable.

## Noted, not fixed

`benchmark_competitors` already crashes for `MasseyCompetitor` on `master` —
`evaluate_competitor` forces `_minimum_rating = 0` on the competitor class, and
Massey's ratings are legitimately negative. Reproduced on a clean `master`
checkout, so it is pre-existing and out of scope here.