### PR TITLE
Make LambdaArena.expected_score a pure read

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -188,6 +188,8 @@ class LambdaArena(BaseArena):
         """Calculate the expected score for a matchup between two competitors.
 
         This method returns the probability that competitor a will beat competitor b.
+        It is a read: an identifier the arena has not seen is scored as an unrated
+        competitor without being added to the population.
 
         Args:
             a: The first competitor or competitor identifier.
@@ -196,12 +198,18 @@ class LambdaArena(BaseArena):
         Returns:
             float: The probability that a will beat b (between 0 and 1).
         """
-        if a not in self.competitors:
-            self.competitors[a] = self.base_competitor(**self.base_competitor_kwargs)
-        if b not in self.competitors:
-            self.competitors[b] = self.base_competitor(**self.base_competitor_kwargs)
+        return self._competitor_for_prediction(a).expected_score(self._competitor_for_prediction(b))
 
-        return self.competitors[a].expected_score(self.competitors[b])
+    def _competitor_for_prediction(self, id_val: Any) -> BaseCompetitor:
+        """Return the competitor for an identifier without adding it to the population."""
+        if id_val in self.competitors:
+            return self.competitors[id_val]
+        logger.warning(
+            "Competitor '%s' is not in this arena; predicting with an unrated competitor "
+            "without adding it to the population.",
+            id_val,
+        )
+        return self.base_competitor(**self.base_competitor_kwargs)
 
     def export_state(self) -> Dict[Any, Dict[str, Any]]:
         """Export the current state of this arena for serialization.

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -143,9 +143,37 @@ class TestArenas(unittest.TestCase):
         score_c_d = arena.expected_score("C", "D")
         self.assertAlmostEqual(score_c_d, 0.5, places=2)
 
-        # Now they should be in the arena with default ratings
-        self.assertIn("C", arena.competitors)
-        self.assertIn("D", arena.competitors)
+        # Predicting for them does not add them to the population
+        self.assertNotIn("C", arena.competitors)
+        self.assertNotIn("D", arena.competitors)
+
+    def test_expected_score_does_not_add_unseen_competitors(self):
+        """expected_score is a read: unseen identifiers stay out of the population."""
+        arena = LambdaArena(lambda a, b: True)
+        arena.matchup("x", "y")
+
+        population_before = {k: v.rating for k, v in arena.competitors.items()}
+        self.assertEqual(population_before, {"x": 416.0, "y": 384.0})
+
+        # Two unseen identifiers score as two unrated competitors.
+        self.assertEqual(arena.expected_score("ghost1", "ghost2"), 0.5)
+
+        # A seen-vs-unseen pair scores against a transient default competitor, matching
+        # what an explicit pair of competitors at those ratings would give.
+        default_rating = EloCompetitor().rating
+        seen, unseen = EloCompetitor(initial_rating=416.0), EloCompetitor(initial_rating=default_rating)
+        self.assertEqual(arena.expected_score("x", "ghost1"), seen.expected_score(unseen))
+        self.assertEqual(arena.expected_score("ghost1", "x"), unseen.expected_score(seen))
+
+        # None of those calls touched the population, the leaderboard or the export.
+        self.assertEqual({k: v.rating for k, v in arena.competitors.items()}, population_before)
+        self.assertEqual(len(arena.leaderboard()), 2)
+        self.assertEqual(sorted(arena.export_state()), ["x", "y"])
+
+        # A later matchup still creates and rates the identifier normally.
+        arena.matchup("ghost1", "x")
+        self.assertEqual(sorted(arena.competitors), ["ghost1", "x", "y"])
+        self.assertGreater(arena.competitors["ghost1"].rating, default_rating)
 
     def test_lambda_arena_export_state(self):
         """Test that the arena state can be exported correctly."""


### PR DESCRIPTION
Closes #136

`LambdaArena.expected_score` is documented as a read, but it opened by inserting
any unseen identifier into `self.competitors`. Asking for a hypothetical
prediction therefore added both entities permanently to `leaderboard()` and
`export_state()` at the default rating, and an identifier typo was silently
absorbed.

## What changed

- `expected_score` now resolves each identifier through a new private
  `_competitor_for_prediction`, which returns the existing competitor when the
  arena has seen it and otherwise scores against a transient
  `self.base_competitor(**self.base_competitor_kwargs)` instance without
  inserting it. The returned probability is unchanged.
- An unknown identifier emits a `logger.warning` naming it, so a typo is visible.
- `matchup` already creates both competitors itself before calling
  `expected_score`, so its create-on-demand behaviour is untouched, as are
  `process_history` and `_get_or_create_competitor`.
- `evaluate_performance` and `validate` have the same family of problem and are
  covered by their own issue; they are deliberately not touched here.

Test changes in `tests/test_Arenas.py`: the existing
`test_lambda_arena_expected_score` asserted the old side effect, so its two
`assertIn` lines became `assertNotIn`. A new
`test_expected_score_does_not_add_unseen_competitors` asserts on values — the
exact population map before and after (`{"x": 416.0, "y": 384.0}`), the returned
probability for an unseen pair (exactly `0.5`), the seen-vs-unseen probability
against what two explicit `EloCompetitor`s at those ratings give, the leaderboard
length, the exported keys, and that a later `matchup` for the same identifier
still creates and rates it.

## Verification

Reproduction from the issue, on this branch:

```
0.5
[('x', 416.0), ('y', 384.0)]
['x', 'y']
```

`ghost1`/`ghost2` appear in neither the leaderboard nor `export_state()`.
`arena.expected_score("x", "ghost")` returns `0.5230095872975623`, exactly equal
to `EloCompetitor(initial_rating=416.0).expected_score(EloCompetitor())` — the
same computation the old code performed after inserting the competitor, so no
prediction changed. The warning fires as
`Competitor 'ghsot1' is not in this arena; predicting with an unrated competitor
without adding it to the population.` A subsequent `matchup("ghost1", "x")`
creates `ghost1` and rates it above the default (416.74).

**Mutation check.** With the fix committed, I reinstated the two
`self.competitors[...] = ...` assignments (confirming the mutation was live by
reading `inspect.getsource` of the imported method, and clearing `__pycache__`).
`tests/test_Arenas.py` then reported **2 failed, 17 passed**: the new test failed
on the population assertion
(`{'x': 416.0, 'y': 384.0, 'ghost1': 400, 'ghost2': 400} != {'x': 416.0, 'y': 384.0}`)
and `test_lambda_arena_expected_score` failed on `assertNotIn("C", ...)`.
Restoring the file returned the interpreter-imported source to the fixed version
and the suite to green.

Gates:

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py`
  → **397 passed, 6 skipped** (396 at the `530ce0b` branch point, plus the new test).
- `ruff check .` → **All checks passed!**