### PR TITLE
Normalize outcomes in History.accuracy_by_prior_bouts

### DIFF
--- a/elote/arenas/base.py
+++ b/elote/arenas/base.py
@@ -594,10 +594,21 @@ class History:
         logger.info("Calculating accuracy by prior bouts for %d evaluation bouts.", len(self.bouts))
 
         # Process each bout in the evaluation history
+        skipped_bouts = 0
         for bout in self.bouts:
             # Get the current bout count for each competitor
             a_count = competitor_bout_counts.get(bout.a, 0)
             b_count = competitor_bout_counts.get(bout.b, 0)
+
+            # Update bout counts for both competitors for subsequent bouts in evaluation
+            competitor_bout_counts[bout.a] = a_count + 1
+            competitor_bout_counts[bout.b] = b_count + 1
+
+            # Outcomes are heterogeneous (arena strings or caller floats); normalize before comparing
+            actual = bout._normalized_outcome()
+            if actual is None:
+                skipped_bouts += 1
+                continue
 
             # Determine the minimum bout count between the two competitors
             min_bout_count = min(a_count, b_count)
@@ -608,20 +619,18 @@ class History:
 
             # Check if prediction is correct, properly handling draws
             is_predicted_draw = lower_threshold <= bout.predicted_outcome <= upper_threshold
-            is_actual_draw = bout.outcome == 0.5
 
             if (
-                (is_predicted_draw and is_actual_draw)
-                or (bout.predicted_outcome > upper_threshold and bout.outcome == 1.0)
-                or (bout.predicted_outcome < lower_threshold and bout.outcome == 0.0)
+                (is_predicted_draw and actual == "draw")
+                or (bout.predicted_outcome > upper_threshold and actual == "a")
+                or (bout.predicted_outcome < lower_threshold and actual == "b")
             ):
                 accuracy_by_min_bouts[min_bout_count]["correct"] += 1
 
             accuracy_by_min_bouts[min_bout_count]["total"] += 1
 
-            # Update bout counts for both competitors for subsequent bouts in evaluation
-            competitor_bout_counts[bout.a] = a_count + 1
-            competitor_bout_counts[bout.b] = b_count + 1
+        if skipped_bouts > 0:
+            logger.warning("Skipped %d bouts with unrecognized outcomes while calculating accuracy.", skipped_bouts)
 
         # Calculate accuracy for each bucket
         for _bout_count, metrics in accuracy_by_min_bouts.items():

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 from elote.arenas.base import History, Bout
 from elote.competitors.elo import EloCompetitor
@@ -448,6 +449,116 @@ class TestOptimizeThresholds(unittest.TestCase):
 
         self.assertEqual(first, second)
         self.assertLessEqual(first[1][0], first[1][1])
+
+
+def _repeated_history(outcome, predicted_outcome=0.9, count=20):
+    """Build a history of identical bouts, so every bin lands in one bucket."""
+    history = History()
+    for _ in range(count):
+        history.add_bout(Bout("a", "b", predicted_outcome, outcome))
+    return history
+
+
+def _arena_with_online_eval_history(training_matchups=200, eval_matchups=160, seed=11):
+    """Train an arena, then record further ``matchup`` calls as an online evaluation history.
+
+    ``LambdaArena.matchup`` records the strings ``"win"``/``"loss"``/``"tie"`` as the bout
+    outcome, which is the path the float-only dataset helpers never exercise.
+    """
+    rng = random.Random(seed)
+    strengths = {"c%d" % i: rng.gauss(0, 200) for i in range(12)}
+
+    def comparison(a, b, attributes=None):
+        return strengths[a] + rng.gauss(0, 100) > strengths[b] + rng.gauss(0, 100)
+
+    arena = LambdaArena(comparison, base_competitor=EloCompetitor)
+    ids = list(strengths)
+    for _ in range(training_matchups):
+        a, b = rng.sample(ids, 2)
+        arena.matchup(a, b)
+
+    training_history = arena.history
+    arena.history = History()
+    for _ in range(eval_matchups):
+        a, b = rng.sample(ids, 2)
+        arena.matchup(a, b)
+    eval_history = arena.history
+    arena.history = training_history
+
+    return arena, eval_history
+
+
+class TestAccuracyByPriorBouts(unittest.TestCase):
+    """``accuracy_by_prior_bouts`` must read outcomes the way every other metric does."""
+
+    def test_string_outcomes_score_identically_to_float_outcomes(self):
+        """A history of arena-recorded "win" bouts reports the same accuracy as 1.0 bouts."""
+        arena = MockArena()
+
+        string_binned = _repeated_history("win").accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+        float_binned = _repeated_history(1.0).accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+
+        self.assertEqual(float_binned[0]["accuracy"], 1.0)
+        self.assertEqual(string_binned[0]["accuracy"], 1.0)
+        self.assertEqual(string_binned, float_binned)
+
+    def test_string_losses_score_identically_to_float_outcomes(self):
+        """The "loss" spelling must be scored against the lower threshold, not dropped."""
+        arena = MockArena()
+
+        string_binned = _repeated_history("loss", predicted_outcome=0.1).accuracy_by_prior_bouts(arena, bin_size=100)
+        float_binned = _repeated_history(0.0, predicted_outcome=0.1).accuracy_by_prior_bouts(arena, bin_size=100)
+
+        self.assertEqual(string_binned["binned"][0]["accuracy"], 1.0)
+        self.assertEqual(string_binned, float_binned)
+
+    def test_tie_outcomes_are_counted_inside_the_draw_band(self):
+        """Drawn bouts recorded as "tie" count as correct when the prediction is in the band."""
+        arena = MockArena()
+        history = History()
+        for _ in range(12):
+            history.add_bout(Bout("a", "b", 0.5, "tie"))
+        for _ in range(8):
+            history.add_bout(Bout("a", "b", 0.5, "win"))
+
+        binned = history.accuracy_by_prior_bouts(arena, thresholds=(0.4, 0.6), bin_size=100)["binned"]
+
+        self.assertEqual(binned[0]["total"], 20)
+        self.assertAlmostEqual(binned[0]["accuracy"], 12 / 20)
+
+    def test_unrecognized_outcomes_are_skipped_not_counted_wrong(self):
+        """A bout whose outcome does not normalize is skipped rather than scored as incorrect."""
+        arena = MockArena()
+        history = _repeated_history("win")
+        for _ in range(5):
+            history.add_bout(Bout("a", "b", 0.9, "nonsense"))
+
+        binned = history.accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+
+        self.assertEqual(binned[0]["total"], 20)
+        self.assertEqual(binned[0]["accuracy"], 1.0)
+
+    def test_arena_driven_bins_agree_with_calculate_metrics(self):
+        """The bout-weighted mean of the bins equals the accuracy of the same history."""
+        arena, eval_history = _arena_with_online_eval_history()
+
+        # Every bout carries an arena string outcome, so the pre-fix code scored zero of them.
+        self.assertTrue(all(isinstance(bout.outcome, str) for bout in eval_history.bouts))
+
+        expected = eval_history.calculate_metrics()["accuracy"]
+        self.assertGreater(expected, 0.5)
+
+        # bin_size=25 keeps every bin above the method's own reporting floor of 10 bouts,
+        # so the weighted mean covers the whole history.
+        binned = eval_history.accuracy_by_prior_bouts(arena, bin_size=25)["binned"]
+        self.assertGreater(len(binned), 1)
+        self.assertTrue(all(bin_data["accuracy"] is not None for bin_data in binned.values()))
+
+        total = sum(bin_data["total"] for bin_data in binned.values())
+        weighted = sum(bin_data["accuracy"] * bin_data["total"] for bin_data in binned.values())
+
+        self.assertEqual(total, len(eval_history.bouts))
+        self.assertAlmostEqual(weighted / total, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #132

`History.accuracy_by_prior_bouts` was the last `History` reader comparing `bout.outcome` **raw** against `1.0`/`0.5`/`0.0`. `Bout.outcome` is heterogeneous by design — `LambdaArena.matchup()` records the strings `"win"`/`"loss"`/`"tie"`, while the dataset helpers and `evaluate_performance`/`validate` store the caller's floats — so no string-outcome bout could satisfy any of the three conditions and **every bin came back at exactly 0.0** for any history built through the arena. `plot_accuracy_by_prior_bouts` consumes this output directly, so the "does the model improve with experience?" plot drew a flat zero line for those users.

## What changed

`elote/arenas/base.py` — inside `accuracy_by_prior_bouts` only:

- The outcome is read once via `bout._normalized_outcome()` and compared against `"a"`/`"draw"`/`"b"`, matching how `confusion_matrix`, `calculate_metrics` and `get_calibration_data` already do it.
- A bout whose outcome does not normalize is skipped (and logged, in aggregate) rather than counted as incorrect, consistent with `confusion_matrix`'s skip rule — it no longer inflates the bin `total`. Prior-bout counts are still advanced for such a bout, since the competitors did play it.

Float outcomes are unaffected: `_normalized_outcome()` maps them to the same three categories, so `elote/benchmark.py` output is unchanged.

`tests/test_history_metrics.py` gains `TestAccuracyByPriorBouts` (5 tests), including one driving a real `LambdaArena` — 200 training matchups, then 160 further `arena.matchup()` calls recorded as an online evaluation history, so every bout carries a string outcome.

Deliberately **out of scope** (noted in the issue): the binning step's hardcoded `total > 10` floor, which silently reports `accuracy: None` for small bins. Worth its own issue.

## Verification

All commands run from the branch with `env -u VIRTUAL_ENV uv run --extra dev`.

- `pytest -q --ignore=tests/test_examples.py` → **420 passed, 6 skipped** (measured baseline on master at 934b979 via `git stash`: 415 passed, 6 skipped; +5 new).
- `ruff check .` → All checks passed.
- `grep -n "bout.outcome ==" elote/arenas/base.py` → no hits.
- 20 bouts at `predicted_outcome=0.9`: outcome `"win"` and outcome `1.0` now both report bin accuracy `1.0`, and the two binned dicts are equal (`test_string_outcomes_score_identically_to_float_outcomes`). Same for `"loss"` vs `0.0` at `predicted_outcome=0.1`.
- Arena-driven run (`test_arena_driven_bins_agree_with_calculate_metrics`): the bout-weighted mean of the per-bin accuracies equals `calculate_metrics()["accuracy"]` on the same history (0.8625) to float tolerance, over 160 bouts in 2 bins. `bin_size=25` is chosen so every bin clears the method's own `total > 10` reporting floor — otherwise the dropped small bins make the weighted mean cover only part of the history, an artifact of the out-of-scope floor rather than of this fix.
- Drawn bouts recorded as `"tie"` with `thresholds=(0.4, 0.6)` and `predicted_outcome=0.5`: 12 ties + 8 wins → accuracy exactly 0.6 (`test_tie_outcomes_are_counted_inside_the_draw_band`).

### Mutation check

1. **Reverting only the normalization** (back to `actual = bout.outcome` plus the raw `== 1.0/0.5/0.0` comparisons; mutation confirmed on disk and `__pycache__` cleared): **5 failed, 415 passed** — all five new tests fail. Critically, the pre-existing float-path test `tests/test_datasets.py::test_accuracy_by_prior_bouts_counts_drawn_training_bouts` **passes under the mutation** (it is in the 415). That is expected — it exercises unchanged behaviour on the float path, so it does **not** guard this fix; the new arena-driven test is what carries the evidence.
2. **Dropping only the unrecognized-outcome skip** (keeping normalization): 1 failed — `test_unrecognized_outcomes_are_skipped_not_counted_wrong`. So the two halves of the change are guarded by disjoint tests rather than one test standing in for both.

After restoring, the suite is green again at 420 passed / 6 skipped and the diff contains no mutation residue (`git status` clean).