### PR TITLE
Skip unseen competitors in arena evaluation instead of inventing them

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -278,6 +278,9 @@ class LambdaArena(BaseArena):
     ) -> None:
         """Evaluate the performance of the competitors based on a list of evaluation bouts.
 
+        Bouts naming a competitor the arena has not seen are skipped: evaluation never
+        adds to the population, so unknown identifiers contribute no prediction.
+
         Args:
             eval_bouts (list): A list of (competitor_a, competitor_b, outcome) tuples.
             progress_bar (bool, optional): Whether to display a progress bar.
@@ -287,20 +290,22 @@ class LambdaArena(BaseArena):
         skipped_bouts = 0
         logger.info("Evaluating performance using %d bouts", total_bouts)
         for i, (a, b, outcome) in enumerate(iterator):
-            # Get or create competitors
-            try:
-                c_a = self._get_or_create_competitor(a)
-                c_b = self._get_or_create_competitor(b)
-            except KeyError as e:
-                # If a competitor is not found, skip this bout
+            # Evaluation is a read: an identifier the arena never trained on has no
+            # rating to evaluate, so the bout is skipped rather than scored against a
+            # freshly defaulted competitor.
+            unknown = a if a not in self.competitors else (b if b not in self.competitors else None)
+            if unknown is not None:
                 skipped_bouts += 1
                 logger.warning(
                     "Skipping evaluation bout %d/%d: Competitor '%s' not found in training history.",
                     i + 1,
                     total_bouts,
-                    e,
+                    unknown,
                 )
                 continue
+
+            c_a = self.competitors[a]
+            c_b = self.competitors[b]
 
             # Skip bouts where the actual outcome is None
             if outcome is None:
@@ -323,6 +328,9 @@ class LambdaArena(BaseArena):
     def validate(self, validation_bouts: List[Tuple[str, str, Optional[float]]], progress_bar: bool = True) -> None:
         """Run a validation set through the arena without updating ratings, only recording predictions.
 
+        Bouts naming a competitor the arena has not seen are skipped: validation never
+        adds to the population, so unknown identifiers contribute no prediction.
+
         Args:
             validation_bouts (list): A list of (competitor_a, competitor_b, outcome) tuples.
             progress_bar (bool, optional): Whether to display a progress bar.
@@ -332,20 +340,22 @@ class LambdaArena(BaseArena):
         skipped_bouts = 0
         logger.info("Validating model using %d bouts", total_bouts)
         for i, (a, b, outcome) in enumerate(iterator):
-            # Get or create competitors
-            try:
-                c_a = self._get_or_create_competitor(a)
-                c_b = self._get_or_create_competitor(b)
-            except KeyError as e:
-                # If a competitor is not found, skip this bout
+            # Validation is a read: an identifier the arena never trained on has no
+            # rating to validate, so the bout is skipped rather than scored against a
+            # freshly defaulted competitor.
+            unknown = a if a not in self.competitors else (b if b not in self.competitors else None)
+            if unknown is not None:
                 skipped_bouts += 1
                 logger.warning(
                     "Skipping validation bout %d/%d: Competitor '%s' not found in training history.",
                     i + 1,
                     total_bouts,
-                    e,
+                    unknown,
                 )
                 continue
+
+            c_a = self.competitors[a]
+            c_b = self.competitors[b]
 
             # Skip bouts where the actual outcome is None
             if outcome is None:

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -314,6 +314,94 @@ class TestArenas(unittest.TestCase):
                 self.assertEqual(ratings_before, ratings_after)
 
 
+class TestArenaEvaluationSkipsUnknownCompetitors(unittest.TestCase):
+    """evaluate_performance and validate must never invent competitors.
+
+    Both are reads over held-out data: an identifier the arena never trained on has
+    no rating, so the bout is skipped rather than scored against a default rating and
+    silently added to the population.
+    """
+
+    # ("x", "y") are trained; every other identifier is unknown to the arena.
+    ROWS = [
+        ("x", "y", 1.0),  # both known -> exactly one bout
+        ("ghost", "x", 0.0),  # first unknown -> no bout
+        ("y", "ghost", 1.0),  # second unknown -> no bout
+        ("g2", "g3", 1.0),  # both unknown -> no bout
+    ]
+
+    def _trained_arena(self):
+        arena = LambdaArena(func=lambda a, b: True)
+        arena.process_history([("x", "y", 1.0), ("x", "y", 1.0)], progress_bar=False)
+        return arena
+
+    def _run(self, method_name):
+        arena = self._trained_arena()
+        population_before = {cid: c.rating for cid, c in arena.competitors.items()}
+        getattr(arena, method_name)(self.ROWS, progress_bar=False)
+        return arena, population_before
+
+    def test_evaluate_performance_records_only_known_bouts(self):
+        arena, population_before = self._run("evaluate_performance")
+
+        # Only the single all-known row is scored; the three unknown rows record nothing.
+        self.assertEqual(len(arena.eval_history.bouts), 1)
+        bout = arena.eval_history.bouts[0]
+        self.assertEqual((bout.a, bout.b), ("x", "y"))
+
+        # The population is untouched, in membership and in ratings.
+        self.assertEqual(sorted(arena.competitors), ["x", "y"])
+        self.assertEqual({cid: c.rating for cid, c in arena.competitors.items()}, population_before)
+
+    def test_validate_records_only_known_bouts(self):
+        arena, population_before = self._run("validate")
+
+        self.assertEqual(len(arena.validation_history.bouts), 1)
+        bout = arena.validation_history.bouts[0]
+        self.assertEqual((bout.a, bout.b), ("x", "y"))
+
+        self.assertEqual(sorted(arena.competitors), ["x", "y"])
+        self.assertEqual({cid: c.rating for cid, c in arena.competitors.items()}, population_before)
+
+    def test_leaderboard_and_export_state_exclude_evaluation_only_identifiers(self):
+        for method_name in ("evaluate_performance", "validate"):
+            with self.subTest(method=method_name):
+                arena, _ = self._run(method_name)
+
+                self.assertEqual(sorted(entry["competitor"] for entry in arena.leaderboard()), ["x", "y"])
+                self.assertEqual(sorted(arena.export_state()), ["x", "y"])
+
+    def test_unknown_competitor_warning_is_emitted(self):
+        for method_name, label in (("evaluate_performance", "evaluation"), ("validate", "validation")):
+            with self.subTest(method=method_name):
+                arena = self._trained_arena()
+                with self.assertLogs("elote", level="WARNING") as captured:
+                    getattr(arena, method_name)(self.ROWS, progress_bar=False)
+
+                messages = [record.getMessage() for record in captured.records]
+                self.assertEqual(len(messages), 3)
+                self.assertIn(
+                    "Skipping %s bout 2/4: Competitor 'ghost' not found in training history." % label,
+                    messages,
+                )
+                self.assertIn(
+                    "Skipping %s bout 3/4: Competitor 'ghost' not found in training history." % label,
+                    messages,
+                )
+                self.assertIn(
+                    "Skipping %s bout 4/4: Competitor 'g2' not found in training history." % label,
+                    messages,
+                )
+
+    def test_process_history_still_creates_competitors_on_demand(self):
+        """Training is unchanged: unseen identifiers are created and the bout is recorded."""
+        arena = LambdaArena(func=lambda a, b: True)
+        arena.process_history([("new_a", "new_b", 1.0)], progress_bar=False)
+
+        self.assertEqual(sorted(arena.competitors), ["new_a", "new_b"])
+        self.assertEqual(len(arena.history.bouts), 1)
+
+
 class TestArenaStateRoundTrip(unittest.TestCase):
     """LambdaArena must be restorable from its own export_state() output."""
 


### PR DESCRIPTION
Closes #133

## What was wrong

`LambdaArena.evaluate_performance` and `LambdaArena.validate` opened their loop with a `try` / `except KeyError` around `_get_or_create_competitor`, but that helper *creates* a competitor for any unseen identifier and never raises. The skip branch was unreachable, `skipped_bouts` was always 0 for that cause, and the "not found in training history" warning could never fire.

The visible consequences: every held-out row naming an untrained identifier was scored as a real prediction against a freshly defaulted rating (a flat `0.5` when both were unknown) and counted toward `eval_history` accuracy, calibration and threshold optimization — and the identifier was **permanently added to `arena.competitors`**, so it appeared in `leaderboard()` and `export_state()` having played nothing.

`elote/datasets/utils.py::evaluate_arena_with_dataset` already had the intended behaviour (`if a not in arena.competitors or b not in arena.competitors: continue`), so the two evaluation surfaces disagreed and the arena-native one was the wrong one.

## What changed

- `evaluate_performance` and `validate` now check membership against `self.competitors` before doing anything, incrementing `skipped_bouts` and emitting the existing warning (naming the first unknown identifier) when either side is unknown. The dead `try` / `except KeyError` is gone rather than left as a second unreachable path.
- `process_history` is untouched — that is training, where create-on-demand is correct.
- Both docstrings now state the skip behaviour.

## Behaviour change worth calling out

This is a genuine behaviour change, not just dead-code removal. Callers whose evaluation/validation sets contain cold-start competitors will now see **fewer** bouts in `eval_history` / `validation_history`, and their reported evaluation accuracy may move — the previously-recorded predictions against default ratings were meaningless, so the figures should improve in meaning if not in value. This matches what `evaluate_arena_with_dataset` has always done.

## Verification

Run from the worktree at branch point `52562e3`.

**Full suite** — `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py`
- base (`git stash`): **399 passed, 6 skipped**
- branch: **404 passed, 6 skipped** (the 5 new tests)

(The issue quoted 387 as the baseline; that was measured on the older `51ba5ee`. `52562e3` is the current tip of `master` and is at 399.)

**Lint** — `env -u VIRTUAL_ENV uv run --extra dev ruff check .` → `All checks passed!`

**Mutation check.** I restored the original `try` / `except KeyError` in both methods (verified the mutation was live by grepping for `except KeyError` — 2 hits — and clearing `__pycache__`), then re-ran `tests/test_Arenas.py`: **4 failed, 22 passed**. Which test catches which half:

| Test | Fails on the mutation with |
|---|---|
| `test_evaluate_performance_records_only_known_bouts` | `AssertionError: 4 != 1` — the three unknown rows each recorded a bout (**no-bout half**) |
| `test_validate_records_only_known_bouts` | `AssertionError: 4 != 1` — same, for `validate` (**no-bout half**) |
| `test_leaderboard_and_export_state_exclude_evaluation_only_identifiers` | `Lists differ: ['g2', 'g3', 'ghost', 'x', 'y'] != ['x', 'y']` (**population-unchanged half**) |
| `test_unknown_competitor_warning_is_emitted` | `AssertionError: no logs of level WARNING or higher triggered on elote` — the warning is genuinely unreachable on the old code |
| `test_process_history_still_creates_competitors_on_demand` | *passes on both* — deliberately, it documents that training is unchanged |

So the no-bout half is carried by the two `*_records_only_known_bouts` tests and the population-unchanged half by `test_leaderboard_and_export_state_...`; the first two also assert the population and ratings, so they cover both. The `process_history` test guards nothing about this fix by design — it is the regression guard against over-applying the membership check to the training path.

After restoring the fix I re-ran the full suite (404 passed, 6 skipped) to confirm the baseline was green again and the working tree held the fix, not the mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)