### PR TITLE
Thread dataset point scores into the margin-aware rating systems

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -88,6 +88,35 @@ that model margin of victory (currently :doc:`Massey <rating_systems/massey>`) c
 payload; the rest validate and ignore it. Omitting ``scores`` leaves every system on its
 existing unit-score behaviour, so the argument is fully backward compatible.
 
+Scores from a dataset
+~~~~~~~~~~~~~~~~~~~~~
+
+Dataset rows carry their scores in the ``attributes`` mapping, so the training and
+benchmarking helpers take a ``score_keys`` pair naming the two keys, in
+``(a_score_key, b_score_key)`` order. ``CollegeFootballDataset`` writes ``home_score``
+and ``away_score``:
+
+.. code-block:: python
+
+    from elote import CollegeFootballDataset, benchmark_competitors, MasseyCompetitor, KeenerCompetitor
+
+    split = CollegeFootballDataset(start_year=2020, end_year=2021).time_split(test_ratio=0.2)
+
+    results = benchmark_competitors(
+        [{"class": MasseyCompetitor, "name": "Massey"}, {"class": KeenerCompetitor, "name": "Keener"}],
+        split,
+        lambda a, b, attributes=None: True,
+        score_keys=("home_score", "away_score"),
+    )
+
+``score_keys`` is also accepted by ``train_arena_with_dataset``,
+``train_and_evaluate_arena`` and ``evaluate_competitor``. It defaults to ``None``, which
+trains on unit margins exactly as before. Rows whose attributes are missing, lack either
+key, or carry a non-numeric value are trained without scores rather than raising, since
+real feeds have gaps; a score pair that is present but inconsistent with the row's
+outcome is still a ``ValueError``. Evaluation only reads expected scores, so
+``score_keys`` has no effect on the held-out half of a split.
+
 Using Different Rating Systems
 ----------------------------
 

--- a/elote/benchmark.py
+++ b/elote/benchmark.py
@@ -8,7 +8,7 @@ using consistent evaluation metrics and visualization.
 import contextlib
 import inspect
 import logging
-from typing import Dict, Iterator, List, Type, Optional, Any, Callable
+from typing import Dict, Iterator, List, Tuple, Type, Optional, Any, Callable
 import time
 
 from elote.arenas.lambda_arena import LambdaArena
@@ -79,6 +79,8 @@ def evaluate_competitor(
     batch_size: Optional[int] = None,
     progress_callback: Optional[Callable[[str, int, int], None]] = None,
     optimize_thresholds: bool = True,
+    *,
+    score_keys: Optional[Tuple[str, str]] = None,
 ) -> Dict[str, Any]:
     """
     Train and evaluate a specific competitor type.
@@ -93,6 +95,10 @@ def evaluate_competitor(
         batch_size: Number of matchups to process in each batch
         progress_callback: Callback function for reporting progress
         optimize_thresholds: Whether to optimize prediction thresholds
+        score_keys: Optional pair of attribute keys naming each training row's two point
+            scores, in ``(a_score_key, b_score_key)`` order, forwarded to
+            :func:`~elote.datasets.utils.train_arena_with_dataset`. Required to benchmark
+            margin-aware systems (Massey, Keener) on real margins rather than unit ones.
 
     Returns:
         Dictionary containing evaluation results
@@ -139,7 +145,13 @@ def evaluate_competitor(
         else:
             train_progress = None
 
-        train_arena_with_dataset(arena, data_split.train, batch_size=batch_size, progress_callback=train_progress)
+        train_arena_with_dataset(
+            arena,
+            data_split.train,
+            batch_size=batch_size,
+            progress_callback=train_progress,
+            score_keys=score_keys,
+        )
 
         train_time = time.time() - start_time
         logger.info(f"Training completed in {train_time:.2f} seconds")
@@ -211,6 +223,8 @@ def benchmark_competitors(
     batch_size: Optional[int] = None,
     progress_callback: Optional[Callable[[str, int, int], None]] = None,
     optimize_thresholds: bool = True,
+    *,
+    score_keys: Optional[Tuple[str, str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Benchmark multiple competitor types against each other.
@@ -222,6 +236,8 @@ def benchmark_competitors(
         batch_size: Number of matchups to process in each batch
         progress_callback: Callback function for reporting progress
         optimize_thresholds: Whether to optimize prediction thresholds
+        score_keys: Optional pair of attribute keys naming each training row's two point
+            scores, forwarded to :func:`evaluate_competitor` for every configuration
 
     Returns:
         List of dictionaries containing evaluation results for each competitor
@@ -242,6 +258,7 @@ def benchmark_competitors(
             batch_size=batch_size,
             progress_callback=progress_callback,
             optimize_thresholds=optimize_thresholds,
+            score_keys=score_keys,
         )
 
         results.append(result)

--- a/elote/datasets/utils.py
+++ b/elote/datasets/utils.py
@@ -6,9 +6,45 @@ This module provides utility functions for using datasets with arenas for evalua
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import datetime
+import math
+import numbers
 
 from elote.arenas.base import BaseArena, Bout, History
 from elote.datasets.base import DataSplit
+
+
+def _scores_from_attributes(
+    attributes: Optional[Dict[str, Any]], score_keys: Tuple[str, str]
+) -> Optional[Tuple[float, float]]:
+    """Read a row's two point scores out of its attributes, in ``(a, b)`` order.
+
+    Real feeds have gaps, so anything short of two usable numbers means "no scores for this
+    row" rather than an error: a missing attributes mapping, a missing key, or a value that
+    is not a finite real number. Payloads that are well-formed but wrong -- negative, or
+    disagreeing with the recorded outcome -- are still rejected downstream by
+    :func:`elote.competitors.base.validate_scores`.
+
+    Args:
+        attributes: The row's attributes mapping, which may be None.
+        score_keys: The attribute keys holding the two scores, as ``(a_key, b_key)``.
+
+    Returns:
+        tuple of float, or None: The two scores in ``(a, b)`` order, or None.
+    """
+    if not attributes:
+        return None
+
+    values: List[float] = []
+    for key in score_keys:
+        value = attributes.get(key)
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
+            return None
+        as_float = float(value)
+        if not math.isfinite(as_float):
+            return None
+        values.append(as_float)
+
+    return values[0], values[1]
 
 
 def train_arena_with_dataset(
@@ -16,6 +52,8 @@ def train_arena_with_dataset(
     train_data: List[Tuple[Any, Any, float, Optional[datetime.datetime], Optional[Dict[str, Any]]]],
     batch_size: Optional[int] = None,
     progress_callback: Optional[Callable[[int, int], None]] = None,
+    *,
+    score_keys: Optional[Tuple[str, str]] = None,
 ) -> BaseArena:
     """
     Train an arena with a dataset.
@@ -25,6 +63,14 @@ def train_arena_with_dataset(
         train_data: List of matchup tuples (competitor_a, competitor_b, outcome, timestamp, attributes)
         batch_size: Number of matchups to process in each batch (for progress reporting)
         progress_callback: Callback function for reporting progress (current, total)
+        score_keys: Optional pair of attribute keys naming each row's two point scores, in
+            ``(a_score_key, b_score_key)`` order -- for example
+            ``("home_score", "away_score")`` for
+            :class:`~elote.datasets.football.CollegeFootballDataset`. When supplied, rows
+            carrying both scores are trained with an explicit outcome and the score payload,
+            so margin-aware systems (Massey, Keener) see the real margins instead of unit
+            ones. Rows without usable scores are trained exactly as they are with the
+            default of None, which leaves behaviour unchanged.
 
     Returns:
         The trained arena
@@ -60,15 +106,24 @@ def train_arena_with_dataset(
 
         # Process each matchup
         for a, b, outcome, _, attributes in batch:
+            scores = None if score_keys is None else _scores_from_attributes(attributes, score_keys)
+
             if outcome == 1.0:
                 # A wins
-                arena.matchup(a, b, attributes=attributes)
+                if scores is None:
+                    arena.matchup(a, b, attributes=attributes)
+                else:
+                    arena.matchup(a, b, attributes=attributes, outcome=1.0, scores=scores)
             elif outcome == 0.0:
-                # B wins
-                arena.matchup(b, a, attributes=attributes)
+                # B wins. The call is reversed so b is the winner, so the score pair has to
+                # be reversed with it to stay in the arena's caller order.
+                if scores is None:
+                    arena.matchup(b, a, attributes=attributes)
+                else:
+                    arena.matchup(b, a, attributes=attributes, outcome=1.0, scores=(scores[1], scores[0]))
             else:
                 # Draw
-                arena.matchup(a, b, attributes=attributes, outcome=0.5)
+                arena.matchup(a, b, attributes=attributes, outcome=0.5, scores=scores)
 
         # Report progress
         if progress_callback is not None:
@@ -154,6 +209,8 @@ def train_and_evaluate_arena(
     data_split: DataSplit,
     batch_size: Optional[int] = None,
     progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    *,
+    score_keys: Optional[Tuple[str, str]] = None,
 ) -> Tuple[BaseArena, History]:
     """
     Train and evaluate an arena with a dataset split.
@@ -163,6 +220,9 @@ def train_and_evaluate_arena(
         data_split: DataSplit object containing train and test sets
         batch_size: Number of matchups to process in each batch (for progress reporting)
         progress_callback: Callback function for reporting progress (phase, current, total)
+        score_keys: Optional pair of attribute keys naming each row's two point scores,
+            forwarded to :func:`train_arena_with_dataset`. Evaluation only reads expected
+            scores, so it has no use for them.
 
     Returns:
         Tuple of (trained_arena, history)
@@ -176,7 +236,7 @@ def train_and_evaluate_arena(
         train_progress = None
 
     trained_arena = train_arena_with_dataset(
-        arena, data_split.train, batch_size=batch_size, progress_callback=train_progress
+        arena, data_split.train, batch_size=batch_size, progress_callback=train_progress, score_keys=score_keys
     )
 
     # Evaluate the arena

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -6,11 +6,14 @@ the right competitor order. Systems that actually consume a score (Massey and Ke
 covered here for the plumbing and in their own known-value file for the numbers.
 """
 
+import datetime
+import random
 import unittest
 
 from elote import (
     BradleyTerryCompetitor,
     ColleyMatrixCompetitor,
+    DataSplit,
     DWZCompetitor,
     ECFCompetitor,
     EloCompetitor,
@@ -20,6 +23,8 @@ from elote import (
     LambdaArena,
     MasseyCompetitor,
     TrueSkillCompetitor,
+    benchmark_competitors,
+    train_arena_with_dataset,
 )
 
 
@@ -243,6 +248,196 @@ class TestArenaScoreForwarding(unittest.TestCase):
                 arena.matchup("a", "b", outcome=0.5, scores=(7.0, 7.0))
                 arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
                 self.assertEqual(len(arena.history.bouts), 3)
+
+
+_SEASON_START = datetime.datetime(2024, 9, 1)
+
+# A hand-built schedule covering all three branches of the training helper: rows where a
+# won, rows where b won, and a drawn row. Scores live under the CollegeFootballDataset keys.
+SCORED_ROWS = [
+    ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": 31, "away_score": 17}),
+    ("Bengals", "Steelers", 0.0, _SEASON_START + datetime.timedelta(days=1), {"home_score": 3, "away_score": 45}),
+    ("Ravens", "Steelers", 0.0, _SEASON_START + datetime.timedelta(days=2), {"home_score": 10, "away_score": 24}),
+    ("Steelers", "Browns", 1.0, _SEASON_START + datetime.timedelta(days=3), {"home_score": 28, "away_score": 7}),
+    ("Browns", "Ravens", 0.5, _SEASON_START + datetime.timedelta(days=4), {"home_score": 20, "away_score": 20}),
+]
+
+SCORE_KEYS = ("home_score", "away_score")
+
+
+def _leaderboard(arena):
+    return {entry["competitor"]: entry["rating"] for entry in arena.leaderboard()}
+
+
+def _trained(competitor_class, rows, **kwargs):
+    arena = LambdaArena(_always_true, base_competitor=competitor_class)
+    train_arena_with_dataset(arena, rows, **kwargs)
+    return arena
+
+
+def _scored_split(num_matchups=180, test_ratio=0.3, seed=11):
+    """Build a DataSplit whose attributes carry real, outcome-consistent point scores."""
+    rng = random.Random(seed)
+    names = [f"team_{i}" for i in range(8)]
+    strengths = {name: rng.uniform(-10.0, 10.0) for name in names}
+
+    rows = []
+    for i in range(num_matchups):
+        a, b = rng.sample(names, 2)
+        a_score = max(0, round(24 + strengths[a] - strengths[b] + rng.gauss(0, 6)))
+        b_score = max(0, round(24 + strengths[b] - strengths[a] + rng.gauss(0, 6)))
+        outcome = 1.0 if a_score > b_score else (0.0 if a_score < b_score else 0.5)
+        rows.append(
+            (a, b, outcome, _SEASON_START + datetime.timedelta(days=i), {"home_score": a_score, "away_score": b_score})
+        )
+
+    split_at = int(len(rows) * (1 - test_ratio))
+    return DataSplit(train=rows[:split_at], test=rows[split_at:])
+
+
+class TestDatasetScoreForwarding(unittest.TestCase):
+    """train_arena_with_dataset only reaches the margin path when score_keys is supplied."""
+
+    def test_score_keys_reproduce_hand_driven_matchups(self):
+        """Training with score_keys must equal driving the same games through the arena."""
+        by_helper = _trained(MasseyCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS)
+
+        by_hand = LambdaArena(_always_true, base_competitor=MasseyCompetitor)
+        by_hand.matchup("Ravens", "Bengals", attributes=SCORED_ROWS[0][4], outcome=1.0, scores=(31, 17))
+        by_hand.matchup("Steelers", "Bengals", attributes=SCORED_ROWS[1][4], outcome=1.0, scores=(45, 3))
+        by_hand.matchup("Steelers", "Ravens", attributes=SCORED_ROWS[2][4], outcome=1.0, scores=(24, 10))
+        by_hand.matchup("Steelers", "Browns", attributes=SCORED_ROWS[3][4], outcome=1.0, scores=(28, 7))
+        by_hand.matchup("Browns", "Ravens", attributes=SCORED_ROWS[4][4], outcome=0.5, scores=(20, 20))
+
+        self.assertEqual(_leaderboard(by_helper), _leaderboard(by_hand))
+        # Exact values, so a change in either path is visible rather than merely "equal".
+        self.assertEqual(
+            _leaderboard(by_helper),
+            {"Steelers": 19.25, "Ravens": 0.0, "Browns": -0.875, "Bengals": -18.375},
+        )
+
+    def test_score_keys_change_the_massey_fit(self):
+        """The same rows without score_keys stay on unit margins, so the fit differs."""
+        self.assertEqual(
+            _leaderboard(_trained(MasseyCompetitor, SCORED_ROWS)),
+            {"Steelers": 0.75, "Ravens": 0.0, "Browns": -0.125, "Bengals": -0.625},
+        )
+
+    def test_default_reproduces_the_current_output_for_keener(self):
+        """Pinned literals for both paths of the other score-consuming system."""
+        self.assertEqual(
+            _leaderboard(_trained(KeenerCompetitor, SCORED_ROWS)),
+            {"Steelers": 1.5088623362, "Ravens": 0.9649085365, "Browns": 0.923455846, "Bengals": 0.6027732813},
+        )
+        self.assertEqual(
+            _leaderboard(_trained(KeenerCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS)),
+            {"Steelers": 1.7295652954, "Ravens": 0.9585153377, "Browns": 0.9169460231, "Bengals": 0.3949733438},
+        )
+
+    def test_scores_are_inert_for_a_system_that_ignores_them(self):
+        """Elo validates the payload and ignores it, so its ratings must not move."""
+        self.assertEqual(
+            _leaderboard(_trained(EloCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS)),
+            _leaderboard(_trained(EloCompetitor, SCORED_ROWS)),
+        )
+
+    def test_bout_shape_is_unchanged(self):
+        """Forwarding scores must not alter the recorded bouts."""
+        with_scores = _trained(MasseyCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS)
+        without = _trained(MasseyCompetitor, SCORED_ROWS)
+
+        self.assertEqual(
+            [(bout.a, bout.b, bout.outcome) for bout in with_scores.history.bouts],
+            [(bout.a, bout.b, bout.outcome) for bout in without.history.bouts],
+        )
+
+    def test_b_wins_rows_reverse_the_score_pair(self):
+        """A 45-0 result must land identically however the row expresses it.
+
+        The b-wins branch calls ``matchup(b, a, ...)``, so the pair has to be reversed with
+        it. This case is deliberately not symmetric under swapping the two competitors.
+        """
+        as_a_loss = _trained(
+            MasseyCompetitor,
+            [("Browns", "Steelers", 0.0, _SEASON_START, {"home_score": 0, "away_score": 45})],
+            score_keys=SCORE_KEYS,
+        )
+        as_b_win = _trained(
+            MasseyCompetitor,
+            [("Steelers", "Browns", 1.0, _SEASON_START, {"home_score": 45, "away_score": 0})],
+            score_keys=SCORE_KEYS,
+        )
+
+        self.assertEqual(_leaderboard(as_a_loss), {"Steelers": 22.5, "Browns": -22.5})
+        self.assertEqual(_leaderboard(as_a_loss), _leaderboard(as_b_win))
+
+    def test_rows_without_usable_scores_train_without_them(self):
+        """Real feeds have gaps, so a row short of two numbers is trained score-free."""
+        gappy = [
+            ("Ravens", "Bengals", 1.0, _SEASON_START, None),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": 31}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"away_score": 17}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": 31, "away_score": None}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": None, "away_score": None}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": "31", "away_score": "17"}),
+            ("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": 31, "away_score": float("nan")}),
+        ]
+
+        with_keys = _trained(MasseyCompetitor, gappy, score_keys=SCORE_KEYS)
+        without_keys = _trained(MasseyCompetitor, gappy)
+
+        self.assertEqual(len(with_keys.history.bouts), len(gappy))
+        self.assertEqual(_leaderboard(with_keys), _leaderboard(without_keys))
+
+    def test_mixed_rows_use_scores_only_where_they_are_present(self):
+        """One gappy row must not disable the margin path for the rest of the schedule."""
+        rows = list(SCORED_ROWS)
+        rows[0] = (rows[0][0], rows[0][1], rows[0][2], rows[0][3], {"home_score": 31})
+
+        mixed = _trained(MasseyCompetitor, rows, score_keys=SCORE_KEYS)
+        self.assertNotEqual(_leaderboard(mixed), _leaderboard(_trained(MasseyCompetitor, rows)))
+        self.assertNotEqual(
+            _leaderboard(mixed), _leaderboard(_trained(MasseyCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS))
+        )
+
+    def test_malformed_payloads_still_raise(self):
+        """A present-but-wrong score pair is a data error, not a gap."""
+        rows = [("Ravens", "Bengals", 1.0, _SEASON_START, {"home_score": 3, "away_score": 45})]
+        with self.assertRaises(ValueError):
+            _trained(MasseyCompetitor, rows, score_keys=SCORE_KEYS)
+
+
+class TestBenchmarkScoreForwarding(unittest.TestCase):
+    """benchmark_competitors can put the score-based systems on real margins."""
+
+    def test_score_keys_change_the_benchmarked_metrics(self):
+        split = _scored_split()
+        configs = [
+            {"class": MasseyCompetitor, "name": "Massey"},
+            {"class": KeenerCompetitor, "name": "Keener"},
+        ]
+
+        plain = benchmark_competitors(configs, split, _always_true, optimize_thresholds=False)
+        scored = benchmark_competitors(configs, split, _always_true, optimize_thresholds=False, score_keys=SCORE_KEYS)
+
+        self.assertEqual([r["name"] for r in scored], ["Massey", "Keener"])
+        for plain_result, scored_result in zip(plain, scored, strict=True):
+            with self.subTest(competitor=scored_result["name"]):
+                self.assertGreater(sum(scored_result["confusion_matrix"].values()), 0)
+                self.assertNotEqual(plain_result["accuracy"], scored_result["accuracy"])
+
+    def test_default_leaves_the_benchmark_on_unit_margins(self):
+        """Without score_keys the trained arena must match a score-free training run."""
+        split = _scored_split(num_matchups=60)
+        result = benchmark_competitors(
+            [{"class": MasseyCompetitor, "name": "Massey"}], split, _always_true, optimize_thresholds=False
+        )[0]
+
+        self.assertEqual(
+            _leaderboard(result["arena"]),
+            _leaderboard(_trained(MasseyCompetitor, split.train)),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #134

## What changed

The optional `scores` channel existed on `beat`/`lost_to`/`tied` and on `LambdaArena.matchup`, but nothing between a dataset row and a competitor forwarded it — so every documented dataset workflow silently trained Massey and Keener on unit margins.

Added an opt-in, keyword-only `score_keys: Optional[Tuple[str, str]] = None` naming the two attribute keys in `(a_score, b_score)` order, and threaded it through:

- `elote/datasets/utils.py::train_arena_with_dataset` — the real change. When `score_keys` is set and the row's `attributes` carry both keys as finite real numbers, the row is trained with an explicit `outcome=` plus `scores=`. The branch structure is unchanged, so the recorded `Bout` shape is identical. **The b-wins branch calls `arena.matchup(b, a, ...)`, so the pair is reversed to `(b_score, a_score)` to stay in the arena's caller order.**
- `train_and_evaluate_arena`, `evaluate_competitor`, `benchmark_competitors` — forwarding only.
- `docs/source/quickstart.rst` — a "Scores from a dataset" subsection next to the existing `scores` section, worked with the `CollegeFootballDataset` keys.

Default `None` reproduces today's behaviour exactly. Rows with `attributes=None`, a missing key, or a `None`/non-numeric/non-finite value are trained without scores rather than raising — real feeds have gaps. A payload that is present but *inconsistent* with the row's outcome is still a `ValueError` from `BaseCompetitor._validate_scores`.

Out of scope as specified, and not touched: the five-field row format, a scores column on `SyntheticDataset`, and `evaluate_arena_with_dataset` (evaluation only reads `expected_score`).

## Verification

All commands run from a clean worktree at `52562e3`.

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` → **410 passed, 6 skipped** (398 at the branch point + 12 new).
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` → **All checks passed!**
- `ruff format --check` on the three touched Python files → clean (the file was format-clean at base, so the addition does not introduce drift).
- Sphinx HTML build: the new `quickstart.rst` heading contributes **zero** new warnings; the ten reported for that file are the pre-existing "Title underline too short" ones.

New tests live in `tests/test_score_channel.py`, the cross-competitor home for score-payload behaviour, as `TestDatasetScoreForwarding` and `TestBenchmarkScoreForwarding`:

- Massey trained through the helper with `score_keys=("home_score","away_score")` over a five-row hand-built schedule produces a leaderboard **identical** to driving the same five games through `LambdaArena.matchup(..., outcome=..., scores=...)` by hand, pinned to exact values `{Steelers: 19.25, Ravens: 0.0, Browns: -0.875, Bengals: -18.375}` — and **different** from the `score_keys=None` fit, pinned at `{0.75, 0.0, -0.125, -0.625}`.
- `score_keys=None` output pinned with literals for Keener too, plus Elo asserted inert with and without scores (it validates and ignores the payload).
- A 45-0 result asserted identical whether the row is written `("Browns","Steelers", 0.0, {home:0, away:45})` or `("Steelers","Browns", 1.0, {home:45, away:0})` — deliberately not symmetric under swapping the competitors.
- `benchmark_competitors(..., score_keys=(...))` over a `DataSplit` of 180 scored games runs end-to-end for `MasseyCompetitor` and `KeenerCompetitor` and returns accuracies that differ from the `score_keys=None` run; a companion test asserts the default run's trained arena matches a score-free training run exactly.
- Gap rows (`attributes=None`, `{}`, one key only, `None` value, string value, `NaN`) all train without raising and give a leaderboard identical to the `score_keys=None` run; a mixed schedule with one gappy row is asserted different from *both* all-scored and all-unscored.

### Mutation check

Each mutation applied alone, `__pycache__` cleared, and the live value confirmed via `inspect.getsource` before running (source-on-disk alone is not proof against stale bytecode):

| Mutation | Result |
| --- | --- |
| Drop the `(scores[1], scores[0])` reversal in the b-wins branch | **7 failed**, including `test_b_wins_rows_reverse_the_score_pair` |
| Drop the `scores=` forwarding entirely (`scores = None`) | **6 failed**, including `test_score_keys_reproduce_hand_driven_matchups` |

Worth noting for review: because the b-wins branch passes `outcome=1.0` alongside the reversed pair, dropping the reversal does **not** train the margin backwards silently as the issue anticipated — `validate_scores` sees `first < second` against a declared win and raises `ValueError`. So that mistake is loud rather than silent, and the asymmetric test catches it either way.

After restoring both mutations the suite is back to 410 passed / 6 skipped and `git status` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)