### PR TITLE
Keep restored Colley and Massey fits graph-consistent

### DIFF
--- a/elote/competitors/colley.py
+++ b/elote/competitors/colley.py
@@ -61,7 +61,7 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         self._losses = 0
         self._ties = 0
         self._opponents: Dict["ColleyMatrixCompetitor", int] = {}  # Opponent -> num games
-        self._head_to_head: Dict["ColleyMatrixCompetitor", int] = {}  # Opponent -> wins against
+        self._head_to_head: Dict["ColleyMatrixCompetitor", float] = {}  # Opponent -> wins against
         # Add a unique ID for hashing
         self._id = id(self)
         logger.debug("Initialized ColleyMatrixCompetitor %d with initial rating %.3f", self._id, self._initial_rating)
@@ -171,11 +171,13 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         # Record the tie for this competitor
         self._ties += 1
         self._opponents[competitor] = self._opponents.get(competitor, 0) + 1
+        self._head_to_head[competitor] = self._head_to_head.get(competitor, 0) + 0.5
 
         # Record the tie for the opponent
         competitor_typed = competitor_colley
         competitor_typed._ties += 1
         competitor_typed._opponents[self] = competitor_typed._opponents.get(self, 0) + 1
+        competitor_typed._head_to_head[self] = competitor_typed._head_to_head.get(self, 0) + 0.5
 
         logger.debug("Recorded tie for %d and %d", self._id, competitor_typed._id)
         # Recalculate ratings for all connected competitors
@@ -253,15 +255,14 @@ class ColleyMatrixCompetitor(BaseCompetitor):
 
         # Fill the matrix and vector more efficiently
         for i, comp_i in enumerate(competitors):
-            total_games_i = comp_i.num_games
+            total_games_i = sum(comp_i._opponents.values())
             
             # Set diagonal element: 2 + total_games
             C[i, i] = 2 + total_games_i
             
             # Set off-diagonal elements and calculate b[i] in one pass
-            wins_i = comp_i._wins
-            losses_i = comp_i._losses
-            b[i] = 1 + (wins_i - losses_i) / 2
+            head_to_head_wins_i = sum(comp_i._head_to_head.values())
+            b[i] = 1 + (2 * head_to_head_wins_i - total_games_i) / 2
 
             # Fill off-diagonal elements for opponents
             for opponent, games_vs_opponent in comp_i._opponents.items():
@@ -432,6 +433,7 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         self._losses = state.get("losses", 0)
         self._ties = state.get("ties", 0)
         self._opponents = {}  # Cannot restore opponent references from serialization
+        self._head_to_head = {}
 
     @classmethod
     def from_state(cls: Type[T], state: Dict[str, Any]) -> T:
@@ -479,6 +481,8 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         competitor._wins = state.get("wins", 0)
         competitor._losses = state.get("losses", 0)
         competitor._ties = state.get("ties", 0)
+        competitor._opponents = {}
+        competitor._head_to_head = {}
 
         # Note: We can't restore the opponent list from state
         # This would require reconstructing the entire match history

--- a/elote/competitors/massey.py
+++ b/elote/competitors/massey.py
@@ -93,6 +93,7 @@ class MasseyCompetitor(BaseCompetitor):
         # ``self_score - opponent_score`` over every game played.
         self._point_differential = 0.0
         self._opponents: Dict["MasseyCompetitor", int] = {}  # Opponent -> num games
+        self._margins_for: Dict["MasseyCompetitor", float] = {}
         # Unique ID for hashing (instances are used as dict keys in the match graph).
         self._id = id(self)
         logger.debug("Initialized MasseyCompetitor %d with initial rating %.3f", self._id, self._initial_rating)
@@ -179,10 +180,12 @@ class MasseyCompetitor(BaseCompetitor):
         self._wins += 1
         self._point_differential += margin
         self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._margins_for[opponent] = self._margins_for.get(opponent, 0.0) + margin
 
         opponent._losses += 1
         opponent._point_differential -= margin
         opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._margins_for[self] = opponent._margins_for.get(self, 0.0) - margin
 
         logger.debug("Recorded win for %d, loss for %d", self._id, opponent._id)
         self._recalculate_ratings()
@@ -209,9 +212,11 @@ class MasseyCompetitor(BaseCompetitor):
 
         self._ties += 1
         self._opponents[opponent] = self._opponents.get(opponent, 0) + 1
+        self._margins_for.setdefault(opponent, 0.0)
 
         opponent._ties += 1
         opponent._opponents[self] = opponent._opponents.get(self, 0) + 1
+        opponent._margins_for.setdefault(self, 0.0)
 
         logger.debug("Recorded tie for %d and %d", self._id, opponent._id)
         self._recalculate_ratings()
@@ -274,8 +279,8 @@ class MasseyCompetitor(BaseCompetitor):
         M = np.zeros((n, n), dtype=np.float64)
         p = np.zeros(n, dtype=np.float64)
         for i, comp in enumerate(competitors):
-            M[i, i] = comp.num_games
-            p[i] = comp._point_differential
+            M[i, i] = sum(comp._opponents.values())
+            p[i] = sum(comp._margins_for.values())
             for opponent, games in comp._opponents.items():
                 j = idx.get(opponent)
                 if j is not None:
@@ -366,6 +371,7 @@ class MasseyCompetitor(BaseCompetitor):
         self._ties = state.get("ties", 0)
         self._point_differential = state.get("point_differential", float(self._wins - self._losses))
         self._opponents = {}
+        self._margins_for = {}
 
     @classmethod
     def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
@@ -388,6 +394,7 @@ class MasseyCompetitor(BaseCompetitor):
         self._ties = 0
         self._point_differential = 0.0
         self._opponents = {}
+        self._margins_for = {}
 
     @classmethod
     def configure_class(cls, **kwargs: Any) -> None:

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -388,6 +388,50 @@ class TestArenaStateRoundTrip(unittest.TestCase):
 
                 self.assertEqual(self._ratings(arena), self._ratings(restored))
 
+    def test_global_fit_ratings_remain_valid_after_restored_play(self):
+        """Restored graph-based fits must use only results in the rebuilt graph."""
+        for competitor_cls in (ColleyMatrixCompetitor, MasseyCompetitor):
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = self._trained_arena(competitor_cls)
+                state = json.loads(json.dumps(arena.export_state()))
+                restored = LambdaArena(lambda a, b: a > b, base_competitor=competitor_cls, initial_state=state)
+                fresh = LambdaArena(lambda a, b: a > b, base_competitor=competitor_cls)
+
+                for a, b in self._matchups(seed=2, count=30):
+                    restored.matchup(a, b)
+                    fresh.matchup(a, b)
+
+                restored_ratings = self._ratings(restored)
+                fresh_ratings = self._ratings(fresh)
+                self.assertEqual(restored_ratings, fresh_ratings)
+
+                ratings = list(restored_ratings.values())
+                if competitor_cls is ColleyMatrixCompetitor:
+                    self.assertTrue(all(0.0 <= rating <= 1.0 for rating in ratings))
+                    self.assertAlmostEqual(sum(ratings), len(ratings) / 2, places=12)
+                else:
+                    self.assertAlmostEqual(sum(ratings) / len(ratings), 0.0, places=12)
+
+    def test_colley_restore_paths_rebuild_fit_from_new_results(self):
+        """Both Colley restore APIs must discard the old graph's fit inputs."""
+        first, second = ColleyMatrixCompetitor(), ColleyMatrixCompetitor()
+        for _ in range(10):
+            first.beat(second)
+        states = [json.loads(json.dumps(comp.export_state())) for comp in (first, second)]
+
+        for restore_method in ("from_state", "import_state"):
+            with self.subTest(restore_method=restore_method):
+                if restore_method == "from_state":
+                    restored = [ColleyMatrixCompetitor.from_state(state) for state in states]
+                else:
+                    restored = [ColleyMatrixCompetitor(), ColleyMatrixCompetitor()]
+                    for comp, state in zip(restored, states, strict=True):
+                        comp.import_state(state)
+
+                restored[0].beat(restored[1])
+                self.assertAlmostEqual(restored[0].rating, 0.625)
+                self.assertAlmostEqual(restored[1].rating, 0.375)
+
     def test_plain_constructor_kwargs_are_still_supported(self):
         """The pre-existing kwargs form of initial_state must keep working."""
         arena = LambdaArena(


### PR DESCRIPTION
Closes #135

## Summary

- derive Colley's diagonal and right-hand side from the rebuilt opponent graph, including half-win credits for ties
- track Massey margins per opponent and derive its fit entirely from that rebuilt graph
- preserve serialized lifetime totals for reporting while resetting all graph-owned fit data on import
- cover continued arena play plus both Colley restore paths with value assertions

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 398 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — clean
- `git diff --check` — clean
- direct JSON reproduction — Colley restored result `0.625 / 0.375`; Massey restored result `10.0 / -10.0`
- known-value suites remained unmodified and passed

## Mutation check

I reinstated each stale lifetime read separately with bytecode disabled and verified the new arena continuation test failed each time:

- Colley: restored `num_games` and win/loss inputs; the exact fresh-start comparison failed and exposed ratings outside `[0, 1]`
- Massey: restored `_point_differential` as `p`; the exact fresh-start comparison failed with materially inflated ratings

The Massey exact-value comparison is intentional: mean zero alone cannot catch this bug because the solver enforces that constraint even with an inconsistent right-hand side.
