### PR TITLE
Preserve native rating floors in benchmarks

### DIFF
--- a/elote/benchmark.py
+++ b/elote/benchmark.py
@@ -120,8 +120,10 @@ def evaluate_competitor(
     mutated_class_vars = ["_minimum_rating"] + [f"_{param}" for param in competitor_params]
 
     with _restored_class_vars(competitor_class, mutated_class_vars):
-        # Set common parameters
-        arena.set_competitor_class_var("_minimum_rating", 0)
+        # Preserve the native scale of global-fit systems, whose fitted ratings may be
+        # signed. Incremental systems retain the benchmark's common zero floor.
+        if not hasattr(competitor_class, "_recalculate_ratings"):
+            arena.set_competitor_class_var("_minimum_rating", 0)
 
         # Set any additional parameters
         for param, value in competitor_params.items():

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -7,6 +7,7 @@ from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.glicko import GlickoCompetitor
 from elote.competitors.trueskill import TrueSkillCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
+from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.keener import KeenerCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
@@ -433,6 +434,33 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
 
         self.assertGreater(result["accuracy"], 0.5)
         self.assertGreaterEqual(result["accuracy_opt"], result["accuracy"])
+
+    def test_massey_preserves_signed_ratings_through_benchmark_paths(self):
+        """Massey's zero-mean scale must survive both public benchmark entry points."""
+        result = evaluate_competitor(
+            competitor_class=MasseyCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=False,
+        )
+
+        ratings = [competitor.rating for competitor in result["arena"].competitors.values()]
+        self.assertLess(min(ratings), 0.0)
+        self.assertGreater(max(ratings), 0.0)
+        self.assertEqual(len(result["history"].bouts), 60)
+        self.assertEqual(result["confusion_matrix"], {"tp": 28, "fp": 1, "tn": 29, "fn": 2})
+        self.assertEqual(result["accuracy"], 0.95)
+
+        results = benchmark_competitors(
+            [{"class": MasseyCompetitor, "name": "Massey", "params": {}}],
+            self.data_split,
+            _always_true,
+            optimize_thresholds=False,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "Massey")
+        self.assertEqual(results[0]["accuracy"], result["accuracy"])
 
     def test_keener_can_be_compared_against_another_global_fit_system(self):
         """benchmark_competitors must accept Keener alongside its siblings."""


### PR DESCRIPTION
Closes #126

## Summary

- preserve native minimum-rating semantics for global-fit competitors during benchmarking
- retain the temporary zero-floor override and class-variable restoration for incremental systems
- add an end-to-end Massey regression covering both public benchmark entry points, signed ratings, exact metrics, and bout accounting

## Verification

- `PYTHONDONTWRITEBYTECODE=1 env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 387 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — passed
- `env -u VIRTUAL_ENV uv run --extra dev ruff format --check elote/benchmark.py tests/test_benchmark_module.py` — passed
- Mutation check: reinstating the unconditional `_minimum_rating = 0` override makes the focused Massey regression fail with `InvalidRatingValueException` on a fitted rating of -0.5
