### PR TITLE
Let Glicko-1 and Glicko-2 replay historical dated matches

### DIFF
--- a/elote/competitors/glicko.py
+++ b/elote/competitors/glicko.py
@@ -37,7 +37,9 @@ class GlickoCompetitor(BaseCompetitor):
         Args:
             initial_rating (float, optional): The initial rating of this competitor. Default: 1500.
             initial_rd (float, optional): The initial rating deviation of this competitor. Default: 350.
-            initial_time (datetime, optional): The initial timestamp for this competitor. Default: current time.
+            initial_time (datetime, optional): The initial timestamp for this competitor. When omitted the
+                competitor has no recorded activity and adopts the time of its first match, so a stream of
+                historical results can be replayed through it.
 
         Raises:
             InvalidRatingValueException: If the initial rating is below the minimum rating.
@@ -56,12 +58,12 @@ class GlickoCompetitor(BaseCompetitor):
         self._initial_rd = initial_rd
         self._rating = initial_rating
         self.rd = initial_rd
-        self._last_activity = initial_time if initial_time is not None else datetime.now()
+        self._last_activity: Optional[datetime] = initial_time
         logger.debug(
             "Initialized GlickoCompetitor with rating=%.1f, rd=%.1f, time=%s",
             self._initial_rating,
             self._initial_rd,
-            self._last_activity.isoformat(),
+            self._last_activity,
         )
 
     def __repr__(self) -> str:
@@ -100,7 +102,7 @@ class GlickoCompetitor(BaseCompetitor):
         return {
             "rating": self._rating,
             "rd": self.rd,
-            "last_activity": self._last_activity.isoformat(),
+            "last_activity": self._last_activity.isoformat() if self._last_activity is not None else None,
         }
 
     def _import_parameters(self, parameters: Dict[str, Any]) -> None:
@@ -151,9 +153,11 @@ class GlickoCompetitor(BaseCompetitor):
             raise InvalidParameterException("RD must be positive")
         self.rd = rd
 
-        # Set last activity time
+        # Set last activity time. An explicit null means the competitor has never been active,
+        # while a missing key belongs to a state document written before that was representable.
         if "last_activity" in state:
-            self._last_activity = datetime.fromisoformat(state["last_activity"])
+            last_activity = state["last_activity"]
+            self._last_activity = datetime.fromisoformat(last_activity) if last_activity is not None else None
         else:
             self._last_activity = datetime.now()
             logger.warning(
@@ -238,7 +242,7 @@ class GlickoCompetitor(BaseCompetitor):
         )
         self._rating = self._initial_rating
         self.rd = self._initial_rd
-        self._last_activity = datetime.now()
+        self._last_activity = None
 
     @property
     def rating(self) -> float:
@@ -379,11 +383,12 @@ class GlickoCompetitor(BaseCompetitor):
         current_time = match_time if match_time is not None else datetime.now()
 
         logger.debug("Computing match result for %s vs %s (score=%.1f, time=%s)", self, competitor, s, current_time)
-        # Validate match time is not before last activity
-        if current_time < self._last_activity:
+        # Validate match time is not before last activity. A competitor with no recorded
+        # activity adopts this match's time rather than being compared against it.
+        if self._last_activity is not None and current_time < self._last_activity:
             logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
             raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor._last_activity:
+        if competitor._last_activity is not None and current_time < competitor._last_activity:
             logger.error("Match time %s is before opponent last activity %s", current_time, competitor._last_activity)
             raise InvalidParameterException("Match time cannot be before opponent's last activity time")
 
@@ -444,7 +449,7 @@ class GlickoCompetitor(BaseCompetitor):
         logger.debug("Calculated new RD for %s: %.1f", self, s_new_rd)
         return s_new_r, s_new_rd
 
-    def update_rd_for_inactivity(self, current_time: datetime = None) -> None:
+    def update_rd_for_inactivity(self, current_time: Optional[datetime] = None) -> None:
         """Update the rating deviation based on time elapsed since last activity.
 
         This implements Glickman's formula for increasing uncertainty in ratings
@@ -455,6 +460,14 @@ class GlickoCompetitor(BaseCompetitor):
             current_time (datetime, optional): The current time to calculate inactivity against.
                 If None, uses the current system time.
         """
+        # A competitor with no recorded activity has nothing to be inactive since. It adopts an
+        # explicitly supplied time as its first activity, and stays inactive otherwise so that a
+        # historical replay is still possible afterwards.
+        if self._last_activity is None:
+            if current_time is not None:
+                self._last_activity = current_time
+            return
+
         if current_time is None:
             current_time = datetime.now()
 

--- a/elote/competitors/glicko2.py
+++ b/elote/competitors/glicko2.py
@@ -58,7 +58,9 @@ class Glicko2Competitor(BaseCompetitor):
             initial_rating (float, optional): The initial rating of this competitor. Default: 1500.
             initial_rd (float, optional): The initial rating deviation of this competitor. Default: 350.
             initial_volatility (float, optional): The initial volatility of this competitor. Default: _default_volatility.
-            initial_time (datetime, optional): The initial timestamp for this competitor. Default: current time.
+            initial_time (datetime, optional): The initial timestamp for this competitor. When omitted the
+                competitor has no recorded activity and adopts the time of its first match, so a stream of
+                historical results can be replayed through it.
 
         Raises:
             InvalidRatingValueException: If the initial rating is below the minimum rating.
@@ -93,7 +95,7 @@ class Glicko2Competitor(BaseCompetitor):
 
         # Store match results for rating period and track last activity
         self._match_results: List[_MatchResult] = []
-        self._last_activity = initial_time if initial_time is not None else datetime.now()
+        self._last_activity: Optional[datetime] = initial_time
 
         logger.debug(
             "Initialized Glicko2Competitor: rating=%.1f, rd=%.1f, volatility=%.3f, mu=%.3f, phi=%.3f, time=%s",
@@ -102,7 +104,7 @@ class Glicko2Competitor(BaseCompetitor):
             self._sigma,
             self._mu,
             self._phi,
-            self._last_activity.isoformat(),
+            self._last_activity,
         )
 
     def __repr__(self) -> str:
@@ -145,7 +147,7 @@ class Glicko2Competitor(BaseCompetitor):
             "volatility": self._sigma,
             "mu": self._mu,
             "phi": self._phi,
-            "last_activity": self._last_activity.isoformat(),
+            "last_activity": self._last_activity.isoformat() if self._last_activity is not None else None,
         }
 
     def _import_parameters(self, parameters: Dict[str, Any]) -> None:
@@ -212,9 +214,11 @@ class Glicko2Competitor(BaseCompetitor):
         self._mu = state.get("mu", self._rating_to_mu(rating))
         self._phi = state.get("phi", self._rd_to_phi(rd))
 
-        # Set last activity time
+        # Set last activity time. An explicit null means the competitor has never been active,
+        # while a missing key belongs to a state document written before that was representable.
         if "last_activity" in state:
-            self._last_activity = datetime.fromisoformat(state["last_activity"])
+            last_activity = state["last_activity"]
+            self._last_activity = datetime.fromisoformat(last_activity) if last_activity is not None else None
         else:
             self._last_activity = datetime.now()
             logger.warning(
@@ -322,7 +326,7 @@ class Glicko2Competitor(BaseCompetitor):
         self._mu = self._rating_to_mu(self._initial_rating)
         self._phi = self._rd_to_phi(self._initial_rd)
         self._match_results = []
-        self._last_activity = datetime.now()
+        self._last_activity = None
 
     @property
     def rating(self) -> float:
@@ -503,6 +507,14 @@ class Glicko2Competitor(BaseCompetitor):
             current_time (datetime, optional): The current time to calculate inactivity against.
                 If None, uses the current system time.
         """
+        # A competitor with no recorded activity has nothing to be inactive since. It adopts an
+        # explicitly supplied time as its first activity, and stays inactive otherwise so that a
+        # historical replay is still possible afterwards.
+        if self._last_activity is None:
+            if current_time is not None:
+                self._last_activity = current_time
+            return
+
         if current_time is None:
             current_time = datetime.now()  # type: ignore[unreachable]
 
@@ -735,11 +747,12 @@ class Glicko2Competitor(BaseCompetitor):
         """
         current_time = match_time if match_time is not None else datetime.now()
 
-        # Validate match time is not before last activity
-        if current_time < self._last_activity:
+        # Validate match time is not before last activity. A competitor with no recorded
+        # activity adopts this match's time rather than being compared against it.
+        if self._last_activity is not None and current_time < self._last_activity:
             logger.error("Match time %s is before self last activity %s", current_time, self._last_activity)
             raise InvalidParameterException("Match time cannot be before competitor's last activity time")
-        if current_time < competitor._last_activity:
+        if competitor._last_activity is not None and current_time < competitor._last_activity:
             logger.error("Match time %s is before opponent last activity %s", current_time, competitor._last_activity)
             raise InvalidParameterException("Match time cannot be before opponent's last activity time")
 

--- a/tests/test_Glicko2Competitor.py
+++ b/tests/test_Glicko2Competitor.py
@@ -1,4 +1,6 @@
 import unittest
+from datetime import datetime, timedelta
+
 from elote import Glicko2Competitor
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -152,8 +154,14 @@ class TestGlicko2(unittest.TestCase):
         # Check that the ratings have changed
         self.assertNotEqual(player1.rating, pre_match_rating1)
 
-        # Test that update_ratings with no matches increases RD
-        player3 = Glicko2Competitor(initial_rating=1800, initial_rd=100, initial_volatility=0.06)
+        # Test that update_ratings with no matches increases RD over the elapsed time. The
+        # competitor needs a recorded prior activity for there to be an elapsed period at all.
+        player3 = Glicko2Competitor(
+            initial_rating=1800,
+            initial_rd=100,
+            initial_volatility=0.06,
+            initial_time=datetime.now() - timedelta(days=10),
+        )
         initial_rd = player3.rd
         player3.update_ratings()  # No matches, should increase RD
         self.assertGreater(player3.rd, initial_rd)

--- a/tests/test_glicko_historical_time.py
+++ b/tests/test_glicko_historical_time.py
@@ -1,0 +1,177 @@
+"""Tests for replaying historical, dated results through the Glicko rating systems.
+
+Glicko-1 and Glicko-2 are the two systems whose rating deviation inflates over elapsed
+time, so they are the two that accept ``match_time``. A competitor that has never played
+has no activity to compare a match time against: it adopts the time of its first match.
+That is what makes ``LambdaArena.matchup(..., match_time=...)`` usable on historical data,
+where competitors are created lazily and every timestamp is in the past.
+"""
+
+import unittest
+from datetime import datetime, timedelta
+
+from elote import Glicko2Competitor, GlickoCompetitor, LambdaArena
+from elote.competitors.base import InvalidParameterException
+
+
+def _always_true(a, b, attributes=None):
+    """Comparison function that always awards the win to the first competitor."""
+    return True
+
+
+COMPETITOR_CLASSES = (GlickoCompetitor, Glicko2Competitor)
+
+# A dated schedule far enough in the past that it can never be mistaken for wall-clock now,
+# spanning months and given in increasing order.
+START = datetime(2024, 1, 1)
+SCHEDULE = (
+    ("a", "b", START),
+    ("b", "c", START + timedelta(days=45)),
+    ("a", "c", START + timedelta(days=120)),
+    ("c", "b", START + timedelta(days=200)),
+    ("a", "b", START + timedelta(days=280)),
+)
+
+
+def _replay(competitor_class, schedule):
+    """Run a dated schedule through a fresh arena and return it."""
+    arena = LambdaArena(_always_true, base_competitor=competitor_class)
+    for a, b, match_time in schedule:
+        arena.matchup(a, b, match_time=match_time)
+    return arena
+
+
+class TestHistoricalMatchups(unittest.TestCase):
+    def test_first_matchup_accepts_a_past_timestamp(self):
+        """A lazily created competitor takes its first match's time, however old."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                arena = LambdaArena(_always_true, base_competitor=competitor_class)
+                arena.matchup("x", "y", match_time=datetime(2024, 1, 1))
+
+                self.assertEqual(arena.competitors["x"]._last_activity, datetime(2024, 1, 1))
+                self.assertEqual(arena.competitors["y"]._last_activity, datetime(2024, 1, 1))
+
+    def test_dated_replay_inflates_rd_relative_to_a_gapless_replay(self):
+        """The elapsed months between historical matches actually inflate RD."""
+        gapless = tuple((a, b, START) for a, b, _ in SCHEDULE)
+
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                spread = _replay(competitor_class, SCHEDULE)
+                simultaneous = _replay(competitor_class, gapless)
+
+                for name in ("a", "b", "c"):
+                    self.assertGreater(
+                        spread.competitors[name].rd,
+                        simultaneous.competitors[name].rd,
+                        f"{name} should be less certain after months of gaps",
+                    )
+
+    def test_out_of_order_match_still_raises(self):
+        """A second match dated before the first is still rejected."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                arena = LambdaArena(_always_true, base_competitor=competitor_class)
+                arena.matchup("x", "y", match_time=datetime(2024, 6, 1))
+
+                with self.assertRaises(InvalidParameterException):
+                    arena.matchup("x", "y", match_time=datetime(2024, 5, 31))
+
+    def test_out_of_order_match_raises_for_the_opponent_too(self):
+        """The guard covers a competitor that is stale only via the opponent."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                arena = LambdaArena(_always_true, base_competitor=competitor_class)
+                arena.matchup("x", "y", match_time=datetime(2024, 6, 1))
+
+                # "z" has never played, so only "y" carries a last-activity time here.
+                with self.assertRaises(InvalidParameterException):
+                    arena.matchup("z", "y", match_time=datetime(2024, 5, 31))
+
+    def test_match_time_none_is_unaffected(self):
+        """Omitting match_time keeps working and stamps wall-clock activity."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                before = datetime.now()
+                arena = LambdaArena(_always_true, base_competitor=competitor_class)
+                arena.matchup("x", "y")
+                after = datetime.now()
+
+                for name in ("x", "y"):
+                    self.assertIsNotNone(arena.competitors[name]._last_activity)
+                    self.assertGreaterEqual(arena.competitors[name]._last_activity, before)
+                    self.assertLessEqual(arena.competitors[name]._last_activity, after)
+
+    def test_explicit_initial_time_still_bounds_matches(self):
+        """A competitor constructed with initial_time keeps rejecting earlier matches."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                first = competitor_class(initial_time=datetime(2024, 6, 1))
+                second = competitor_class(initial_time=datetime(2024, 6, 1))
+
+                with self.assertRaises(InvalidParameterException):
+                    first.beat(second, match_time=datetime(2024, 5, 1))
+
+
+class TestHistoricalStateRoundTrip(unittest.TestCase):
+    """A never-played competitor and a played one must both survive serialization."""
+
+    def test_never_played_competitor_round_trips_and_accepts_history(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                fresh = competitor_class()
+                state = fresh.export_state()
+                self.assertIsNone(state["state"]["last_activity"])
+
+                restored = competitor_class.from_state(state)
+                self.assertIsNone(restored._last_activity)
+
+                # The restored competitor can still start its history in the past.
+                restored.beat(competitor_class.from_state(state), match_time=datetime(2024, 1, 1))
+                self.assertEqual(restored._last_activity, datetime(2024, 1, 1))
+
+    def test_played_competitor_round_trips_and_continues_identically(self):
+        follow_up = START + timedelta(days=365)
+
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                original = _replay(competitor_class, SCHEDULE)
+                restored = LambdaArena(
+                    _always_true,
+                    base_competitor=competitor_class,
+                    initial_state=original.export_state(),
+                )
+
+                for name in ("a", "b", "c"):
+                    self.assertAlmostEqual(restored.competitors[name].rating, original.competitors[name].rating)
+                    self.assertAlmostEqual(restored.competitors[name].rd, original.competitors[name].rd)
+
+                # Continue play on both with an explicit match time, so wall-clock drift
+                # between the two arenas cannot enter the comparison.
+                original.matchup("a", "c", match_time=follow_up)
+                restored.matchup("a", "c", match_time=follow_up)
+
+                for name in ("a", "c"):
+                    self.assertAlmostEqual(restored.competitors[name].rating, original.competitors[name].rating)
+                    self.assertAlmostEqual(restored.competitors[name].rd, original.competitors[name].rd)
+
+    def test_legacy_state_without_last_activity_still_imports(self):
+        """A state document written before null activity was representable is unchanged."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                state = competitor_class(initial_time=datetime(2024, 1, 1)).export_state()
+                del state["state"]["last_activity"]
+                del state["last_activity"]
+
+                before = datetime.now()
+                restored = competitor_class.from_state(state)
+                after = datetime.now()
+
+                self.assertIsNotNone(restored._last_activity)
+                self.assertGreaterEqual(restored._last_activity, before)
+                self.assertLessEqual(restored._last_activity, after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #101

## What changed

`GlickoCompetitor` and `Glicko2Competitor` stamped `self._last_activity` with `datetime.now()` in
`__init__`. `LambdaArena` creates competitors lazily and has no way to supply a per-competitor
`initial_time`, so every competitor was born "active now" and the out-of-order guard in
`_compute_match_result` rejected the first real match on any historical timestamp — which is every
timestamp the repo's datasets produce.

`_last_activity` is now `Optional[datetime]` and starts as `None` when no `initial_time` is given:

- `_compute_match_result` compares against `_last_activity` only when there is one; a competitor with
  no recorded activity adopts the supplied `current_time` as its first activity. The
  `InvalidParameterException` still fires for a genuinely out-of-order match, on either side of the pair.
- `update_rd_for_inactivity` returns early for a never-active competitor (there is no elapsed period to
  inflate over), adopting an explicitly supplied time. With no time supplied it leaves the competitor
  inactive, so `Glicko2Competitor.update_ratings()` on an unplayed competitor does not silently stamp
  wall-clock time and re-break the historical path.
- `export_state()` writes an explicit `null` for a never-active competitor.
  `_import_current_state` reads `null` as "never active", an ISO string as before, and a *missing*
  `last_activity` key exactly as before (wall clock + warning) so state documents written before this
  change import unchanged.
- `reset()` returns `_last_activity` to `None` rather than `datetime.now()`, so a reset competitor is
  once again in its initial, never-played state.

`match_time=None` and explicitly-passed `initial_time` behave exactly as before. The RD-inflation
formula, `update_ratings`, and `elote/datasets/utils.py` are untouched, per the issue's scope guard.

## Assertion that had to change

`tests/test_Glicko2Competitor.py::TestGlicko2::test_update_ratings` asserted that
`update_ratings()` on a brand-new competitor with no matches increases RD. That only passed because
the constructor pre-stamped wall-clock time and `update_ratings()` then measured the microseconds
since — the exact behaviour this issue calls a bug. The test now constructs that competitor with
`initial_time=datetime.now() - timedelta(days=10)`, which preserves the intent ("no matches, elapsed
time, RD grows") and makes the guard stronger than a microsecond of drift. No other existing test
changed.

## New tests

`tests/test_glicko_historical_time.py`, 9 tests, each run against both classes via `subTest`:

- the issue's reproducer, plus an assertion that both lazily created competitors adopt the match time;
- a dated replay through `LambdaArena` (five matchups spanning ~9 months, increasing order, competitors
  created lazily) asserting every competitor's final `rd` is strictly greater than from the identical
  schedule run with all matches at one timestamp — i.e. the inactivity inflation actually fired;
- out-of-order rejection, both for the competitor itself and for the opponent, and for a competitor
  built with an explicit past `initial_time`;
- `match_time=None` still stamping wall-clock activity;
- `export_state()`/`from_state()` round-trips for a never-played competitor (which can then still start
  its history in the past) and for a played arena, continuing play on both with an explicit
  `match_time` so wall-clock drift cannot enter the rating/`rd` comparison;
- a legacy state document with `last_activity` deleted still importing with the old wall-clock fallback.

## Mutation check

Run with `PYTHONDONTWRITEBYTECODE=1`; the fix was committed first, and the restored baseline was
re-run green (9 passed) between mutations.

**A — revert "adopt first match time"** (`_last_activity = initial_time if initial_time is not None else
datetime.now()`, i.e. the original bug): 6 failed / 3 passed.
Fails `test_first_matchup_accepts_a_past_timestamp`, `test_dated_replay_inflates_rd_relative_to_a_gapless_replay`,
`test_never_played_competitor_round_trips_and_accepts_history`,
`test_played_competitor_round_trips_and_continues_identically`, plus the two arena ordering tests
(their *first*, historical matchup raises under this mutation).
Passes `test_explicit_initial_time_still_bounds_matches`.

**B — delete the out-of-order guard** (both `raise InvalidParameterException` blocks in
`_compute_match_result`, adopt behaviour left intact): 3 failed / 6 passed.
Fails `test_out_of_order_match_still_raises`, `test_out_of_order_match_raises_for_the_opponent_too`,
`test_explicit_initial_time_still_bounds_matches`.
Passes every reproducer, replay and round-trip test.

Disjoint sets: A alone fails the four reproducer/replay/round-trip tests; B alone fails
`test_explicit_initial_time_still_bounds_matches`. The two arena ordering tests fail under both,
because mutation A breaks the historical matchup they set up with — that overlap is stated rather than
engineered away, since a mis-sorted *historical* stream is the realistic case the guard exists for.

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` → **396 passed, 6 skipped**
  (387 on this branch point + 9 new). `tests/test_examples.py` is excluded because it fails wholesale on
  `master` for environmental reasons (it shells out to an interpreter without `elote` installed).
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` (`make lint`) → **All checks passed!**
- `env -u VIRTUAL_ENV uv run --extra dev mypy --python-version 3.12 elote` → **no issues found in 26 source files**.
  (`make typecheck` itself aborts in `scipy-stubs` before reaching `elote`, on `master` too.)
- The issue's three-line reproducer runs clean for both classes.

## Follow-up not done here

`elote/datasets/utils.py::train_arena_with_dataset` still sorts training rows by timestamp and then
discards it (`for a, b, outcome, _, attributes in batch`), so it never passes `match_time`. The issue
flags that as a separate note and its scope guard excludes it; this PR is the precondition.