### PR TITLE
Add the Keener score-based rating system

### DIFF
--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -84,6 +84,15 @@ Massey Competitor
    :show-inheritance:
    :special-members: __init__
 
+Keener Competitor
+-----------------
+
+.. automodule:: elote.competitors.keener
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 Bradley-Terry Competitor
 -----------------------
 

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -49,6 +49,12 @@ Massey Competitor
 .. autoclass:: elote.competitors.massey.MasseyCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Keener Competitor
+-----------------
+
+.. autoclass:: elote.competitors.keener.KeenerCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
 Bradley-Terry Competitor
 ------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/dwz
    rating_systems/colley
    rating_systems/massey
+   rating_systems/keener
    rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -64,6 +64,12 @@ Overview Comparison
      - No
      - Yes
      - Margin-scale sports ranking
+   * - **Keener**
+     - Sports (1993)
+     - Medium
+     - No
+     - Yes
+     - Score-based eigenvector ranking
    * - **Bradley-Terry**
      - Statistics (1952)
      - Medium
@@ -78,8 +84,10 @@ Overview Comparison
      - Complex domains
 
 Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ) update ratings incrementally after each
-result. Global-fit systems (Colley Matrix, Massey and Bradley-Terry) re-solve the whole connected
-group of competitors from the full set of results, which makes them order independent.
+result. Global-fit systems (Colley Matrix, Massey, Keener and Bradley-Terry) re-solve the whole
+connected group of competitors from the full set of results, which makes them order independent.
+Massey and Keener are the two that read the optional score payload; the rest use only who beat
+whom.
 
 Mathematical Formulation
 -----------------------
@@ -106,6 +114,8 @@ Mathematical Formulation
      - Ratings solve :math:`C r = b`; :math:`E_A = \frac{1}{1 + e^{-4 (r_A - r_B)}}`
    * - **Massey**
      - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B)}}`
+   * - **Keener**
+     - Ratings are the dominant eigenvector of :math:`H_{ij} = h(a_{ij}) / g_i + \varepsilon` with :math:`a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}` and :math:`h(x) = \frac{1}{2} + \frac{1}{2}\mathrm{sgn}(x - \frac{1}{2})\sqrt{|2x - 1|}`; :math:`E_A = \frac{r_A}{r_A + r_B}`
    * - **Bradley-Terry**
      - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
    * - **Ensemble**
@@ -136,6 +146,8 @@ Key Parameters
      - Initial rating (default 0.5)
    * - **Massey**
      - Initial rating (default 0.0), Expected-score scale
+   * - **Keener**
+     - Initial rating (default 1.0), Perturbation, Expected-score scale
    * - **Bradley-Terry**
      - Initial rating, Scale, Regularization, Max iterations
    * - **Ensemble**
@@ -265,6 +277,22 @@ Massey
 - Ratings are zero mean, so about half of them are negative
 - Requires a connected schedule to compare competitors
 
+Keener
+^^^^^^
+
+**Strengths:**
+- Reads real scores through a bounded, concave transform, so blowouts inform without dominating
+- Order independent: depends only on the set of results
+- The eigenvector recursion values a win in proportion to the opponent's own rating
+- Perron-Frobenius guarantees a unique positive solution on any connected schedule
+- Ratings are strictly positive and average exactly 1.0
+
+**Weaknesses:**
+- Re-solves the whole connected group after each result
+- Much weaker on outcome-only data, where the unit-score fallback discards its main input
+- The stabilizing perturbation is an extra knob that quietly couples competitors who never met
+- Requires a connected schedule to compare competitors
+
 Bradley-Terry
 ^^^^^^^^^^^^^
 
@@ -312,7 +340,8 @@ Consider the following factors when choosing a rating system:
    - General purpose: Elo or Glicko
 
 3. **Order Independence**: Do you need a ranking that ignores schedule order?
-   - Yes: Colley Matrix, Massey, or Bradley-Terry
+   - Yes: Colley Matrix, Massey, Keener, or Bradley-Terry
+   - Yes, and you have real scores: Massey (linear margin) or Keener (bounded score share)
    - No: any online system (Elo, Glicko, etc.)
 
 4. **Computational Resources**:
@@ -343,6 +372,7 @@ Here's a quick comparison of how to use each system in Elote:
         DWZCompetitor,
         ColleyMatrixCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
         BradleyTerryCompetitor,
         BlendedCompetitor,
     )
@@ -371,6 +401,9 @@ Here's a quick comparison of how to use each system in Elote:
     # Massey (zero-mean margin scale)
     massey_player = MasseyCompetitor()
 
+    # Keener (strictly positive, mean 1.0; reads real scores)
+    keener_player = KeenerCompetitor()
+
     # Bradley-Terry (Elo-compatible scale)
     bt_player = BradleyTerryCompetitor(initial_rating=1500)
 
@@ -387,6 +420,10 @@ Here's a quick comparison of how to use each system in Elote:
     opponent = EloCompetitor(initial_rating=1400)
     print(f"Expected score: {player.expected_score(opponent):.2%}")
     player.beat(opponent)  # record a win
+
+    # Score-based systems additionally accept the optional scores payload
+    home, away = KeenerCompetitor(), KeenerCompetitor()
+    home.beat(away, scores=(35, 3))
 
 Empirical Comparison
 -------------------

--- a/docs/source/rating_systems/keener.rst
+++ b/docs/source/rating_systems/keener.rst
@@ -1,0 +1,254 @@
+Keener Ratings
+==============
+
+Overview
+--------
+
+Keener's method, introduced by James Keener in 1993, is the score-based member of the classical
+global-fit family that also contains the :doc:`Colley Matrix Method <colley>`, :doc:`Massey
+<massey>` and :doc:`Bradley-Terry <bradley_terry>`. Where those three solve a linear system or
+maximize a likelihood, Keener builds a square **preference matrix** from the points competitors
+have scored on one another and reads the ratings off that matrix's dominant eigenvector.
+
+The eigenvector construction is what gives the method its character: a competitor's rating is
+proportional to a weighted average of its opponents' ratings, weighted by how strongly it
+outscored them. Beating a strong opponent is therefore worth more than beating a weak one, and
+the recursion resolves itself globally rather than through a chain of pairwise updates. Like the
+other global-fit systems, the whole connected group is re-solved after every recorded result, so
+the ratings depend only on the set of results and not on the order they arrived in.
+
+How It Works
+------------
+
+Let :math:`S_{ij}` be the total number of points competitor :math:`i` has scored against
+competitor :math:`j` across all their meetings, and :math:`g_i` the number of games :math:`i` has
+played.
+
+**1. Smoothed preference.** Raw score shares are unstable for lopsided or barely-played pairs --
+a single 3-0 result would read as total dominance -- so Keener applies Laplace smoothing:
+
+.. math::
+
+   a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}
+
+**2. Skew transform.** The smoothed share is pushed away from the middle by Keener's skew
+function
+
+.. math::
+
+   h(x) = \frac{1}{2} + \frac{1}{2}\,\mathrm{sgn}\!\left(x - \frac{1}{2}\right)
+          \sqrt{\left|2x - 1\right|}
+
+which is monotone, fixes :math:`0`, :math:`\tfrac{1}{2}` and :math:`1`, and satisfies
+:math:`h(x) + h(1 - x) = 1`, so the matrix stays antisymmetric about :math:`\tfrac{1}{2}`. The
+square root is the point: it damps the influence of very large margins, so running up the score
+has sharply diminishing returns.
+
+**3. Games-played normalization.** Row :math:`i` is divided by :math:`g_i`, making each entry an
+average preference *per game* so that a competitor cannot accumulate rating merely by playing
+more often. Pairs that never met contribute nothing to the row rather than the "no evidence"
+value :math:`h(\tfrac{1}{2}) = \tfrac{1}{2}`; on a sparse schedule those entries would otherwise
+outnumber the real ones and the fit would degenerate into a ranking by :math:`1/g_i`.
+
+**4. Stabilization.** A small positive constant :math:`\varepsilon` (Keener's :math:`\varepsilon
+E` perturbation, default ``1e-4``) is added to every entry:
+
+.. math::
+
+   H_{ij} = \frac{h(a_{ij})\,[\,i \text{ played } j\,]}{g_i} + \varepsilon
+
+This makes :math:`H` strictly positive, so by the Perron-Frobenius theorem its dominant
+eigenvalue is real and simple and the corresponding eigenvector is strictly positive and unique
+up to scale. Without it, a schedule whose match graph is bipartite or otherwise imprimitive has
+no single dominant eigenvector to read, and disconnected sub-groups would have no relation at
+all.
+
+The ratings of a connected group are then that dominant eigenvector, scaled so that they average
+exactly :math:`1.0`:
+
+.. math::
+
+   H\,r = \lambda_{\max}\,r, \qquad \frac{1}{n}\sum_i r_i = 1
+
+Because they are a positive strength scale rather than a probability scale, the expected score is
+the natural share
+
+.. math::
+
+   E_a = \frac{r_a}{r_a + r_b}
+
+computed internally as a logistic of the log rating ratio with a class-configurable scale
+(default 1.0, which is exactly the share above). Two equal ratings give exactly 0.5 and the two
+argument orders sum to exactly 1.0.
+
+Scores
+------
+
+Keener is a score-based method, so supplying real scores is what it is built for. ``beat`` /
+``lost_to`` / ``tied`` accept the common optional ``scores`` payload -- the two competitors'
+scores **in the argument order of the call**:
+
+.. code-block:: python
+
+    from elote import KeenerCompetitor
+
+    team_a, team_b = KeenerCompetitor(), KeenerCompetitor()
+
+    team_a.beat(team_b, scores=(35, 3))
+    # The same game from the loser's side -- the pair is not reordered:
+    # team_b.lost_to(team_a, scores=(3, 35))
+
+Through an arena the pair is always given in ``(a, b)`` order, whichever competitor won, together
+with an explicit ``outcome`` so the two can be checked for agreement:
+
+.. code-block:: python
+
+    from elote import LambdaArena, KeenerCompetitor
+
+    arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+    arena.matchup("Team A", "Team B", outcome=1.0, scores=(35, 3))
+    arena.matchup("Team A", "Team C", outcome=0.0, scores=(7, 24))   # C won; order unchanged
+
+.. note::
+
+   When ``scores`` is omitted, the same unit-score fallback the rest of the library uses applies:
+   the winner is credited ``1`` and the loser ``0``, and a draw credits each side ``0.5``. That
+   keeps Keener usable on outcome-only data and keeps it consistent with every other system, but
+   it discards exactly the information the method is built on -- on win/loss-only data, Colley or
+   Massey will generally be the better choice.
+
+Advantages
+----------
+
+- **Uses Scores**: the only shipped system that reads margin of victory through a nonlinear,
+  bounded transform, so large wins count for more without dominating.
+- **Order Independent**: the ratings depend only on the set of results, not the schedule order.
+- **Strength of Schedule**: the eigenvector recursion values a win in proportion to the opponent's
+  own rating.
+- **Well Grounded**: Perron-Frobenius guarantees a unique positive solution on any connected
+  schedule.
+- **Positive Scale**: ratings are strictly positive and average exactly 1.0, so a rating reads
+  directly as "this many times the population average".
+
+Limitations
+-----------
+
+- **Recomputes Globally**: like Colley, Massey and Bradley-Terry, each result re-solves the whole
+  connected group, which is more expensive than Elo's constant-time update for very large
+  populations.
+- **Weaker Without Scores**: the unit-score fallback keeps it usable on outcome-only data, but it
+  throws away the method's main input.
+- **Perturbation Is a Knob**: the ``eps`` that makes the matrix positive also quietly couples
+  competitors who never met; very small or very large values change the fit.
+- **Connectivity Needed**: groups of competitors that never play each other are rated
+  independently of one another.
+- **No Uncertainty**: like Colley, Massey and Bradley-Terry, the rating is a point estimate with
+  no confidence measure attached.
+
+Comparison with the Other Global-Fit Systems
+--------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+
+   * - System
+     - Uses scores
+     - Rating scale
+     - Fitted by
+   * - **Colley**
+     - No
+     - Bounded [0, 1], mean 0.5
+     - Solving a regularized linear system
+   * - **Massey**
+     - Yes (margin)
+     - Signed, zero mean
+     - Least squares on cumulative margins
+   * - **Bradley-Terry**
+     - No
+     - Elo-compatible
+     - Maximum likelihood over paired outcomes
+   * - **Keener**
+     - Yes (score share)
+     - Strictly positive, mean 1.0
+     - Dominant eigenvector of a preference matrix
+
+Keener and Massey are the two score-based systems, and they use scores very differently. Massey is
+**linear** in the margin: a 35-3 win contributes exactly 32, and a 70-6 win contributes exactly
+64, so a single blowout can move a rating a long way. Keener is **bounded and concave**: the score
+enters only as a share, and the square root in the skew transform means the difference between a
+comfortable win and a rout is small. If you want ratings whose differences read as predicted
+margins, use Massey; if you want scores to inform the ranking without letting one blowout
+dominate it, use Keener.
+
+Against Colley and Bradley-Terry, which see only who beat whom, Keener will usually separate
+evenly-matched records that those two must call equal -- but only when real scores are supplied.
+On outcome-only data Keener's unit-score fallback is strictly less informative than Colley's
+win-percentage model, because the skew transform compresses the single bit of information that is
+left.
+
+Implementation in Elote
+-----------------------
+
+Elote implements Keener Ratings through the ``KeenerCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import KeenerCompetitor
+
+    # Every competitor starts at 1.0, the mean the fitted ratings are normalized to
+    team_a = KeenerCompetitor()
+    team_b = KeenerCompetitor()
+    team_c = KeenerCompetitor()
+
+    # Get win probability
+    print(f"Team A win probability: {team_a.expected_score(team_b):.2%}")
+
+    # Record results; the whole connected group is re-solved after each one
+    team_a.beat(team_b, scores=(28, 7))
+    team_b.beat(team_c, scores=(14, 7))
+    team_a.beat(team_c, scores=(35, 3))
+
+    print(f"Team A: {team_a.rating:.4f}")   # 1.7379
+    print(f"Team B: {team_b.rating:.4f}")   # 0.8349
+    print(f"Team C: {team_c.rating:.4f}")   # 0.4272
+
+Parameters
+^^^^^^^^^^
+
+- ``initial_rating`` (constructor): the rating of a competitor that has not played yet.
+  Default ``1.0``, the mean the fitted ratings are normalized to, so an unplayed competitor sits
+  exactly at the population average. Must be strictly positive.
+
+Class-level parameters, set through ``KeenerCompetitor.configure_class(...)``:
+
+- ``perturbation``: Keener's :math:`\varepsilon`, added to every matrix entry. Default ``1e-4``.
+  Must be positive.
+- ``expected_score_scale``: the logistic scale applied to the log rating ratio by
+  ``expected_score``. Default ``1.0``, which is the plain Keener share; larger values sharpen
+  predictions. Must be positive.
+- ``round_decimals``: the number of decimal places fitted ratings are canonicalized to. Default
+  ``10``. The eigen-solve's row-order noise is around ``5e-15``, five orders of magnitude below
+  this grid, so canonicalizing here is what makes the fit exactly order independent.
+
+State and Serialization
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``export_state()`` records the fitted rating, the win/loss/tie counts, and the aggregate score
+totals ``points_for`` and ``points_against``.
+
+.. warning::
+
+   As with Colley, Massey and Bradley-Terry, the per-opponent match graph holds live object
+   references and cannot be serialized, so it is reset on import. A restored competitor keeps its
+   rating and score totals, but continued play re-fits it from the new results alone rather than
+   from the full history. To resume a population exactly, keep the original competitor objects
+   alive, or re-apply the recorded results to a fresh set.
+
+References
+----------
+
+1. Keener, J. P. (1993). "The Perron-Frobenius Theorem and the Ranking of Football Teams".
+   *SIAM Review*, 35(1), 80-93.
+2. Langville, A. N., & Meyer, C. D. (2012). *Who's #1? The Science of Rating and Ranking*,
+   chapter 4. Princeton University Press.

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -26,6 +26,7 @@ Available rating systems:
 - DWZ: The Deutsche Wertungszahl (German evaluation number) system
 - Colley Matrix: A least-squares rating system that solves a system of linear equations
 - Massey: A least-squares rating system whose ratings live on a signed margin scale
+- Keener: A score-based rating system built on the dominant eigenvector of a preference matrix
 - Bradley-Terry: A maximum-likelihood paired-comparison model
 - Ensemble: A meta-rating system that combines multiple rating systems
 
@@ -48,6 +49,7 @@ from elote.competitors.ecf import ECFCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
 from elote.competitors.massey import MasseyCompetitor
+from elote.competitors.keener import KeenerCompetitor
 from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
@@ -84,6 +86,7 @@ __all__ = [
     "DWZCompetitor",
     "ColleyMatrixCompetitor",
     "MasseyCompetitor",
+    "KeenerCompetitor",
     "BradleyTerryCompetitor",
     "BlendedCompetitor",
     # Arenas

--- a/elote/competitors/keener.py
+++ b/elote/competitors/keener.py
@@ -1,0 +1,542 @@
+"""Keener Ratings implementation for the Elote library.
+
+Keener's method is the score-based member of the classical global-fit family. Where
+:class:`~elote.competitors.colley.ColleyMatrixCompetitor` and
+:class:`~elote.competitors.massey.MasseyCompetitor` solve a linear system, Keener builds a
+square *preference matrix* from the points competitors have scored on one another and reads
+the ratings off that matrix's dominant eigenvector.
+
+The construction has four steps. Let ``S_ij`` be the total number of points ``i`` has scored
+against ``j`` across all their meetings.
+
+1. **Smoothed preference.** Raw score shares are unstable for lopsided or barely-played
+   pairs, so Keener applies Laplace smoothing:
+
+   .. math::
+
+      a_{ij} = \\frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}
+
+   A pair that has never met gives ``a_ij = 1/2`` -- no evidence either way.
+
+2. **Skew transform.** ``a_ij`` is pushed away from the middle by Keener's skew function
+
+   .. math::
+
+      h(x) = \\frac{1}{2} + \\frac{1}{2}\\,\\mathrm{sgn}\\!\\left(x - \\frac{1}{2}\\right)
+             \\sqrt{\\left|2x - 1\\right|}
+
+   which is monotone, fixes ``0``, ``1/2`` and ``1``, and satisfies ``h(x) + h(1 - x) = 1``,
+   so the matrix stays antisymmetric about ``1/2``. Its square root damps the influence of
+   very large margins, which is what stops the method rewarding running up the score without
+   limit.
+
+3. **Games-played normalization.** Row ``i`` is divided by the number of games ``i`` played,
+   so a competitor cannot accumulate rating merely by playing more often.
+
+4. **Stabilization.** A small positive constant is added to every entry. Keener's own
+   ``A + eps * E`` perturbation makes the matrix strictly positive, so Perron-Frobenius
+   applies: the dominant eigenvalue is real and simple and its eigenvector is strictly
+   positive and unique up to scale. Without it a schedule whose graph is bipartite or
+   otherwise imprimitive has no single dominant eigenvector to read.
+
+The ratings of a connected group are then that dominant eigenvector, scaled so they average
+exactly ``1.0``.
+
+References:
+- Keener, J. P. (1993). The Perron-Frobenius Theorem and the Ranking of Football Teams.
+  SIAM Review, 35(1), 80-93.
+- Langville, A. N., & Meyer, C. D. (2012). Who's #1? The Science of Rating and Ranking.
+  Princeton University Press, chapter 4.
+"""
+
+import math
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, List, cast, Set
+
+import numpy as np
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException, InvalidRatingValueException
+from elote.logging import logger
+
+T = TypeVar("T", bound="KeenerCompetitor")
+
+
+class KeenerCompetitor(BaseCompetitor):
+    """Keener Ratings competitor.
+
+    Keener rates a connected population from the dominant eigenvector of a pairwise
+    preference matrix built from points scored. Like Colley, Massey and Bradley-Terry -- and
+    unlike Elo -- ratings are not nudged after each result; the whole connected group is
+    re-fit from the complete match history, which makes the method order independent.
+
+    **Scores.** ``beat`` / ``lost_to`` / ``tied`` accept the common optional ``scores``
+    payload, the two competitors' scores in caller order. Keener is a score-based method, so
+    supplying real scores is what it is built for. When they are omitted the implementation
+    falls back to the same unit scores the rest of the library uses: the winner is credited
+    ``1`` and the loser ``0``, and a draw credits each side ``0.5``. Unit-score Keener still
+    produces a sensible ranking, but it only sees who beat whom.
+
+    Key characteristics:
+    - Global eigenvector fit (does not depend on the order of results)
+    - Ratings are strictly positive and average exactly 1.0 within a connected group
+    - Large margins have a damped, not linear, influence thanks to the skew transform
+
+    Class Attributes:
+        _minimum_rating (float): The minimum allowed rating value. Default: 0.0. Keener
+            ratings are strictly positive, so no Elo-style floor applies.
+        _default_initial_rating (float): Default initial rating. Default: 1.0, which is the
+            mean the fitted ratings are normalized to, so an unplayed competitor sits exactly
+            at the population average.
+        _perturbation (float): Keener's ``eps``, added to every matrix entry so the matrix is
+            strictly positive and Perron-Frobenius applies. Default: 1e-4.
+        _expected_score_scale (float): Logistic scale applied to the log rating ratio by
+            :meth:`expected_score`. Default: 1.0, which is the plain Keener share
+            ``r_a / (r_a + r_b)``.
+        _round_decimals (int): Number of decimal places fitted ratings are canonicalized to,
+            so that solver noise cannot make mathematically identical records differ.
+            Default: 10, chosen because the eigen-solve's row-order noise is around 5e-15 --
+            five orders of magnitude below the rounding grid.
+    """
+
+    _minimum_rating: ClassVar[float] = 0.0
+    _default_initial_rating: ClassVar[float] = 1.0
+    _perturbation: ClassVar[float] = 1e-4
+    _expected_score_scale: ClassVar[float] = 1.0
+    _round_decimals: ClassVar[int] = 10
+
+    # Ratings are strictly positive by construction; this only guards expected_score against
+    # a rating a caller has explicitly set to zero.
+    _probability_floor: ClassVar[float] = 1e-300
+
+    def __init__(self, initial_rating: Optional[float] = None):
+        """Initialize a new Keener competitor.
+
+        Args:
+            initial_rating (float, optional): The initial rating of this competitor.
+                Default: 1.0.
+
+        Raises:
+            InvalidRatingValueException: If the initial rating is not positive.
+        """
+        super().__init__()
+
+        self._initial_rating = initial_rating if initial_rating is not None else self._default_initial_rating
+        if self._initial_rating <= 0:
+            raise InvalidRatingValueException("Keener ratings are strictly positive; initial_rating must be > 0")
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        # Aggregate score totals across every game played. These are the serializable
+        # summary of the score history; the per-opponent breakdown below is not.
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._opponents: Dict["KeenerCompetitor", int] = {}  # Opponent -> num games
+        # Opponent -> total points this competitor has scored against that opponent. This is
+        # the S_ij the preference matrix is built from.
+        self._scores_for: Dict["KeenerCompetitor", float] = {}
+        # Unique ID for hashing (instances are used as dict keys in the match graph).
+        self._id = id(self)
+        logger.debug("Initialized KeenerCompetitor %d with initial rating %.6f", self._id, self._initial_rating)
+
+    @property
+    def rating(self) -> float:
+        """Get the current rating of this competitor.
+
+        Returns:
+            float: The current rating.
+        """
+        return self._rating
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        """Set the current rating of this competitor.
+
+        Args:
+            value (float): The new rating value.
+
+        Raises:
+            InvalidRatingValueException: If the rating value is below the minimum rating.
+        """
+        if value < self._minimum_rating:
+            logger.warning(
+                "Attempted to set rating %.6f below minimum %.6f for %d", value, self._minimum_rating, self._id
+            )
+            raise InvalidRatingValueException(f"Rating cannot be below the minimum rating of {self._minimum_rating}")
+        self._rating = value
+
+    @property
+    def num_games(self) -> int:
+        """Get the total number of games played by this competitor.
+
+        Returns:
+            int: The total number of games played.
+        """
+        return self._wins + self._losses + self._ties
+
+    def expected_score(self, competitor: "BaseCompetitor") -> float:
+        """Calculate the expected score against another competitor.
+
+        Keener ratings are positive strengths rather than probabilities, so the natural
+        mapping is the share ``r_self / (r_self + r_competitor)``. That share is computed
+        here as a logistic of the log rating ratio, which is the same quantity written in a
+        form that is exactly complementary in floating point: two equal ratings give exactly
+        0.5, and the two argument orders sum to exactly 1.0.
+
+        Args:
+            competitor (BaseCompetitor): The competitor to compare against.
+
+        Returns:
+            float: The expected score (probability of winning).
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        mine = max(self.rating, self._probability_floor)
+        theirs = max(competitor.rating, self._probability_floor)
+        log_ratio = math.log(mine) - math.log(theirs)
+        return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * log_ratio)))
+
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has won against the given competitor.
+
+        The scores are recorded in the match graph and the whole connected group is re-fit.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. When omitted the unit scores ``1`` and
+                ``0`` are recorded.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a win for this competitor.
+        """
+        logger.debug("Competitor %s beat %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 1.0)
+        opponent = cast(KeenerCompetitor, competitor)
+        mine, theirs = (1.0, 0.0) if validated is None else validated
+
+        self._wins += 1
+        opponent._losses += 1
+        self._record_game(opponent, mine, theirs)
+
+        logger.debug("Recorded win for %d (%.3f-%.3f), loss for %d", self._id, mine, theirs, opponent._id)
+        self._recalculate_ratings()
+
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has tied with the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They must be equal. When omitted each
+                side is credited the unit draw score ``0.5``.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a draw.
+        """
+        logger.debug("Competitor %s tied with %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.5)
+        opponent = cast(KeenerCompetitor, competitor)
+        mine, theirs = (0.5, 0.5) if validated is None else validated
+
+        self._ties += 1
+        opponent._ties += 1
+        self._record_game(opponent, mine, theirs)
+
+        logger.debug("Recorded tie for %d and %d (%.3f-%.3f)", self._id, opponent._id, mine, theirs)
+        self._recalculate_ratings()
+
+    def lost_to(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that won.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. Reversed before being passed to the
+                winner's :meth:`beat`.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a loss for this competitor.
+        """
+        logger.debug("Competitor %s lost to %s", self, competitor)
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(self, scores=None if validated is None else (validated[1], validated[0]))
+
+    def _record_game(self, opponent: "KeenerCompetitor", mine: float, theirs: float) -> None:
+        """Record one game's scores on both sides of the match graph.
+
+        Args:
+            opponent: The other competitor in the game.
+            mine: The points this competitor scored.
+            theirs: The points the opponent scored.
+        """
+        self._points_for += mine
+        self._points_against += theirs
+        self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._scores_for[opponent] = self._scores_for.get(opponent, 0.0) + mine
+
+        opponent._points_for += theirs
+        opponent._points_against += mine
+        opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._scores_for[self] = opponent._scores_for.get(self, 0.0) + theirs
+
+    def _get_connected_competitors(self) -> List["KeenerCompetitor"]:
+        """Get all competitors connected to this competitor in the match graph.
+
+        Returns:
+            List[KeenerCompetitor]: A list of all connected competitors.
+        """
+        visited: Set["KeenerCompetitor"] = set()
+        to_visit: List["KeenerCompetitor"] = [self]
+        all_competitors = []
+
+        while to_visit:
+            current = to_visit.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            all_competitors.append(current)
+            for opponent in current._opponents:
+                if opponent not in visited:
+                    to_visit.append(opponent)
+
+        logger.debug("Found %d connected competitors", len(all_competitors))
+        return all_competitors
+
+    @classmethod
+    def _preference_matrix(cls, scores: "np.ndarray", pair_games: "np.ndarray", games: "np.ndarray") -> "np.ndarray":
+        """Build Keener's stabilized preference matrix from a raw score matrix.
+
+        Args:
+            scores: ``S``, where ``S[i, j]`` is the total number of points ``i`` scored
+                against ``j``.
+            pair_games: ``G``, where ``G[i, j]`` is the number of games ``i`` played
+                against ``j``.
+            games: The number of games each competitor played in total.
+
+        Returns:
+            numpy.ndarray: The strictly positive preference matrix.
+        """
+        totals = scores + scores.T
+        # Laplace-smoothed score share.
+        proportions = (scores + 1.0) / (totals + 2.0)
+
+        # Keener's skew transform: monotone, fixes 1/2, and h(x) + h(1 - x) == 1.
+        centered = 2.0 * proportions - 1.0
+        preferences = 0.5 + 0.5 * np.sign(centered) * np.sqrt(np.abs(centered))
+
+        # A pair that never met expresses no preference, and neither does a competitor
+        # against itself. Leaving unplayed pairs at the "no evidence" value h(1/2) = 1/2
+        # instead would swamp the row: on a sparse schedule the n - games_i entries for
+        # opponents never faced dominate the games_i real ones, and the fit degenerates
+        # into a ranking by 1 / games_played.
+        preferences = np.where(pair_games > 0, preferences, 0.0)
+        np.fill_diagonal(preferences, 0.0)
+
+        # Divide by games played, making each row the competitor's average preference per
+        # game, so a longer schedule is not itself worth rating.
+        preferences = preferences / np.maximum(games, 1.0)[:, None]
+
+        # Keener's eps * E perturbation: makes the matrix strictly positive, so its dominant
+        # eigenvalue is simple and its eigenvector strictly positive. This is also what
+        # connects competitors who never met, which the mask above disconnected.
+        return cast("np.ndarray", preferences + cls._perturbation)
+
+    def _recalculate_ratings(self) -> None:
+        """Re-fit the Keener ratings for all connected competitors.
+
+        Builds the preference matrix for the connected group, takes the eigenvector of its
+        dominant eigenvalue, and scales the result so the group's ratings average 1.0.
+        """
+        competitors = self._get_connected_competitors()
+        n = len(competitors)
+        if n <= 1:
+            logger.debug("Only one competitor in network, skipping recalculation.")
+            return
+
+        idx = {comp: i for i, comp in enumerate(competitors)}
+
+        scores = np.zeros((n, n), dtype=np.float64)
+        pair_games = np.zeros((n, n), dtype=np.float64)
+        games = np.zeros(n, dtype=np.float64)
+        for i, comp in enumerate(competitors):
+            games[i] = comp.num_games
+            for opponent, points in comp._scores_for.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    scores[i, j] = points
+            for opponent, count in comp._opponents.items():
+                j = idx.get(opponent)
+                if j is not None:
+                    pair_games[i, j] = count
+
+        matrix = self._preference_matrix(scores, pair_games, games)
+
+        try:
+            eigenvalues, eigenvectors = np.linalg.eig(matrix)
+        except np.linalg.LinAlgError as e:
+            logger.warning(
+                "Keener eigenvector solve failed (%s). Falling back to mean-preference ratings for %d competitors.",
+                str(e),
+                n,
+            )
+            self._fallback_rating_calculation(competitors, matrix)
+            return
+
+        # The matrix is strictly positive, so by Perron-Frobenius the eigenvalue of largest
+        # magnitude is real, simple and positive, and its eigenvector can be taken positive.
+        dominant = int(np.argmax(eigenvalues.real))
+        vector = np.real(eigenvectors[:, dominant])
+        if vector.sum() < 0:
+            # LAPACK returns eigenvectors up to sign; orient the Perron vector positive.
+            vector = -vector
+
+        if not np.all(np.isfinite(vector)) or vector.sum() <= 0:
+            logger.warning("Keener eigenvector was degenerate for %d competitors; falling back.", n)
+            self._fallback_rating_calculation(competitors, matrix)
+            return
+
+        vector = np.maximum(vector, self._probability_floor)
+        ratings = vector * (n / vector.sum())
+
+        # LAPACK's pivoting follows row order, and row order is the order competitors were
+        # discovered in, so two runs over the same results can differ in the last few bits.
+        # Canonicalizing makes mathematically identical records compare exactly equal and
+        # makes the fit order independent.
+        ratings = np.round(ratings, decimals=self._round_decimals)
+
+        for i, comp in enumerate(competitors):
+            comp.rating = float(ratings[i])
+
+    def _fallback_rating_calculation(self, competitors: List["KeenerCompetitor"], matrix: "np.ndarray") -> None:
+        """Assign mean-preference ratings when the eigenvector cannot be computed.
+
+        Args:
+            competitors: The connected group of competitors to rate.
+            matrix: The preference matrix that was built for them.
+        """
+        means = matrix.sum(axis=1)
+        total = float(means.sum())
+        n = len(competitors)
+        if total <= 0:
+            values = np.full(n, 1.0)
+        else:
+            values = means * (n / total)
+        for comp, value in zip(competitors, values, strict=True):
+            comp.rating = float(max(value, self._probability_floor))
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        """Export the parameters used to initialize this competitor.
+
+        Returns:
+            dict: A dictionary containing the initialization parameters.
+        """
+        return {
+            "initial_rating": self._initial_rating,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        """Export the current state variables of this competitor.
+
+        Returns:
+            dict: A dictionary containing the current state variables.
+        """
+        return {
+            "rating": self._rating,
+            "wins": self._wins,
+            "losses": self._losses,
+            "ties": self._ties,
+            "points_for": self._points_for,
+            "points_against": self._points_against,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        """Import parameters from a state dictionary.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+        """
+        self._initial_rating = parameters.get("initial_rating", self._default_initial_rating)
+        self._rating = self._initial_rating
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        """Import current state variables from a state dictionary.
+
+        Note: opponent references cannot be restored from serialization, so the match graph is
+        reset; the rating and the aggregate score totals are preserved.
+
+        Args:
+            state (dict): A dictionary containing state variables.
+        """
+        self._rating = state.get("rating", self._initial_rating)
+        self._wins = state.get("wins", 0)
+        self._losses = state.get("losses", 0)
+        self._ties = state.get("ties", 0)
+        self._points_for = state.get("points_for", 0.0)
+        self._points_against = state.get("points_against", 0.0)
+        self._opponents = {}
+        self._scores_for = {}
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        """Create a new competitor instance from parameters.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Returns:
+            KeenerCompetitor: A new competitor instance.
+        """
+        return cls(initial_rating=parameters.get("initial_rating", cls._default_initial_rating))
+
+    def reset(self) -> None:
+        """Reset this competitor to its initial state."""
+        logger.info("Resetting KeenerCompetitor %d to initial state.", self._id)
+        self._rating = self._initial_rating
+        self._wins = 0
+        self._losses = 0
+        self._ties = 0
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._opponents = {}
+        self._scores_for = {}
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        """Configure class-level parameters for this rating system.
+
+        Overrides the base implementation to validate the Keener-specific parameters.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        if "expected_score_scale" in kwargs and kwargs["expected_score_scale"] <= 0:
+            raise InvalidParameterException("expected_score_scale must be positive")
+        if "perturbation" in kwargs and kwargs["perturbation"] <= 0:
+            raise InvalidParameterException("perturbation must be positive")
+        super().configure_class(**kwargs)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<KeenerCompetitor: rating={self._rating:.4f}, W/L/T={self._wins}/{self._losses}/{self._ties}>"
+
+    def __str__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<KeenerCompetitor: rating={self._rating:.4f}>"
+
+    def __eq__(self, other: Any) -> bool:
+        """Check if two competitors are the same object (by unique ID)."""
+        if not isinstance(other, KeenerCompetitor):
+            return NotImplemented
+        return self._id == other._id
+
+    def __hash__(self) -> int:
+        """Get a hash value for this competitor based on its unique ID."""
+        return hash(self._id)

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -11,6 +11,7 @@ from elote import (
     EloCompetitor,
     Glicko2Competitor,
     GlickoCompetitor,
+    KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
     TrueSkillCompetitor,
@@ -299,9 +300,10 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
     )
 
-    # Colley, Massey and Bradley-Terry reset their opponent match graph on import by design
+    # Colley, Massey, Bradley-Terry and Keener reset their opponent match graph on import by design
     # (documented in their own docstrings), so only the incremental systems can be
     # expected to keep rating identically after a restore.
     INCREMENTAL_COMPETITORS = (

--- a/tests/test_KeenerCompetitor.py
+++ b/tests/test_KeenerCompetitor.py
@@ -1,0 +1,291 @@
+"""Behavioural tests for KeenerCompetitor.
+
+Numeric reference values live in tests/test_KeenerCompetitor_known_values.py.
+"""
+
+import json
+import unittest
+
+from elote import KeenerCompetitor, LambdaArena
+from elote.competitors.base import (
+    BaseCompetitor,
+    InvalidParameterException,
+    InvalidRatingValueException,
+    MissMatchedCompetitorTypesException,
+)
+
+
+def _play(schedule, count=3):
+    """Apply a schedule of ``(i, j, score_i, score_j)`` tuples to ``count`` fresh competitors."""
+    competitors = [KeenerCompetitor() for _ in range(count)]
+    for i, j, score_i, score_j in schedule:
+        if score_i > score_j:
+            competitors[i].beat(competitors[j], scores=(score_i, score_j))
+        elif score_i < score_j:
+            competitors[i].lost_to(competitors[j], scores=(score_i, score_j))
+        else:
+            competitors[i].tied(competitors[j], scores=(score_i, score_j))
+    return competitors
+
+
+class TestKeenerBasics(unittest.TestCase):
+    def test_defaults(self):
+        competitor = KeenerCompetitor()
+        self.assertEqual(competitor.rating, 1.0)
+        self.assertEqual(competitor.num_games, 0)
+        self.assertEqual(competitor._points_for, 0.0)
+        self.assertEqual(competitor._points_against, 0.0)
+
+    def test_custom_initial_rating(self):
+        self.assertEqual(KeenerCompetitor(initial_rating=2.5).rating, 2.5)
+
+    def test_non_positive_initial_rating_rejected(self):
+        for bad in (0.0, -1.0):
+            with self.subTest(initial_rating=bad):
+                with self.assertRaises(InvalidRatingValueException):
+                    KeenerCompetitor(initial_rating=bad)
+
+    def test_rating_setter_rejects_values_below_the_floor(self):
+        competitor = KeenerCompetitor()
+        with self.assertRaises(InvalidRatingValueException):
+            competitor.rating = -0.5
+
+    def test_type_mismatch_is_rejected(self):
+        from elote import EloCompetitor
+
+        competitor = KeenerCompetitor()
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.expected_score(EloCompetitor())
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.beat(EloCompetitor())
+
+    def test_registered_for_state_reconstruction(self):
+        self.assertIn("KeenerCompetitor", BaseCompetitor.list_competitor_types())
+        self.assertIs(BaseCompetitor.get_competitor_class("KeenerCompetitor"), KeenerCompetitor)
+
+    def test_configure_class_validates_parameters(self):
+        with self.assertRaises(InvalidParameterException):
+            KeenerCompetitor.configure_class(expected_score_scale=0)
+        with self.assertRaises(InvalidParameterException):
+            KeenerCompetitor.configure_class(perturbation=0)
+
+
+class TestKeenerExpectedScore(unittest.TestCase):
+    def test_two_fresh_competitors_predict_one_half(self):
+        self.assertEqual(KeenerCompetitor().expected_score(KeenerCompetitor()), 0.5)
+
+    def test_predictions_are_exactly_complementary(self):
+        a, b, c = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        for first, second in ((a, b), (b, a), (a, c), (c, b)):
+            with self.subTest(pair=(first.rating, second.rating)):
+                self.assertEqual(first.expected_score(second) + second.expected_score(first), 1.0)
+
+    def test_predictions_stay_in_the_unit_interval_after_lopsided_results(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        for _ in range(12):
+            a.beat(b, scores=(99.0, 0.0))
+            for first, second in ((a, b), (b, a)):
+                score = first.expected_score(second)
+                self.assertGreaterEqual(score, 0.0)
+                self.assertLessEqual(score, 1.0)
+
+    def test_stronger_competitor_is_favoured(self):
+        a, b, _ = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        self.assertGreater(a.rating, b.rating)
+        self.assertGreater(a.expected_score(b), 0.5)
+
+
+class TestKeenerResults(unittest.TestCase):
+    def test_win_updates_both_sides(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+
+        self.assertEqual((a._wins, a._losses, a._ties), (1, 0, 0))
+        self.assertEqual((b._wins, b._losses, b._ties), (0, 1, 0))
+        self.assertEqual((a._points_for, a._points_against), (28.0, 7.0))
+        self.assertEqual((b._points_for, b._points_against), (7.0, 28.0))
+        self.assertGreater(a.rating, b.rating)
+
+    def test_lost_to_records_the_same_game_as_beat(self):
+        winner_first = KeenerCompetitor(), KeenerCompetitor()
+        winner_first[0].beat(winner_first[1], scores=(28.0, 7.0))
+
+        loser_first = KeenerCompetitor(), KeenerCompetitor()
+        loser_first[1].lost_to(loser_first[0], scores=(7.0, 28.0))
+
+        self.assertEqual(loser_first[0].rating, winner_first[0].rating)
+        self.assertEqual(loser_first[1].rating, winner_first[1].rating)
+        self.assertEqual(loser_first[0]._points_for, 28.0)
+        self.assertEqual(loser_first[1]._points_for, 7.0)
+
+    def test_draw_is_symmetric(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.tied(b, scores=(17.0, 17.0))
+
+        self.assertEqual(a.rating, b.rating)
+        self.assertEqual((a._ties, b._ties), (1, 1))
+        self.assertEqual((a._points_for, b._points_for), (17.0, 17.0))
+
+    def test_omitted_scores_fall_back_to_unit_scores(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b)
+        self.assertEqual((a._points_for, a._points_against), (1.0, 0.0))
+
+        c, d = KeenerCompetitor(), KeenerCompetitor()
+        c.tied(d)
+        self.assertEqual((c._points_for, d._points_for), (0.5, 0.5))
+
+    def test_unit_scores_reproduce_the_omitted_score_path(self):
+        plain = KeenerCompetitor(), KeenerCompetitor()
+        plain[0].beat(plain[1])
+        plain[0].tied(plain[1])
+
+        scored = KeenerCompetitor(), KeenerCompetitor()
+        scored[0].beat(scored[1], scores=(1.0, 0.0))
+        scored[0].tied(scored[1], scores=(0.5, 0.5))
+
+        self.assertEqual(plain[0].rating, scored[0].rating)
+        self.assertEqual(plain[1].rating, scored[1].rating)
+
+    def test_margins_matter(self):
+        """A blowout and a one-point win over the same schedule must not fit the same ratings."""
+        blowout = _play([(0, 1, 50, 0), (1, 2, 3, 2)])
+        narrow = _play([(0, 1, 3, 2), (1, 2, 3, 2)])
+        self.assertNotAlmostEqual(blowout[0].rating, narrow[0].rating, places=6)
+
+    def test_ratings_are_positive_and_average_one(self):
+        competitors = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        for competitor in competitors:
+            self.assertGreater(competitor.rating, 0.0)
+        self.assertAlmostEqual(sum(c.rating for c in competitors) / len(competitors), 1.0, places=9)
+
+    def test_disconnected_groups_are_rated_independently(self):
+        a, b, c, d = (KeenerCompetitor() for _ in range(4))
+        a.beat(b, scores=(30.0, 10.0))
+        first_pair = (a.rating, b.rating)
+
+        c.beat(d, scores=(4.0, 3.0))
+        # The second group shares no opponent with the first, so the first is untouched.
+        self.assertEqual((a.rating, b.rating), first_pair)
+        self.assertNotEqual(c.rating, a.rating)
+
+    def test_reset_restores_a_fresh_competitor(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        a.reset()
+
+        fresh = KeenerCompetitor()
+        self.assertEqual(a.rating, fresh.rating)
+        self.assertEqual(a.num_games, 0)
+        self.assertEqual((a._points_for, a._points_against), (0.0, 0.0))
+        self.assertEqual(a._scores_for, {})
+
+
+class TestKeenerOrderIndependence(unittest.TestCase):
+    """The fit must depend on the set of results, not the order they arrived in.
+
+    The fixture below was selected programmatically rather than by hand: a search over
+    random scored schedules kept only one whose RAW solver output differs between the two
+    replay orders (by 5.6e-16 here) while the canonicalized output agrees. A hand-picked
+    schedule usually solves bit-identically in both orders, so the test would pass with the
+    canonicalization deleted and guard nothing.
+    """
+
+    SCHEDULE = [(2, 1, 28, 32), (2, 0, 11, 32), (1, 0, 6, 28), (1, 0, 5, 34)]
+    REPLAY = [(1, 0, 5, 34), (2, 0, 11, 32), (1, 0, 6, 28), (2, 1, 28, 32)]
+
+    def test_replaying_in_a_different_order_gives_identical_ratings(self):
+        first = [c.rating for c in _play(self.SCHEDULE)]
+        second = [c.rating for c in _play(self.REPLAY)]
+        self.assertEqual(first, second)
+
+    def test_the_fixture_is_order_sensitive_without_canonicalization(self):
+        """Guards the guard: with rounding effectively off, the two orders must disagree."""
+        original = KeenerCompetitor._round_decimals
+        try:
+            KeenerCompetitor._round_decimals = 17
+            first = [c.rating for c in _play(self.SCHEDULE)]
+            second = [c.rating for c in _play(self.REPLAY)]
+            self.assertNotEqual(first, second)
+        finally:
+            KeenerCompetitor._round_decimals = original
+
+
+class TestKeenerSerialization(unittest.TestCase):
+    def test_state_round_trip_restores_ratings_and_score_aggregates(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+        a.tied(b, scores=(10.0, 10.0))
+
+        restored = KeenerCompetitor.from_state(a.export_state())
+
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual((restored._wins, restored._losses, restored._ties), (1, 0, 1))
+        self.assertEqual(restored._points_for, 45.0)
+        self.assertEqual(restored._points_against, 13.0)
+
+    def test_json_round_trip(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+
+        restored = KeenerCompetitor.from_json(a.to_json())
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual(restored._points_for, 21.0)
+
+    def test_exported_state_is_json_serializable(self):
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+        self.assertIsInstance(json.dumps(a.export_state()), str)
+
+    def test_match_graph_is_not_restored(self):
+        """Documented limitation, shared with Colley, Massey and Bradley-Terry.
+
+        The opponent graph holds live object references, so it cannot be serialized. A
+        restored competitor keeps its rating and score totals but has no opponents, so
+        continued play re-fits it against only the new results.
+        """
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        restored_a = KeenerCompetitor.from_state(a.export_state())
+        restored_b = KeenerCompetitor.from_state(b.export_state())
+        self.assertEqual(restored_a._scores_for, {})
+        self.assertEqual(restored_a._opponents, {})
+
+        # Continuing play on the restored pair does not reproduce the original pair's fit.
+        restored_a.beat(restored_b, scores=(35.0, 3.0))
+        a.beat(b, scores=(35.0, 3.0))
+        self.assertNotAlmostEqual(restored_a.rating, a.rating, places=6)
+
+
+class TestKeenerArena(unittest.TestCase):
+    def test_arena_round_trip_preserves_the_leaderboard(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b", outcome=1.0, scores=(28.0, 7.0))
+        arena.matchup("b", "c", outcome=1.0, scores=(14.0, 7.0))
+        arena.matchup("a", "c", outcome=0.0, scores=(3.0, 35.0))
+
+        restored = LambdaArena(
+            lambda a, b: True,
+            base_competitor=KeenerCompetitor,
+            initial_state=json.loads(json.dumps(arena.export_state())),
+        )
+        self.assertEqual(restored.leaderboard(), arena.leaderboard())
+
+    def test_arena_forwards_scores_in_competitor_order(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+
+        self.assertEqual(arena.competitors["b"]._points_for, 35.0)
+        self.assertEqual(arena.competitors["a"]._points_for, 3.0)
+        self.assertEqual(arena.competitors["b"]._wins, 1)
+
+    def test_arena_without_scores_uses_unit_fallback(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=KeenerCompetitor)
+        arena.matchup("a", "b")
+        self.assertEqual(arena.competitors["a"]._points_for, 1.0)
+        self.assertEqual(len(arena.history.bouts), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_KeenerCompetitor_known_values.py
+++ b/tests/test_KeenerCompetitor_known_values.py
@@ -1,0 +1,146 @@
+"""Numeric reference values for KeenerCompetitor.
+
+Every value below was calculated independently of ``elote``: the two-competitor cases have a
+closed form (recomputed here from the documented formula), and the three-competitor cases
+were produced by a 60-digit ``decimal`` power iteration written separately from the shipped
+implementation, which uses ``numpy.linalg.eig``.
+
+Recall the construction for a connected group, with ``S_ij`` the points ``i`` scored on ``j``:
+
+    a_ij = (S_ij + 1) / (S_ij + S_ji + 2)                  Laplace-smoothed score share
+    h(x) = 1/2 + 1/2 * sgn(x - 1/2) * sqrt(|2x - 1|)       Keener's skew transform
+    H_ij = h(a_ij) / games_i + eps                         row-normalized, eps = 1e-4
+    r    = dominant eigenvector of H, scaled to mean 1.0
+
+Ratings are canonicalized to ``_round_decimals`` (10) places, so assertions use 9 places.
+"""
+
+import math
+import unittest
+
+from elote import KeenerCompetitor
+
+
+PLACES = 9
+EPS = KeenerCompetitor._perturbation
+
+
+def _skew(share):
+    """Keener's skew transform, written out independently of the implementation."""
+    centered = 2.0 * share - 1.0
+    return 0.5 + 0.5 * math.copysign(math.sqrt(abs(centered)), centered)
+
+
+class TestKeenerKnownValues(unittest.TestCase):
+    def test_single_scored_game_matches_the_two_by_two_closed_form(self):
+        """One 35-3 game between two competitors.
+
+        S = [[0, 35], [3, 0]], so a_01 = 36/40 = 0.9 and a_10 = 4/40 = 0.1, and
+
+            h(0.9) = 1/2 + 1/2*sqrt(0.8),   h(0.1) = 1/2 - 1/2*sqrt(0.8).
+
+        Both played one game, so the row normalization is a no-op and
+
+            H = [[eps, p], [q, eps]]  with  p = h(0.9) + eps, q = h(0.1) + eps.
+
+        For that shape the eigenvalues are eps +/- sqrt(p*q) and the dominant eigenvector is
+        proportional to (sqrt(p), sqrt(q)); scaling to mean 1.0 over n = 2 gives
+
+            r = (2*sqrt(p) / (sqrt(p) + sqrt(q)),  2*sqrt(q) / (sqrt(p) + sqrt(q))).
+        """
+        p = _skew(0.9) + EPS
+        q = _skew(0.1) + EPS
+        root_p, root_q = math.sqrt(p), math.sqrt(q)
+        expected_a = 2.0 * root_p / (root_p + root_q)
+        expected_b = 2.0 * root_q / (root_p + root_q)
+        # Guards the arithmetic above against a silent change in the closed form.
+        self.assertAlmostEqual(expected_a, 1.617757795347885, places=12)
+        self.assertAlmostEqual(expected_b, 0.382242204652116, places=12)
+
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, expected_a, places=PLACES)
+        self.assertAlmostEqual(b.rating, expected_b, places=PLACES)
+
+    def test_single_drawn_game_leaves_both_at_the_population_mean(self):
+        """A drawn game gives a_01 = a_10 = 1/2, so h = 1/2 on both sides and H is symmetric.
+
+        The dominant eigenvector of a symmetric 2x2 with equal off-diagonals is (1, 1),
+        which scales to (1.0, 1.0).
+        """
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.tied(b, scores=(14.0, 14.0))
+
+        self.assertAlmostEqual(a.rating, 1.0, places=PLACES)
+        self.assertAlmostEqual(b.rating, 1.0, places=PLACES)
+
+    def test_asymmetric_scored_schedule(self):
+        """A beat B 28-7, B beat C 14-7, A beat C 35-3.
+
+        Score matrix (rows A, B, C):
+
+            S = [[ 0, 28, 35],
+                 [ 7,  0, 14],
+                 [ 3,  7,  0]]
+
+        so a_AB = 29/37, a_BA = 8/37, a_AC = 36/40, a_CA = 4/40, a_BC = 15/23, a_CB = 8/23.
+        Games played: A two, B two, C two.  Reference ratings from a 60-digit power
+        iteration on the resulting H:
+
+            A = 1.73792467527929154, B = 0.83492367232361227, C = 0.42715165239709619
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        b.beat(c, scores=(14.0, 7.0))
+        a.beat(c, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, 1.73792467527929154, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.83492367232361227, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.42715165239709619, places=PLACES)
+
+    def test_scored_schedule_containing_a_draw(self):
+        """A beat B 30-10, B drew C 14-14, A beat C 21-14.
+
+        The drawn game contributes a_BC = a_CB = 1/2, i.e. h = 1/2 in both directions, and
+        still counts as a game played for both -- which is what pulls C above B here despite
+        C never winning.  Reference ratings from the same 60-digit power iteration:
+
+            A = 1.40226342754892460, B = 0.73428336424082162, C = 0.86345320821025379
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(30.0, 10.0))
+        b.tied(c, scores=(14.0, 14.0))
+        a.beat(c, scores=(21.0, 14.0))
+
+        self.assertAlmostEqual(a.rating, 1.40226342754892460, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.73428336424082162, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.86345320821025379, places=PLACES)
+
+    def test_unit_score_fallback_schedule(self):
+        """A beat B, B beat C, with no score payload at all.
+
+        The unit fallback records 1-0 for each win, so a_AB = 2/3 and h(2/3) = 1/2 +
+        sqrt(1/3)/2 = 0.7886751345948129, with h(1/3) the complement.  A and C never met, so
+        their entries are 0 before the eps perturbation, and B's row is halved because B
+        played twice:
+
+            H = [[eps,      0.7886751 + eps,  eps            ],
+                 [0.1056624 + eps, eps,       0.3943376 + eps],
+                 [eps,      0.2114249 + eps,  eps            ]]
+
+        Reference ratings from the same independent power iteration over that matrix:
+
+            A = 1.67957399744031952, B = 0.86984806605940995, C = 0.45057793650027053
+        """
+        a, b, c = KeenerCompetitor(), KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b)
+        b.beat(c)
+
+        self.assertAlmostEqual(a.rating, 1.67957399744031952, places=PLACES)
+        self.assertAlmostEqual(b.rating, 0.86984806605940995, places=PLACES)
+        self.assertAlmostEqual(c.rating, 0.45057793650027053, places=PLACES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -6,6 +6,8 @@ from elote.competitors.elo import EloCompetitor
 from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.glicko import GlickoCompetitor
 from elote.competitors.trueskill import TrueSkillCompetitor
+from elote.competitors.colley import ColleyMatrixCompetitor
+from elote.competitors.keener import KeenerCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
 from elote.datasets.synthetic import SyntheticDataset
@@ -408,6 +410,46 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
         ratings = [team["rating"] for team in result["top_teams"]]
         self.assertEqual(ratings, sorted(ratings, reverse=True))
         self.assertGreater(ratings[0], ratings[-1])
+
+    def test_keener_runs_end_to_end_through_the_benchmark(self):
+        """Keener is a global-fit system, so the benchmark must not force an initial rating.
+
+        evaluate_competitor detects global-fit classes by the presence of
+        _recalculate_ratings and skips the common start for them; forcing 1500 on a system
+        whose ratings average 1.0 would give degenerate first-bout predictions.
+        """
+        result = evaluate_competitor(
+            competitor_class=KeenerCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=True,
+        )
+
+        competitors = list(result["arena"].competitors.values())
+        self.assertGreater(len(competitors), 0)
+        for competitor in competitors:
+            self.assertEqual(competitor._initial_rating, KeenerCompetitor._default_initial_rating)
+            self.assertGreater(competitor.rating, 0.0)
+
+        self.assertGreater(result["accuracy"], 0.5)
+        self.assertGreaterEqual(result["accuracy_opt"], result["accuracy"])
+
+    def test_keener_can_be_compared_against_another_global_fit_system(self):
+        """benchmark_competitors must accept Keener alongside its siblings."""
+        results = benchmark_competitors(
+            [
+                {"class": KeenerCompetitor, "name": "Keener", "params": {}},
+                {"class": ColleyMatrixCompetitor, "name": "Colley", "params": {}},
+            ],
+            self.data_split,
+            _always_true,
+            optimize_thresholds=False,
+        )
+
+        self.assertEqual([entry["name"] for entry in results], ["Keener", "Colley"])
+        for entry in results:
+            with self.subTest(system=entry["name"]):
+                self.assertGreater(entry["accuracy"], 0.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -2,7 +2,7 @@
 
 The score channel is cross-cutting: every competitor class must accept it, malformed
 payloads must be rejected before anything mutates, and the arena must forward the pair in
-the right competitor order. Systems that actually consume a score (currently Massey) are
+the right competitor order. Systems that actually consume a score (Massey and Keener) are
 covered here for the plumbing and in their own known-value file for the numbers.
 """
 
@@ -16,6 +16,7 @@ from elote import (
     EloCompetitor,
     Glicko2Competitor,
     GlickoCompetitor,
+    KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
     TrueSkillCompetitor,
@@ -37,6 +38,7 @@ COMPETITOR_CLASSES = (
     ColleyMatrixCompetitor,
     BradleyTerryCompetitor,
     MasseyCompetitor,
+    KeenerCompetitor,
 )
 
 # A win, a draw and a loss, with the unit scores each result implies.

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -10,6 +10,7 @@ from elote import (
     ColleyMatrixCompetitor,
     BradleyTerryCompetitor,
     MasseyCompetitor,
+    KeenerCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -435,6 +436,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
         ColleyMatrixCompetitor,
         BradleyTerryCompetitor,
         MasseyCompetitor,
+        KeenerCompetitor,
     )
 
     # A lopsided run: long enough that a one-sided rating gap opens up, with


### PR DESCRIPTION
Closes #123

> **Stacked on #124** (issue #122, the optional score channel), which had no
> branch when this was implemented. This PR is based on `autopilot/issue-122`,
> so the diff shown here is Keener only. GitHub will retarget it to `master`
> automatically once #124 merges. **#124 must land first.**

Adds `KeenerCompetitor` as a normal registered `BaseCompetitor` implementation —
the fourth global-fit system, alongside Colley, Massey and Bradley-Terry, and the
second that reads real scores.

## The algorithm

With `S_ij` the total points `i` scored on `j` and `g_i` the games `i` played:

1. **Laplace-smoothed share** `a_ij = (S_ij + 1) / (S_ij + S_ji + 2)`.
2. **Keener's skew transform** `h(x) = ½ + ½·sgn(x − ½)·√|2x − 1|` — monotone,
   fixes ½, satisfies `h(x) + h(1−x) = 1`. The square root is the point: it damps
   large margins so running up the score has diminishing returns.
3. **Games-played normalization** — row `i` is divided by `g_i`, making each entry
   an average preference per game.
4. **Stabilization** — `+ eps` (default `1e-4`) on every entry, Keener's `eps·E`
   perturbation, so the matrix is strictly positive and Perron-Frobenius gives a
   simple dominant eigenvalue with a unique strictly-positive eigenvector.

Ratings are that eigenvector, scaled so a connected group averages exactly `1.0`.
`expected_score` is the Keener share `r_a / (r_a + r_b)`, written as a logistic of
the log rating ratio so it is exactly complementary in floating point.

**One deliberate departure from the textbook write-up.** Pairs that never met
contribute `0` to a row rather than the neutral `h(½) = ½`. Keeping them at ½ is
harmless on the round-robin schedules the literature uses, but on a sparse
schedule the `n − g_i` entries for opponents never faced swamp the `g_i` real
ones, and dividing by `g_i` then makes the fit a ranking by `1/games_played`.
Measured on `SyntheticDataset(20, 200, seed=42).time_split(0.3)`: the unmasked
form gave accuracy **0.5167** with a top-3 of the three fewest-played competitors
(8, 8, 9 games); the masked form gives **0.8333** with a top-3 matching Colley's
and Massey's exactly. The `eps` perturbation is what re-couples unmet pairs.
Documented in the module, the class and the Sphinx page.

## Scores

Uses the optional payload from #124, with the same unit fallback as the rest of
the library when it is omitted: `1/0` for a win, `0.5/0.5` for a draw. No
Keener-only public method; the class satisfies the full `BaseCompetitor`
interface.

## Verification

Ran from a clean worktree with `env -u VIRTUAL_ENV uv run --extra dev`:

- `pytest -q --ignore=tests/test_examples.py` → **386 passed, 6 skipped**
  (350 on the #124 branch point + 36 new). `tests/test_examples.py` is the
  repository's documented environment-only failure and was excluded.
- `ruff check elote tests` → All checks passed.
- `ruff format --check` on every file this PR touches → all conformant.
- `mypy --python-version 3.12 elote` → Success, no issues in 26 source files.
- Sphinx: `python -m sphinx -b html docs/source /tmp/out` → build succeeded,
  496 warnings vs **484 on the branch point**. The 12 new ones all come from the
  new module's `References:` / `Key characteristics:` bare-bullet docstrings, the
  same pattern every sibling competitor module produces (Colley 7, Bradley-Terry
  11, Massey 13). `keener.rst` itself produces zero.

### Independently calculated fixtures

Every literal in `tests/test_KeenerCompetitor_known_values.py` was computed
**without `elote`**. The two-competitor cases have a closed form — for
`H = [[eps, p], [q, eps]]` the dominant eigenvector is `(√p, √q)` — recomputed in
the test from the documented formula. The three-competitor cases come from a
60-digit `decimal` power iteration written separately from the shipped
implementation, which uses `numpy.linalg.eig`. Assertions are to 9 places,
against a 10-place canonicalization grid.

Covered: an asymmetric scored schedule (28-7, 14-7, 35-3), a schedule containing
a draw (30-10, 14-14 draw, 21-14), a single scored game, a single drawn game, and
the unit-score fallback. Values, not orderings.

> Writing that reference surfaced a trap worth recording: a plain power iteration
> **oscillates** on a near-bipartite preference matrix (`λ₂ ≈ −λ₁`) and returns a
> confidently wrong answer rather than failing. The reference iterates on `H + I`,
> which has the same eigenvectors with the oscillation removed. The disagreement
> with `numpy.linalg.eig` is what exposed it.

### Order independence

`_round_decimals = 10` was chosen by measurement, not by copying Massey's 13.
Over **1064 random scored schedules** replayed in two orders through the real
class, the raw solver output is order-dependent in **968** of them (LAPACK pivots
on row order, and row order is the graph-walk order). After canonicalization:
9, 10 and 11 places give **0** mismatches; 12 gives 6. Raw deltas are ~5e-15,
five orders of magnitude below the 1e-10 grid.

The order-independence fixture was **selected programmatically**, not by hand: a
search kept only a schedule whose raw output differs between the two replay
orders while the canonicalized output agrees. A hand-picked schedule usually
solves bit-identically in both orders, so the test would pass with the
canonicalization deleted. `test_the_fixture_is_order_sensitive_without_canonicalization`
asserts that property directly, so the guard cannot silently go vacuous.

### Mutation checks

Every part of the algorithm was reverted in turn and the suite re-run (bytecode
cleared each time; baseline green after restore, 51 passed):

| Mutation | Tests failed |
| --- | --- |
| Drop the skew transform (use the raw share) | 4 |
| Change the Laplace smoothing constant | 4 |
| Drop the games-played normalization | 3 |
| Drop the never-met mask | 1 |
| Remove the `eps` perturbation | 4 |
| Remove the canonicalization | 1 |
| Ignore the score payload in `beat` | 10 |
| Don't reverse the pair in `lost_to` | 4 |
| Transpose the score matrix | 6 |

The canonicalization is guarded by exactly one test — the order-independence one
above — which is why its companion vacuity check matters.

### Other acceptance items

- Two fresh competitors predict exactly `0.5`; opposite-order predictions sum to
  exactly `1.0`; predictions stay in `[0, 1]` through twelve consecutive 99-0
  wins.
- State export/import restores the rating, the W/L/T counts and the `points_for`
  / `points_against` aggregates. The per-opponent match graph holds live object
  references and cannot be serialized, so it resets on import — the same
  documented limitation Colley, Massey and Bradley-Terry carry. It is tested
  explicitly (`test_match_graph_is_not_restored`) and documented in the module,
  the class docstring and a `.. warning::` on the Sphinx page.
- Added to `tests/test_unified_interface.py::TestExpectedScoreBounds`,
  `tests/test_Arenas.py::TestArenaStateRoundTrip`, the cross-class score-channel
  sweep, and two new end-to-end tests in `tests/test_benchmark_module.py` (one
  running Keener through `evaluate_competitor`, one comparing it against Colley
  via `benchmark_competitors`).
- No numeric reference for any other algorithm changed.

### Docs

New `docs/source/rating_systems/keener.rst` covers the matrix, the skew
transform, the score requirement and fallback, all parameters, strengths,
weaknesses, and a direct comparison with Colley, Massey and Bradley-Terry —
including when *not* to reach for Keener (on outcome-only data its unit-score
fallback is strictly less informative than Colley's win-percentage model, because
the skew transform compresses the one bit that is left). Also wired into
`index.rst`, `competitors.rst`, `api/competitors.rst` and eight places in
`comparison.rst`.