### PR TITLE
Add PythagoreanCompetitor, the points-based classical expectation system

### DIFF
--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -93,6 +93,15 @@ Keener Competitor
    :show-inheritance:
    :special-members: __init__
 
+Pythagorean Competitor
+----------------------
+
+.. automodule:: elote.competitors.pythagorean
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 Bradley-Terry Competitor
 -----------------------
 

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -55,6 +55,12 @@ Keener Competitor
 .. autoclass:: elote.competitors.keener.KeenerCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Pythagorean Competitor
+----------------------
+
+.. autoclass:: elote.competitors.pythagorean.PythagoreanCompetitor
+    :members: export_state,expected_score,beat,tied,rating,to_json,from_json
+
 Bradley-Terry Competitor
 ------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/colley
    rating_systems/massey
    rating_systems/keener
+   rating_systems/pythagorean
    rating_systems/bradley_terry
    rating_systems/ensemble
    rating_systems/comparison

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -70,6 +70,12 @@ Overview Comparison
      - No
      - Yes
      - Score-based eigenvector ranking
+   * - **Pythagorean**
+     - Baseball (1980s)
+     - Low
+     - No
+     - Yes
+     - Points-based win expectation
    * - **Bradley-Terry**
      - Statistics (1952)
      - Medium
@@ -83,11 +89,12 @@ Overview Comparison
      - Depends on components
      - Complex domains
 
-Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ) update ratings incrementally after each
-result. Global-fit systems (Colley Matrix, Massey, Keener and Bradley-Terry) re-solve the whole
-connected group of competitors from the full set of results, which makes them order independent.
-Massey and Keener are the two that read the optional score payload; the rest use only who beat
-whom.
+Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ, Pythagorean) update ratings
+incrementally after each result. Global-fit systems (Colley Matrix, Massey, Keener and
+Bradley-Terry) re-solve the whole connected group of competitors from the full set of results,
+which makes them order independent. Pythagorean is order independent too, for a different reason:
+its state is a running sum of points that ignores the opponent graph entirely. Massey, Keener and
+Pythagorean are the three that read the optional score payload; the rest use only who beat whom.
 
 Mathematical Formulation
 -----------------------
@@ -116,6 +123,8 @@ Mathematical Formulation
      - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B)}}`
    * - **Keener**
      - Ratings are the dominant eigenvector of :math:`H_{ij} = h(a_{ij}) / g_i + \varepsilon` with :math:`a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}` and :math:`h(x) = \frac{1}{2} + \frac{1}{2}\mathrm{sgn}(x - \frac{1}{2})\sqrt{|2x - 1|}`; :math:`E_A = \frac{r_A}{r_A + r_B}`
+   * - **Pythagorean**
+     - :math:`w = \frac{PF^{k}}{PF^{k} + PA^{k}}` on prior-adjusted point totals; :math:`E_A = \frac{w_A - w_A w_B}{w_A + w_B - 2 w_A w_B}` (log5)
    * - **Bradley-Terry**
      - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
    * - **Ensemble**
@@ -148,6 +157,8 @@ Key Parameters
      - Initial rating (default 0.0), Expected-score scale
    * - **Keener**
      - Initial rating (default 1.0), Perturbation, Expected-score scale
+   * - **Pythagorean**
+     - Exponent (default 2.37), Prior points (default 1.0); no initial rating
    * - **Bradley-Terry**
      - Initial rating, Scale, Regularization, Max iterations
    * - **Ensemble**
@@ -293,6 +304,22 @@ Keener
 - The stabilizing perturbation is an extra knob that quietly couples competitors who never met
 - Requires a connected schedule to compare competitors
 
+Pythagorean
+^^^^^^^^^^^
+
+**Strengths:**
+- The rating is already a win expectation in [0, 1], with no scale to translate
+- The cheapest system here: constant-time updates, no population fit
+- Order independent, since the state is a running sum of points
+- No opponent graph to lose, so serialized state restores exactly, continued play included
+- A strong points-only baseline that decades of sports analytics have found hard to beat
+
+**Weaknesses:**
+- No strength-of-schedule adjustment at all: who supplied the points is ignored
+- Reduces to a smoothed win percentage on outcome-only data
+- The exponent is sport-specific; the default is an American-football fit
+- No uncertainty measure attached to the rating
+
 Bradley-Terry
 ^^^^^^^^^^^^^
 
@@ -340,9 +367,10 @@ Consider the following factors when choosing a rating system:
    - General purpose: Elo or Glicko
 
 3. **Order Independence**: Do you need a ranking that ignores schedule order?
-   - Yes: Colley Matrix, Massey, Keener, or Bradley-Terry
-   - Yes, and you have real scores: Massey (linear margin) or Keener (bounded score share)
-   - No: any online system (Elo, Glicko, etc.)
+   - Yes: Colley Matrix, Massey, Keener, Bradley-Terry, or Pythagorean
+   - Yes, and you have real scores: Massey (linear margin), Keener (bounded score share), or
+     Pythagorean (points ratio, no strength of schedule)
+   - No: any other online system (Elo, Glicko, etc.)
 
 4. **Computational Resources**:
    - Limited resources: Elo or ECF
@@ -373,6 +401,7 @@ Here's a quick comparison of how to use each system in Elote:
         ColleyMatrixCompetitor,
         MasseyCompetitor,
         KeenerCompetitor,
+        PythagoreanCompetitor,
         BradleyTerryCompetitor,
         BlendedCompetitor,
     )
@@ -404,6 +433,9 @@ Here's a quick comparison of how to use each system in Elote:
     # Keener (strictly positive, mean 1.0; reads real scores)
     keener_player = KeenerCompetitor()
 
+    # Pythagorean (win expectation in [0, 1]; reads real scores, no initial rating)
+    pythagorean_player = PythagoreanCompetitor(exponent=2.37)
+
     # Bradley-Terry (Elo-compatible scale)
     bt_player = BradleyTerryCompetitor(initial_rating=1500)
 
@@ -424,6 +456,9 @@ Here's a quick comparison of how to use each system in Elote:
     # Score-based systems additionally accept the optional scores payload
     home, away = KeenerCompetitor(), KeenerCompetitor()
     home.beat(away, scores=(35, 3))
+
+    scorers = PythagoreanCompetitor(), PythagoreanCompetitor()
+    scorers[0].beat(scorers[1], scores=(28, 14))
 
 Empirical Comparison
 -------------------

--- a/docs/source/rating_systems/pythagorean.rst
+++ b/docs/source/rating_systems/pythagorean.rst
@@ -1,0 +1,186 @@
+Pythagorean Expectation
+=======================
+
+Overview
+--------
+
+Pythagorean expectation is the oldest points-based rating in the sports canon. Bill James
+introduced it for baseball in the early 1980s after noticing that a team's winning percentage is
+predicted remarkably well by the runs it scored and the runs it allowed, and nothing else. The
+name comes from the resemblance of the original :math:`k = 2` form to the Pythagorean theorem.
+
+It is unusual among the systems in Elote in two ways.
+
+- **The rating is already a win expectation.** Every other shipped system produces a strength
+  score that has to be mapped through a logistic, a normal CDF or a share before it can be read
+  as a probability. A Pythagorean rating is a number in :math:`[0, 1]` that reads directly as
+  "the fraction of games this competitor should win".
+- **It ignores the opponent graph entirely.** A competitor's rating depends only on its own
+  accumulated points for and points against, never on who supplied them. That makes it the
+  cheapest system in the library -- a constant-time update with no graph, no matrix and no refit
+  -- and it is also its main limitation: there is no strength-of-schedule adjustment at all.
+
+How It Works
+------------
+
+Let :math:`PF` be the points a competitor has scored across every game it has played and
+:math:`PA` the points it has allowed. Its rating is
+
+.. math::
+
+   w = \frac{PF^{k}}{PF^{k} + PA^{k}}
+
+The exponent :math:`k` is the one free parameter and is fitted per sport: :math:`2` for baseball
+(James' original), around :math:`2.37` for American football, and around :math:`14` for
+basketball, where scores are much larger and a single point is worth correspondingly less. Elote
+defaults to ``2.37``.
+
+Two competitors are compared with the standard **log5** combination of their two win
+expectations, also due to Bill James:
+
+.. math::
+
+   E_a = \frac{w_a - w_a w_b}{w_a + w_b - 2 w_a w_b}
+
+This is the probability that :math:`a` beats :math:`b` given the rate at which each of them beats
+the field. It is analytically complementary, and the implementation preserves that exactly in
+floating point: the two argument orders sum to exactly ``1.0`` and two equal ratings give exactly
+``0.5``.
+
+Degenerate inputs
+^^^^^^^^^^^^^^^^^
+
+A fresh competitor has :math:`PF = PA = 0`, which makes the rating :math:`0/0`, and an unbeaten
+one has :math:`PA = 0`, which makes the rating exactly :math:`1` and log5 in turn a :math:`0/0`.
+Elote handles both by adding a small **symmetric prior** :math:`c` (``prior_points``, default
+``1.0`` point) to each accumulator rather than by clamping the output:
+
+.. math::
+
+   w = \frac{(PF + c)^{k}}{(PF + c)^{k} + (PA + c)^{k}}
+
+The rating therefore stays a continuous, strictly increasing function of the real totals, a fresh
+competitor sits at exactly ``0.5``, and every rating is strictly inside :math:`(0, 1)`, so log5 is
+always defined. The prior is comparable in size to the library's unit scores and negligible
+against real ones, so it fades as soon as a competitor has played.
+
+Scores
+------
+
+Points are what this system is built on, so supplying real ones is the intended use. ``beat`` /
+``lost_to`` / ``tied`` accept the common optional ``scores`` payload -- the two competitors'
+scores **in the argument order of the call**:
+
+.. code-block:: python
+
+    from elote import PythagoreanCompetitor
+
+    team_a, team_b = PythagoreanCompetitor(), PythagoreanCompetitor()
+
+    team_a.beat(team_b, scores=(28, 14))
+    # The same game from the loser's side -- the pair is not reordered:
+    # team_b.lost_to(team_a, scores=(14, 28))
+
+Through an arena the pair is always given in ``(a, b)`` order, whichever competitor won, together
+with an explicit ``outcome`` so the two can be checked for agreement:
+
+.. code-block:: python
+
+    from elote import LambdaArena, PythagoreanCompetitor
+
+    arena = LambdaArena(lambda a, b: True, base_competitor=PythagoreanCompetitor)
+    arena.matchup("Team A", "Team B", outcome=1.0, scores=(28, 14))
+    arena.matchup("Team A", "Team C", outcome=0.0, scores=(7, 24))   # C won; order unchanged
+
+.. note::
+
+   When ``scores`` is omitted, the same unit-score fallback the rest of the library uses applies:
+   the winner is credited ``1`` and the loser ``0``, and a draw credits each side ``0.5``. On
+   unit scores the rating degenerates into a smoothed winning percentage -- still a usable
+   baseline, but it throws away the information the method exists to use.
+
+Advantages
+----------
+
+- **Directly Interpretable**: the rating *is* a win expectation, with no scale to translate.
+- **Cheapest System Here**: constant-time updates, no population fit, no matrix, no eigenvector.
+- **Order Independent**: the totals are a sum, so the schedule order cannot matter.
+- **Exact Persistence**: there is no opponent graph to lose, so a serialized competitor restores
+  exactly, including continued play.
+- **A Strong Baseline**: decades of sports analytics have found it hard to beat given only points.
+
+Limitations
+-----------
+
+- **No Strength of Schedule**: a 28-14 win over the best competitor in the population and over the
+  worst are worth exactly the same.
+- **Needs Scores**: on outcome-only data it reduces to a smoothed win percentage.
+- **Sport-Specific Exponent**: the default is a football fit; using it on baseball or basketball
+  data without changing ``exponent`` will misstate how sharply points map to wins.
+- **No Uncertainty**: like Colley, Massey, Keener and Bradley-Terry, the rating is a point
+  estimate with no confidence measure attached.
+- **Blind to Context**: garbage-time points, blowouts and close games all enter the same sum.
+
+Implementation in Elote
+-----------------------
+
+Elote implements Pythagorean expectation through the ``PythagoreanCompetitor`` class:
+
+.. code-block:: python
+
+    from elote import PythagoreanCompetitor
+
+    # Every competitor starts at exactly 0.5
+    team_a = PythagoreanCompetitor()
+    team_b = PythagoreanCompetitor()
+
+    # Get win probability (log5 of the two expectations)
+    print(f"Team A win probability: {team_a.expected_score(team_b):.2%}")
+
+    # Record results with real points
+    team_a.beat(team_b, scores=(28, 14))
+
+    print(f"Team A: {team_a.rating:.4f}")   # 0.8267
+    print(f"Team B: {team_b.rating:.4f}")   # 0.1733
+
+Parameters
+^^^^^^^^^^
+
+- ``exponent`` (constructor): the Pythagorean :math:`k` for this competitor. Default: the class
+  exponent. Must be positive.
+
+Note that the constructor deliberately takes **no** ``initial_rating``: the rating is derived from
+the points totals rather than stored, so there is no starting rating to hand over, and for the
+same reason ``rating`` is read-only.
+
+Class-level parameters, set through ``PythagoreanCompetitor.configure_class(...)``:
+
+- ``exponent``: the default Pythagorean :math:`k` for new competitors. Default ``2.37``, the
+  standard American-football fit. Use ``2`` for baseball, or a much larger value for a
+  high-scoring sport such as basketball. Must be positive.
+- ``prior_points``: the symmetric prior added to both accumulators, in points. Default ``1.0``.
+  Larger values pull ratings toward ``0.5`` for longer; must be positive, since a zero prior
+  reinstates the degenerate cases it exists to remove.
+
+State and Serialization
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``export_state()`` records the two points totals and the number of games played. The rating itself
+is not exported because it is a pure function of those totals and the exponent, so restoring the
+totals restores the rating exactly.
+
+.. note::
+
+   Unlike Colley, Massey, Keener and Bradley-Terry, this system keeps no per-opponent match graph,
+   so nothing is lost on import. A restored competitor continues from exactly where the original
+   left off, and further results give ratings identical to those of the competitor it was
+   restored from.
+
+References
+----------
+
+1. James, B. (1981). *The Bill James Baseball Abstract*. The original :math:`k = 2` formulation.
+2. Schatz, A. (2003). "Pythagoras on the Gridiron". *Football Outsiders*. The :math:`k = 2.37` fit
+   for American football used as the default here.
+3. Miller, S. J. (2007). "A Derivation of the Pythagorean Won-Loss Formula in Baseball".
+   *Chance*, 20(1), 40-48. Derives the formula from a Weibull model of scoring.

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -27,6 +27,7 @@ Available rating systems:
 - Colley Matrix: A least-squares rating system that solves a system of linear equations
 - Massey: A least-squares rating system whose ratings live on a signed margin scale
 - Keener: A score-based rating system built on the dominant eigenvector of a preference matrix
+- Pythagorean: A points-based win expectation derived from points scored and allowed
 - Bradley-Terry: A maximum-likelihood paired-comparison model
 - Ensemble: A meta-rating system that combines multiple rating systems
 
@@ -50,6 +51,7 @@ from elote.competitors.dwz import DWZCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
 from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.keener import KeenerCompetitor
+from elote.competitors.pythagorean import PythagoreanCompetitor
 from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
@@ -87,6 +89,7 @@ __all__ = [
     "ColleyMatrixCompetitor",
     "MasseyCompetitor",
     "KeenerCompetitor",
+    "PythagoreanCompetitor",
     "BradleyTerryCompetitor",
     "BlendedCompetitor",
     # Arenas

--- a/elote/competitors/pythagorean.py
+++ b/elote/competitors/pythagorean.py
@@ -1,0 +1,381 @@
+"""Pythagorean expectation implementation for the Elote library.
+
+Pythagorean expectation is the oldest points-based rating in the sports canon. Bill James
+introduced it for baseball in the early 1980s, observing that a team's winning percentage is
+predicted remarkably well by the runs it scored and the runs it allowed:
+
+.. math::
+
+   w = \\frac{PF^{k}}{PF^{k} + PA^{k}}
+
+The name comes from the resemblance to the Pythagorean theorem in the original ``k = 2``
+form. The exponent is the one free parameter, and it is fitted per sport: 2 for baseball
+(James' original), around 2.37 for American football, and around 14 for basketball, where
+scores are much larger and a point is worth correspondingly less.
+
+Two properties make it unusual in this library.
+
+1. **The rating is already a win expectation.** Every other shipped system produces a
+   strength score that has to be mapped through a logistic, a normal CDF or a share before it
+   can be read as a probability. A Pythagorean rating is a number in ``[0, 1]`` that reads
+   directly as "the fraction of games this competitor should win against the field it has
+   played".
+2. **It ignores the opponent graph entirely.** A competitor's rating depends only on its own
+   accumulated points for and points against, never on who supplied them. That makes it the
+   cheapest system here -- a constant-time update with no graph, no matrix and no refit --
+   and also its main limitation: it makes no strength-of-schedule adjustment at all.
+
+Two competitors are compared through the standard log5 combination of their two win
+expectations,
+
+.. math::
+
+   E_a = \\frac{w_a - w_a w_b}{w_a + w_b - 2 w_a w_b}
+
+which is Bill James' formula for the probability that ``a`` beats ``b`` given the rate at
+which each of them beats the field.
+
+References:
+- James, B. (1981). *The Bill James Baseball Abstract*. The original ``k = 2`` formulation.
+- Schatz, A. (2003). "Pythagoras on the Gridiron", Football Outsiders. The ``k = 2.37`` fit
+  for American football used as the default here.
+- Miller, S. J. (2007). "A Derivation of the Pythagorean Won-Loss Formula in Baseball".
+  *Chance*, 20(1), 40-48. Derives the formula from a Weibull model of scoring.
+"""
+
+from typing import Dict, Any, ClassVar, Optional, Sequence, Type, TypeVar, cast
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException
+from elote.logging import logger
+
+T = TypeVar("T", bound="PythagoreanCompetitor")
+
+
+class PythagoreanCompetitor(BaseCompetitor):
+    """Pythagorean expectation competitor.
+
+    Rates a competitor from the points it has scored and the points it has allowed. Unlike
+    Colley, Massey, Keener and Bradley-Terry, nothing is fitted across a population: each
+    result adds to two running totals, and the rating is read straight off them. Unlike Elo
+    and the other incremental systems, the update does not depend on the opponent at all.
+
+    **Scores.** ``beat`` / ``lost_to`` / ``tied`` accept the common optional ``scores``
+    payload, the two competitors' scores in caller order. Points are what this system is
+    built on, so supplying real ones is the intended use. When they are omitted the same
+    unit-score fallback the rest of the library uses applies: the winner is credited ``1``
+    and the loser ``0``, and a draw credits each side ``0.5``. On unit scores the rating
+    degenerates into a smoothed winning percentage, which is still a usable baseline.
+
+    **Degenerate inputs.** A fresh competitor has ``PF = PA = 0`` and an unbeaten one has
+    ``PA = 0``; the first makes the rating ``0/0`` and the second makes it exactly ``1``,
+    which in turn makes log5 ``0/0``. Both are handled by a small symmetric prior added to
+    each accumulator rather than by clamping the output: the rating stays a continuous,
+    strictly monotone function of the real totals, a fresh competitor is exactly ``0.5``, and
+    every rating is strictly inside ``(0, 1)``, so log5 is always defined.
+
+    Key characteristics:
+    - The rating is a win expectation in [0, 1], not a strength score
+    - Constant-time update: no opponent graph, no refit, no order dependence
+    - Reads real scores; falls back to unit scores when they are omitted
+    - Makes no strength-of-schedule adjustment whatsoever
+
+    Class Attributes:
+        _minimum_rating (float): The minimum allowed rating value. Default: 0.0. The rating
+            is a probability, so the inherited Elo-style floor of 100 would saturate it.
+        _default_initial_rating (float): The rating of a competitor that has not played.
+            Default: 0.5, which the symmetric prior produces exactly.
+        _exponent (float): Pythagorean ``k``. Default: 2.37, the standard fit for American
+            football (Football Outsiders). Use 2 for baseball, or a much larger value for a
+            high-scoring sport such as basketball.
+        _prior_points (float): The symmetric prior added to both accumulators, in points.
+            Default: 1.0 -- comparable to the unit scores, negligible against real ones.
+    """
+
+    _minimum_rating: ClassVar[float] = 0.0
+    _default_initial_rating: ClassVar[float] = 0.5
+    _exponent: ClassVar[float] = 2.37
+    _prior_points: ClassVar[float] = 1.0
+
+    def __init__(self, exponent: Optional[float] = None):
+        """Initialize a Pythagorean competitor.
+
+        There is deliberately no ``initial_rating`` argument: the rating is derived from the
+        points totals rather than stored, and a caller-supplied starting rating on a ``[0, 1]``
+        scale has no points totals that would produce it.
+
+        Args:
+            exponent (float, optional): The Pythagorean exponent for this competitor. If
+                None, the class exponent is used. Default: None.
+
+        Raises:
+            InvalidParameterException: If the exponent is not positive.
+        """
+        super().__init__()
+
+        if exponent is not None and exponent <= 0:
+            raise InvalidParameterException("Pythagorean exponent must be positive")
+
+        self._exponent = exponent if exponent is not None else PythagoreanCompetitor._exponent
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._num_games = 0
+        logger.debug("Initialized PythagoreanCompetitor with exponent %.4f", self._exponent)
+
+    def __repr__(self) -> str:
+        """Return a string representation of this competitor."""
+        return (
+            f"<PythagoreanCompetitor: rating={self.rating:.4f}, "
+            f"points={self._points_for:.1f}-{self._points_against:.1f}, games={self._num_games}>"
+        )
+
+    def __str__(self) -> str:
+        """Return a string representation of this competitor."""
+        return f"<PythagoreanCompetitor: rating={self.rating:.4f}>"
+
+    @property
+    def rating(self) -> float:
+        """Get the current rating of this competitor.
+
+        The rating is the Pythagorean win expectation ``PF^k / (PF^k + PA^k)``, computed on
+        the prior-adjusted totals. It is evaluated in the equivalent ratio form
+        ``1 / (1 + (PA/PF)^k)``, which cannot overflow for large totals and returns exactly
+        0.5 whenever the two totals are equal.
+
+        Returns:
+            float: The current rating, strictly inside (0, 1).
+        """
+        scored = self._points_for + self._prior_points
+        allowed = self._points_against + self._prior_points
+        try:
+            powered = (allowed / scored) ** self._exponent
+        except OverflowError:
+            # Needs a points ratio around 1e130, so this is a guard rather than a case:
+            # such a competitor has been outscored beyond anything the float scale can
+            # express, and its expectation is zero to every digit available.
+            powered = float("inf")
+        return float(1.0 / (1.0 + powered))
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        """Set the current rating of this competitor.
+
+        Not supported: the rating is derived from the points totals, so there is no single
+        pair of totals that a given rating corresponds to.
+
+        Args:
+            value (float): The new rating value.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        logger.warning("Attempted to set rating directly on PythagoreanCompetitor, which is not supported.")
+        raise NotImplementedError(
+            "Cannot directly set the rating of a PythagoreanCompetitor. It is derived from points for and against."
+        )
+
+    @property
+    def num_games(self) -> int:
+        """Get the total number of games played by this competitor.
+
+        Returns:
+            int: The total number of games played.
+        """
+        return self._num_games
+
+    @staticmethod
+    def _log5(higher: float, lower: float) -> float:
+        """Combine two win expectations with log5, given in descending order.
+
+        The denominator is formed as the sum of the two numerators rather than as the
+        textbook ``w_a + w_b - 2 w_a w_b``. The two are the same expression, but summing the
+        already-rounded numerators keeps the quotient inside ``[0.5, 1]`` in floating point:
+        both numerators are non-negative and the larger one is at least the smaller, so the
+        denominator is at least the numerator and at most twice it. Written the textbook way,
+        a heavily lopsided pair rounds to 1.0000000000000002.
+
+        Args:
+            higher: The larger of the two win expectations.
+            lower: The smaller of the two win expectations.
+
+        Returns:
+            float: The probability that the ``higher`` competitor wins, in [0.5, 1].
+        """
+        product = higher * lower
+        higher_edge = higher - product
+        lower_edge = lower - product
+        denominator = higher_edge + lower_edge
+        if denominator <= 0.0:
+            # Only reachable when both expectations are exactly 0 or exactly 1, which the
+            # prior rules out for ratings this class produces. Two competitors that agree
+            # completely are an even matchup.
+            return 0.5
+        return higher_edge / denominator
+
+    def expected_score(self, competitor: "BaseCompetitor") -> float:
+        """Calculate the expected score against another competitor.
+
+        Both ratings are already win expectations, so they are combined with the standard
+        log5 formula. The direction with the larger rating is the one actually computed and
+        the other is taken as its complement, which makes the two argument orders sum to
+        exactly 1.0 and makes two equal ratings give exactly 0.5.
+
+        Args:
+            competitor (BaseCompetitor): The competitor to compare against.
+
+        Returns:
+            float: The expected score (probability of winning).
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        mine = self.rating
+        theirs = competitor.rating
+        if mine >= theirs:
+            return self._log5(mine, theirs)
+        return 1.0 - self._log5(theirs, mine)
+
+    def _record_game(self, scored: float, allowed: float) -> None:
+        """Add one game's points to this competitor's running totals.
+
+        Args:
+            scored: The points this competitor scored.
+            allowed: The points this competitor conceded.
+        """
+        self._points_for += scored
+        self._points_against += allowed
+        self._num_games += 1
+
+    def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has won against the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that lost.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. When omitted the unit scores ``1`` and
+                ``0`` are recorded.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a win for this competitor.
+        """
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 1.0)
+        opponent = cast(PythagoreanCompetitor, competitor)
+        mine, theirs = (1.0, 0.0) if validated is None else validated
+
+        self._record_game(mine, theirs)
+        opponent._record_game(theirs, mine)
+        logger.debug("Recorded win %.3f-%.3f for %s over %s", mine, theirs, self, opponent)
+
+    def tied(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
+        """Update ratings after this competitor has tied with the given competitor.
+
+        Args:
+            competitor (BaseCompetitor): The opponent competitor that tied.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They must be equal. When omitted each
+                side is credited the unit draw score ``0.5``.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+            ValueError: If ``scores`` does not describe a draw.
+        """
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.5)
+        opponent = cast(PythagoreanCompetitor, competitor)
+        mine, theirs = (0.5, 0.5) if validated is None else validated
+
+        self._record_game(mine, theirs)
+        opponent._record_game(theirs, mine)
+        logger.debug("Recorded draw %.3f-%.3f between %s and %s", mine, theirs, self, opponent)
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        """Export the parameters used to initialize this competitor.
+
+        Returns:
+            dict: A dictionary containing the initialization parameters.
+        """
+        return {
+            "exponent": self._exponent if self._exponent != self.__class__._exponent else None,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        """Export the current state variables of this competitor.
+
+        The rating itself is not exported: it is a pure function of the two totals and the
+        exponent, so restoring the totals restores the rating exactly.
+
+        Returns:
+            dict: A dictionary containing the current state variables.
+        """
+        return {
+            "points_for": self._points_for,
+            "points_against": self._points_against,
+            "num_games": self._num_games,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        """Import parameters from a state dictionary.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        exponent = parameters.get("exponent", None)
+        if exponent is not None and exponent <= 0:
+            raise InvalidParameterException("Pythagorean exponent must be positive")
+        self._exponent = exponent if exponent is not None else PythagoreanCompetitor._exponent
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        """Import current state variables from a state dictionary.
+
+        Args:
+            state (dict): A dictionary containing state variables.
+
+        Raises:
+            InvalidParameterException: If any state variable is invalid.
+        """
+        points_for = state.get("points_for", 0.0)
+        points_against = state.get("points_against", 0.0)
+        if points_for < 0 or points_against < 0:
+            raise InvalidParameterException("Point totals cannot be negative")
+        self._points_for = float(points_for)
+        self._points_against = float(points_against)
+        self._num_games = int(state.get("num_games", 0))
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        """Create a new competitor instance from parameters.
+
+        Args:
+            parameters (dict): A dictionary containing parameters.
+
+        Returns:
+            PythagoreanCompetitor: A new competitor instance.
+        """
+        return cls(exponent=parameters.get("exponent", None))
+
+    def reset(self) -> None:
+        """Reset this competitor to its initial state."""
+        logger.info("Resetting PythagoreanCompetitor to initial state.")
+        self._points_for = 0.0
+        self._points_against = 0.0
+        self._num_games = 0
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        """Configure class-level parameters for this rating system.
+
+        Overrides the base implementation to validate the Pythagorean-specific parameters.
+
+        Raises:
+            InvalidParameterException: If any parameter is invalid.
+        """
+        if "exponent" in kwargs and kwargs["exponent"] <= 0:
+            raise InvalidParameterException("Pythagorean exponent must be positive")
+        if "prior_points" in kwargs and kwargs["prior_points"] <= 0:
+            raise InvalidParameterException("prior_points must be positive")
+        super().configure_class(**kwargs)

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -14,6 +14,7 @@ from elote import (
     KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
+    PythagoreanCompetitor,
     TrueSkillCompetitor,
 )
 
@@ -417,6 +418,7 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         BradleyTerryCompetitor,
         MasseyCompetitor,
         KeenerCompetitor,
+        PythagoreanCompetitor,
     )
 
     # Colley, Massey, Bradley-Terry and Keener reset their opponent match graph on import by design
@@ -429,6 +431,7 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         TrueSkillCompetitor,
         ECFCompetitor,
         DWZCompetitor,
+        PythagoreanCompetitor,
     )
 
     # Elo aborts on its rating floor when a competitor loses repeatedly from the

--- a/tests/test_PythagoreanCompetitor.py
+++ b/tests/test_PythagoreanCompetitor.py
@@ -1,0 +1,358 @@
+"""Behavioural tests for PythagoreanCompetitor.
+
+Numeric reference values live in tests/test_PythagoreanCompetitor_known_values.py.
+"""
+
+import json
+import random
+import unittest
+
+from elote import LambdaArena, PythagoreanCompetitor
+from elote.competitors.base import (
+    BaseCompetitor,
+    InvalidParameterException,
+    MissMatchedCompetitorTypesException,
+)
+
+
+def _play(schedule, count=3):
+    """Apply a schedule of ``(i, j, score_i, score_j)`` tuples to ``count`` fresh competitors."""
+    competitors = [PythagoreanCompetitor() for _ in range(count)]
+    for i, j, score_i, score_j in schedule:
+        if score_i > score_j:
+            competitors[i].beat(competitors[j], scores=(score_i, score_j))
+        elif score_i < score_j:
+            competitors[i].lost_to(competitors[j], scores=(score_i, score_j))
+        else:
+            competitors[i].tied(competitors[j], scores=(score_i, score_j))
+    return competitors
+
+
+class TestPythagoreanBasics(unittest.TestCase):
+    def test_defaults(self):
+        competitor = PythagoreanCompetitor()
+        self.assertEqual(competitor.rating, 0.5)
+        self.assertEqual(competitor.rating, PythagoreanCompetitor._default_initial_rating)
+        self.assertEqual(competitor.num_games, 0)
+        self.assertEqual((competitor._points_for, competitor._points_against), (0.0, 0.0))
+
+    def test_custom_exponent(self):
+        competitor = PythagoreanCompetitor(exponent=2.0)
+        self.assertEqual(competitor._exponent, 2.0)
+        # A fresh competitor sits at 0.5 whatever the exponent.
+        self.assertEqual(competitor.rating, 0.5)
+
+    def test_non_positive_exponent_rejected(self):
+        for bad in (0.0, -1.0):
+            with self.subTest(exponent=bad):
+                with self.assertRaises(InvalidParameterException):
+                    PythagoreanCompetitor(exponent=bad)
+
+    def test_constructor_does_not_accept_an_initial_rating(self):
+        """The rating is derived from points, so there is no starting rating to hand over.
+
+        benchmark_competitors forces initial_rating=1500 on any incremental class that
+        accepts one, which is meaningless on a [0, 1] scale; not accepting the argument is
+        what keeps this class out of that path.
+        """
+        with self.assertRaises(TypeError):
+            PythagoreanCompetitor(initial_rating=1500)
+
+    def test_rating_cannot_be_set_directly(self):
+        competitor = PythagoreanCompetitor()
+        with self.assertRaises(NotImplementedError):
+            competitor.rating = 0.9
+
+    def test_type_mismatch_is_rejected(self):
+        from elote import EloCompetitor
+
+        competitor = PythagoreanCompetitor()
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.expected_score(EloCompetitor())
+        with self.assertRaises(MissMatchedCompetitorTypesException):
+            competitor.beat(EloCompetitor())
+
+    def test_registered_for_state_reconstruction(self):
+        self.assertIn("PythagoreanCompetitor", BaseCompetitor.list_competitor_types())
+        self.assertIs(BaseCompetitor.get_competitor_class("PythagoreanCompetitor"), PythagoreanCompetitor)
+
+    def test_configure_class_validates_parameters(self):
+        with self.assertRaises(InvalidParameterException):
+            PythagoreanCompetitor.configure_class(exponent=0)
+        with self.assertRaises(InvalidParameterException):
+            PythagoreanCompetitor.configure_class(prior_points=-1)
+
+
+class TestPythagoreanExpectedScore(unittest.TestCase):
+    def test_two_fresh_competitors_predict_one_half(self):
+        self.assertEqual(PythagoreanCompetitor().expected_score(PythagoreanCompetitor()), 0.5)
+
+    def test_predictions_are_exactly_complementary(self):
+        a, b, c = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        for first, second in ((a, b), (b, a), (a, c), (c, b)):
+            with self.subTest(pair=(first.rating, second.rating)):
+                self.assertEqual(first.expected_score(second) + second.expected_score(first), 1.0)
+
+    def test_complementarity_holds_for_a_fixture_that_defeats_the_naive_form(self):
+        """Guards the derivation of the reverse direction, not just log5 itself.
+
+        The fixture was selected programmatically: evaluating log5 independently in each
+        direction, instead of deriving one from the other, loses exact complementarity for
+        about 13% of random point-total pairs (26,894 of 200,000 sampled), and none of the
+        hand-written fixtures in this class happen to be among them.
+        """
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        foils = [PythagoreanCompetitor() for _ in range(3)]
+        a.beat(foils[0], scores=(65.0, 60.0))
+        a.beat(foils[1], scores=(64.0, 61.0))
+        b.lost_to(foils[2], scores=(73.0, 389.0))
+
+        self.assertEqual((a._points_for, a._points_against), (129.0, 121.0))
+        self.assertEqual((b._points_for, b._points_against), (73.0, 389.0))
+        self.assertEqual(a.expected_score(b) + b.expected_score(a), 1.0)
+
+    def test_equal_records_predict_exactly_one_half(self):
+        """Two competitors with identical totals are an even matchup, exactly."""
+        a, b, c, d = (PythagoreanCompetitor() for _ in range(4))
+        a.beat(c, scores=(31.0, 17.0))
+        b.beat(d, scores=(31.0, 17.0))
+        self.assertEqual(a.rating, b.rating)
+        self.assertEqual(a.expected_score(b), 0.5)
+        self.assertEqual(b.expected_score(a), 0.5)
+
+    def test_predictions_stay_in_the_unit_interval_after_lopsided_results(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        for _ in range(50):
+            a.beat(b, scores=(99.0, 0.0))
+            for first, second in ((a, b), (b, a)):
+                score = first.expected_score(second)
+                self.assertGreaterEqual(score, 0.0)
+                self.assertLessEqual(score, 1.0)
+            self.assertEqual(a.expected_score(b) + b.expected_score(a), 1.0)
+
+    def test_an_unbeaten_competitor_still_has_a_defined_prediction(self):
+        """PA = 0 would make the raw rating exactly 1 and log5 a 0/0; the prior prevents it."""
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        for _ in range(10):
+            a.beat(b, scores=(21.0, 0.0))
+
+        self.assertLess(a.rating, 1.0)
+        self.assertGreater(b.rating, 0.0)
+        self.assertLess(a.expected_score(b), 1.0)
+        self.assertGreater(a.expected_score(b), 0.99)
+
+    def test_stronger_competitor_is_favoured(self):
+        a, b, _ = _play([(0, 1, 40, 3), (1, 2, 21, 17), (0, 2, 35, 0)])
+        self.assertGreater(a.rating, b.rating)
+        self.assertGreater(a.expected_score(b), 0.5)
+
+
+class TestPythagoreanResults(unittest.TestCase):
+    def test_win_updates_both_sides(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+
+        self.assertEqual((a._points_for, a._points_against), (28.0, 7.0))
+        self.assertEqual((b._points_for, b._points_against), (7.0, 28.0))
+        self.assertEqual((a.num_games, b.num_games), (1, 1))
+        self.assertGreater(a.rating, 0.5)
+        self.assertLess(b.rating, 0.5)
+
+    def test_lost_to_records_the_same_game_as_beat(self):
+        winner_first = PythagoreanCompetitor(), PythagoreanCompetitor()
+        winner_first[0].beat(winner_first[1], scores=(28.0, 7.0))
+
+        loser_first = PythagoreanCompetitor(), PythagoreanCompetitor()
+        loser_first[1].lost_to(loser_first[0], scores=(7.0, 28.0))
+
+        self.assertEqual(loser_first[0].rating, winner_first[0].rating)
+        self.assertEqual(loser_first[1].rating, winner_first[1].rating)
+        self.assertEqual(loser_first[0]._points_for, 28.0)
+        self.assertEqual(loser_first[1]._points_for, 7.0)
+
+    def test_draw_is_symmetric(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.tied(b, scores=(17.0, 17.0))
+
+        self.assertEqual(a.rating, b.rating)
+        self.assertEqual(a.rating, 0.5)
+        self.assertEqual((a.num_games, b.num_games), (1, 1))
+
+    def test_omitted_scores_fall_back_to_unit_scores(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b)
+        self.assertEqual((a._points_for, a._points_against), (1.0, 0.0))
+
+        c, d = PythagoreanCompetitor(), PythagoreanCompetitor()
+        c.tied(d)
+        self.assertEqual((c._points_for, d._points_for), (0.5, 0.5))
+
+    def test_unit_scores_reproduce_the_omitted_score_path(self):
+        plain = PythagoreanCompetitor(), PythagoreanCompetitor()
+        plain[0].beat(plain[1])
+        plain[0].tied(plain[1])
+
+        scored = PythagoreanCompetitor(), PythagoreanCompetitor()
+        scored[0].beat(scored[1], scores=(1.0, 0.0))
+        scored[0].tied(scored[1], scores=(0.5, 0.5))
+
+        self.assertEqual(plain[0].rating, scored[0].rating)
+        self.assertEqual(plain[1].rating, scored[1].rating)
+
+    def test_real_margins_move_the_rating_in_the_documented_direction(self):
+        """A bigger margin over the same result must rate higher, and a unit win sits between."""
+        blowout = PythagoreanCompetitor(), PythagoreanCompetitor()
+        blowout[0].beat(blowout[1], scores=(50.0, 3.0))
+
+        narrow = PythagoreanCompetitor(), PythagoreanCompetitor()
+        narrow[0].beat(narrow[1], scores=(24.0, 21.0))
+
+        unit = PythagoreanCompetitor(), PythagoreanCompetitor()
+        unit[0].beat(unit[1])
+
+        self.assertGreater(blowout[0].rating, unit[0].rating)
+        self.assertGreater(unit[0].rating, narrow[0].rating)
+        self.assertGreater(narrow[0].rating, 0.5)
+        # The losers mirror the winners.
+        self.assertLess(blowout[1].rating, unit[1].rating)
+        self.assertLess(unit[1].rating, narrow[1].rating)
+
+    def test_points_conceded_lower_the_rating(self):
+        """Two runs with identical points scored are separated only by points allowed."""
+        stingy = _play([(0, 1, 30, 10), (0, 2, 30, 10)])
+        leaky = _play([(0, 1, 30, 28), (0, 2, 30, 28)])
+
+        self.assertEqual(stingy[0]._points_for, leaky[0]._points_for)
+        self.assertGreater(stingy[0].rating, leaky[0].rating)
+
+    def test_the_opponent_does_not_affect_the_rating(self):
+        """The defining limitation: no strength-of-schedule adjustment at all."""
+        weak_opponent = PythagoreanCompetitor(), PythagoreanCompetitor()
+        weak_opponent[0].beat(weak_opponent[1], scores=(28.0, 7.0))
+
+        strong_opponent = [PythagoreanCompetitor() for _ in range(3)]
+        strong_opponent[1].beat(strong_opponent[2], scores=(70.0, 0.0))
+        strong_opponent[0].beat(strong_opponent[1], scores=(28.0, 7.0))
+
+        self.assertEqual(weak_opponent[0].rating, strong_opponent[0].rating)
+
+    def test_exponent_controls_how_sharply_points_translate_to_rating(self):
+        low = PythagoreanCompetitor(exponent=1.0), PythagoreanCompetitor(exponent=1.0)
+        low[0].beat(low[1], scores=(28.0, 14.0))
+
+        high = PythagoreanCompetitor(exponent=8.0), PythagoreanCompetitor(exponent=8.0)
+        high[0].beat(high[1], scores=(28.0, 14.0))
+
+        self.assertGreater(high[0].rating, low[0].rating)
+
+    def test_reset_restores_a_fresh_competitor(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(28.0, 7.0))
+        a.reset()
+
+        self.assertEqual(a.rating, PythagoreanCompetitor().rating)
+        self.assertEqual(a.num_games, 0)
+        self.assertEqual((a._points_for, a._points_against), (0.0, 0.0))
+
+
+class TestPythagoreanInArena(unittest.TestCase):
+    def test_long_arena_run_keeps_every_rating_in_the_unit_interval(self):
+        """A long run must not raise and must not push any rating outside [0, 1].
+
+        Sustained lopsided play is what drives the accumulators far apart, which is exactly
+        where a saturating rating or an undefined log5 would show up.
+        """
+        arena = LambdaArena(lambda a, b: True, base_competitor=PythagoreanCompetitor)
+        rng = random.Random(1979)
+        names = ["a", "b", "c", "d", "e", "f"]
+        strength = {name: 14 + 4 * index for index, name in enumerate(names)}
+
+        for _ in range(2500):
+            first, second = rng.sample(names, 2)
+            first_score = max(0, int(rng.gauss(strength[first], 7)))
+            second_score = max(0, int(rng.gauss(strength[second], 7)))
+            if first_score > second_score:
+                outcome = 1.0
+            elif first_score < second_score:
+                outcome = 0.0
+            else:
+                outcome = 0.5
+            arena.matchup(first, second, outcome=outcome, scores=(first_score, second_score))
+
+            for competitor in arena.competitors.values():
+                self.assertGreaterEqual(competitor.rating, 0.0)
+                self.assertLessEqual(competitor.rating, 1.0)
+
+        self.assertEqual(len(arena.competitors), len(names))
+        self.assertEqual(len(arena.history.bouts), 2500)
+        # The seeded strengths are ordered, so the leaderboard should broadly recover them.
+        leaderboard = [entry["competitor"] for entry in arena.leaderboard()]
+        self.assertEqual(leaderboard[0], "f")
+        self.assertEqual(leaderboard[-1], "a")
+
+    def test_arena_forwards_scores_in_caller_order(self):
+        arena = LambdaArena(lambda a, b: True, base_competitor=PythagoreanCompetitor)
+        arena.matchup("a", "b", outcome=0.0, scores=(3.0, 35.0))
+
+        self.assertEqual(arena.competitors["a"]._points_for, 3.0)
+        self.assertEqual(arena.competitors["b"]._points_for, 35.0)
+
+
+class TestPythagoreanSerialization(unittest.TestCase):
+    def test_state_round_trip_restores_the_rating_and_the_totals(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+        a.tied(b, scores=(10.0, 10.0))
+
+        restored = PythagoreanCompetitor.from_state(a.export_state())
+
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual(restored._points_for, 45.0)
+        self.assertEqual(restored._points_against, 13.0)
+        self.assertEqual(restored.num_games, 2)
+
+    def test_json_round_trip(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+
+        restored = PythagoreanCompetitor.from_json(a.to_json())
+        self.assertEqual(restored.rating, a.rating)
+        self.assertEqual(restored._points_for, 21.0)
+
+    def test_exported_state_is_json_serializable(self):
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(21.0, 14.0))
+        self.assertIsInstance(json.dumps(a.export_state()), str)
+
+    def test_a_custom_exponent_survives_the_round_trip(self):
+        a = PythagoreanCompetitor(exponent=2.0)
+        b = PythagoreanCompetitor(exponent=2.0)
+        a.beat(b, scores=(28.0, 14.0))
+
+        restored = PythagoreanCompetitor.from_state(a.export_state())
+        self.assertEqual(restored._exponent, 2.0)
+        self.assertEqual(restored.rating, a.rating)
+
+    def test_continued_play_after_a_restore_matches_the_original(self):
+        """There is no opponent graph to lose, so a restore is exact, including further play."""
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        restored_a = PythagoreanCompetitor.from_state(json.loads(a.to_json()))
+        restored_b = PythagoreanCompetitor.from_state(json.loads(b.to_json()))
+
+        restored_a.beat(restored_b, scores=(21.0, 14.0))
+        a.beat(b, scores=(21.0, 14.0))
+
+        self.assertEqual(restored_a.rating, a.rating)
+        self.assertEqual(restored_b.rating, b.rating)
+
+    def test_negative_totals_are_rejected_on_import(self):
+        state = PythagoreanCompetitor().export_state()
+        state["state"]["points_for"] = -1.0
+        with self.assertRaises(InvalidParameterException):
+            PythagoreanCompetitor.from_state(state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_PythagoreanCompetitor_known_values.py
+++ b/tests/test_PythagoreanCompetitor_known_values.py
@@ -1,0 +1,130 @@
+"""Numeric reference values for PythagoreanCompetitor.
+
+Every value below is recomputed here from the documented formulas, written out
+independently of the implementation:
+
+    w = (PF + c)^k / ((PF + c)^k + (PA + c)^k)          Pythagorean win expectation
+    E_a = (w_a - w_a*w_b) / (w_a + w_b - 2*w_a*w_b)     log5 combination
+
+with ``k = _exponent`` (2.37 by default, the standard American-football fit) and ``c =
+_prior_points`` (1.0), the symmetric prior that keeps a fresh competitor at exactly 0.5 and
+an unbeaten one strictly below 1.0.
+
+The implementation evaluates the rating in the algebraically identical ratio form
+``1 / (1 + ((PA + c) / (PF + c))^k)``, which cannot overflow on large totals, so the two
+agree to within a few ulps rather than bit for bit; the assertions below allow for that.
+"""
+
+import unittest
+
+from elote import PythagoreanCompetitor
+
+
+PLACES = 12
+K = PythagoreanCompetitor._exponent
+PRIOR = PythagoreanCompetitor._prior_points
+
+
+def _expectation(points_for, points_against, exponent=K):
+    """The Pythagorean win expectation, written out from the documented formula."""
+    scored = (points_for + PRIOR) ** exponent
+    allowed = (points_against + PRIOR) ** exponent
+    return scored / (scored + allowed)
+
+
+def _log5(first, second):
+    """The log5 combination of two win expectations, written out from the formula."""
+    return (first - first * second) / (first + second - 2.0 * first * second)
+
+
+class TestPythagoreanKnownValues(unittest.TestCase):
+    def test_default_exponent_is_the_documented_football_fit(self):
+        self.assertEqual(K, 2.37)
+        self.assertEqual(PRIOR, 1.0)
+
+    def test_fresh_competitor_is_exactly_one_half(self):
+        """PF = PA = 0 is a 0/0 without the prior; with it, (0+1)^k / (2*(0+1)^k) = 1/2."""
+        self.assertEqual(_expectation(0.0, 0.0), 0.5)
+        self.assertEqual(PythagoreanCompetitor().rating, 0.5)
+
+    def test_single_game_totals(self):
+        """One 28-14 game: PF = 28, PA = 14, so the prior-adjusted totals are 29 and 15.
+
+            w = 29^2.37 / (29^2.37 + 15^2.37) = 0.826699207003...
+
+        The loser is the mirror image, 15 against 29.
+        """
+        expected_winner = _expectation(28.0, 14.0)
+        expected_loser = _expectation(14.0, 28.0)
+        # Guards the arithmetic above against a silent change in the closed form.
+        self.assertAlmostEqual(expected_winner, 0.826699207003455, places=PLACES)
+        self.assertAlmostEqual(expected_loser, 0.173300792996545, places=PLACES)
+
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(b, scores=(28.0, 14.0))
+
+        self.assertAlmostEqual(a.rating, expected_winner, places=PLACES)
+        self.assertAlmostEqual(b.rating, expected_loser, places=PLACES)
+
+    def test_two_competitors_with_different_records(self):
+        """A season of three games each, against opponents that do not matter to the fit.
+
+        Competitor A: 31-17, 24-21, 10-27  ->  PF = 65, PA = 65, so exactly 0.5 despite the
+        two wins, since Pythagorean sees only points.
+        Competitor B: 20-14, 35-3, 28-24   ->  PF = 83, PA = 41.
+        """
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        foils = [PythagoreanCompetitor() for _ in range(6)]
+
+        a.beat(foils[0], scores=(31.0, 17.0))
+        a.beat(foils[1], scores=(24.0, 21.0))
+        a.lost_to(foils[2], scores=(10.0, 27.0))
+
+        b.beat(foils[3], scores=(20.0, 14.0))
+        b.beat(foils[4], scores=(35.0, 3.0))
+        b.beat(foils[5], scores=(28.0, 24.0))
+
+        self.assertEqual((a._points_for, a._points_against), (65.0, 65.0))
+        self.assertEqual((b._points_for, b._points_against), (83.0, 41.0))
+
+        self.assertEqual(a.rating, 0.5)
+        expected_b = _expectation(83.0, 41.0)
+        self.assertAlmostEqual(expected_b, 0.837909980755396, places=PLACES)
+        self.assertAlmostEqual(b.rating, expected_b, places=PLACES)
+
+    def test_expected_score_is_the_log5_of_the_two_expectations(self):
+        """A hand-computed log5 pair: w_a from 83-41, w_b from 65-65 (exactly 0.5).
+
+        With w_b = 1/2 log5 reduces to w_a itself, so the pair below deliberately uses a
+        third record as well, where neither side is one half.
+        """
+        strong = _expectation(83.0, 41.0)
+        even = _expectation(65.0, 65.0)
+        middling = _expectation(48.0, 40.0)
+
+        self.assertAlmostEqual(_log5(strong, even), strong, places=PLACES)
+        self.assertAlmostEqual(_log5(strong, middling), 0.772118188713780, places=PLACES)
+        self.assertAlmostEqual(_log5(middling, strong), 0.227881811286220, places=PLACES)
+
+        a, b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        foil_a, foil_b = PythagoreanCompetitor(), PythagoreanCompetitor()
+        a.beat(foil_a, scores=(83.0, 41.0))
+        b.beat(foil_b, scores=(48.0, 40.0))
+
+        self.assertAlmostEqual(a.rating, strong, places=PLACES)
+        self.assertAlmostEqual(b.rating, middling, places=PLACES)
+        self.assertAlmostEqual(a.expected_score(b), _log5(strong, middling), places=PLACES)
+        self.assertAlmostEqual(b.expected_score(a), _log5(middling, strong), places=PLACES)
+
+    def test_baseball_exponent_reproduces_the_classic_two(self):
+        """k = 2 is Bill James' original: a 700-600 run record gives 701^2/(701^2 + 601^2)."""
+        expected = _expectation(700.0, 600.0, exponent=2.0)
+        self.assertAlmostEqual(expected, 0.576354500693172, places=PLACES)
+
+        a, b = PythagoreanCompetitor(exponent=2.0), PythagoreanCompetitor(exponent=2.0)
+        a.beat(b, scores=(700.0, 600.0))
+        self.assertAlmostEqual(a.rating, expected, places=PLACES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -9,6 +9,7 @@ from elote.competitors.trueskill import TrueSkillCompetitor
 from elote.competitors.colley import ColleyMatrixCompetitor
 from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.keener import KeenerCompetitor
+from elote.competitors.pythagorean import PythagoreanCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
 from elote.datasets.synthetic import SyntheticDataset
@@ -475,6 +476,48 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
         )
 
         self.assertEqual([entry["name"] for entry in results], ["Keener", "Colley"])
+        for entry in results:
+            with self.subTest(system=entry["name"]):
+                self.assertGreater(entry["accuracy"], 0.5)
+
+    def test_pythagorean_runs_end_to_end_without_being_handed_an_initial_rating(self):
+        """Pythagorean is incremental, so only its constructor keeps it off the 1500 path.
+
+        evaluate_competitor forces initial_rating=1500 on any incremental class whose
+        __init__ accepts one, and 1500 is meaningless on a [0, 1] win-expectation scale.
+        Asserted by running the real thing rather than by reading the signature check.
+        """
+        result = evaluate_competitor(
+            competitor_class=PythagoreanCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=True,
+        )
+
+        competitors = list(result["arena"].competitors.values())
+        self.assertGreater(len(competitors), 0)
+        for competitor in competitors:
+            self.assertFalse(hasattr(competitor, "_initial_rating"))
+            self.assertGreaterEqual(competitor.rating, 0.0)
+            self.assertLessEqual(competitor.rating, 1.0)
+            self.assertGreater(competitor.num_games, 0)
+
+        self.assertGreater(result["accuracy"], 0.5)
+        self.assertGreaterEqual(result["accuracy_opt"], result["accuracy"])
+
+    def test_pythagorean_can_be_compared_against_an_incremental_system(self):
+        """benchmark_competitors must accept Pythagorean alongside its siblings."""
+        results = benchmark_competitors(
+            [
+                {"class": PythagoreanCompetitor, "name": "Pythagorean", "params": {}},
+                {"class": EloCompetitor, "name": "Elo", "params": {}},
+            ],
+            self.data_split,
+            _always_true,
+            optimize_thresholds=False,
+        )
+
+        self.assertEqual([entry["name"] for entry in results], ["Pythagorean", "Elo"])
         for entry in results:
             with self.subTest(system=entry["name"]):
                 self.assertGreater(entry["accuracy"], 0.5)

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -22,6 +22,7 @@ from elote import (
     KeenerCompetitor,
     LambdaArena,
     MasseyCompetitor,
+    PythagoreanCompetitor,
     TrueSkillCompetitor,
     benchmark_competitors,
     train_arena_with_dataset,
@@ -44,6 +45,7 @@ COMPETITOR_CLASSES = (
     BradleyTerryCompetitor,
     MasseyCompetitor,
     KeenerCompetitor,
+    PythagoreanCompetitor,
 )
 
 # A win, a draw and a loss, with the unit scores each result implies.

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -11,6 +11,7 @@ from elote import (
     BradleyTerryCompetitor,
     MasseyCompetitor,
     KeenerCompetitor,
+    PythagoreanCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -437,6 +438,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
         BradleyTerryCompetitor,
         MasseyCompetitor,
         KeenerCompetitor,
+        PythagoreanCompetitor,
     )
 
     # A lopsided run: long enough that a one-sided rating gap opens up, with


### PR DESCRIPTION
Closes #130

Adds `PythagoreanCompetitor`, the points-based member of the classical sports canon. It is the
first shipped system whose rating is a **win expectation in [0, 1]** rather than a strength score,
the first *incremental* system to consume the score channel from #124, and the only one that
ignores the opponent graph entirely — a constant-time update with no match graph, no matrix and no
refit.

## What changed

`elote/competitors/pythagorean.py` follows the incremental shape of `elo.py`/`dwz.py`, not the
match-graph shape of `colley.py`/`massey.py`/`keener.py`.

- **State**: cumulative points for, points against, and games played.
- **Rating**: `PF^k / (PF^k + PA^k)`, with `_exponent` defaulting to `2.37` (the standard
  American-football fit; Bill James' original baseball form is `k = 2`). `_minimum_rating = 0.0`
  and `_default_initial_rating = 0.5` — the inherited floor of 100 would have saturated the rating
  property, which is the sort key for `LambdaArena.leaderboard()`.
- **`expected_score`**: the standard log5 combination of the two win expectations.
- **Score channel**: consumes `scores` as real points; falls back to the library's unit scores
  (`1/0` win, `0.5/0.5` draw) when omitted, the same convention Keener uses.
  `self._validate_scores(...)` is called in `beat`/`tied`.
- **Constructor**: takes no `initial_rating` (only an optional `exponent`), so
  `evaluate_competitor` cannot hand it 1500. `rating` is read-only for the same reason it is on
  `TrueSkillCompetitor` — it is derived, not stored.
- **Serialization**: the two totals and the game count. The rating is *not* exported because it is
  a pure function of them, so a restore is exact, continued play included.

## Two judgment calls worth reading

**Degenerate inputs are handled with a prior, not a clamp** (as the issue proposed). A fresh
competitor has `PF = PA = 0` and an unbeaten one has `PA = 0`; the first makes the rating `0/0`,
the second makes it exactly `1` and log5 in turn `0/0`. A symmetric prior of `1.0` point is added
to each accumulator, so the rating stays a continuous, strictly increasing function of the real
totals, a fresh competitor is exactly `0.5`, and every rating is strictly inside `(0, 1)`. The
prior is comparable to the library's unit scores and negligible against real ones, so it fades
after a game or two. Clamping the output would have flattened the top of the scale instead and
left `expected_score` needing its own special case.

**Exactness comes from the shape of the arithmetic, not from a clamp.** Two properties are
required to hold *exactly* in floating point:

- The log5 denominator is formed as the sum of its two numerators, `(w_a - w_a w_b) + (w_b - w_a
  w_b)`, rather than as the textbook `w_a + w_b - 2 w_a w_b`. The two are the same expression, but
  summing the already-rounded numerators bounds the quotient inside `[0.5, 1]`. Written the
  textbook way, a heavily lopsided pair returns `1.0000000000000002` — that is a real defect the
  first draft had, caught by the new bounds test.
- Only the direction with the larger rating is computed; the other is taken as its complement.
  Evaluating both directions independently loses exact complementarity for **13% of random
  point-total pairs** (26,894 of 200,000 sampled), so this is load-bearing rather than defensive.

## Wire-up

`elote/__init__.py` (import + `__all__`); docs: new `rating_systems/pythagorean.rst`, plus the
`index.rst` toctree, `competitors.rst`, `api/competitors.rst`, and the six places in
`rating_systems/comparison.rst` that enumerate the systems. Tests: two new files plus the four
shared cross-competitor surfaces (`TestExpectedScoreBounds.COMPETITOR_CLASSES`,
`TestArenaStateRoundTrip.ALL_COMPETITORS`, `test_score_channel.COMPETITOR_CLASSES`, and an
end-to-end pair in `TestBenchmarkEndToEnd`). It is also added to
`TestArenaStateRoundTrip.INCREMENTAL_COMPETITORS`, which the issue did not ask for: it is
incremental and its restore is exact, so it belongs in the stronger continued-play assertion too.
Not added to `tests/test_benchmarks.py`, per the issue.

## Verification

All commands run from a clean worktree at `934b979`.

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` →
  **456 passed, 6 skipped** (415 at the branch point + 41).
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` → **All checks passed**.
  `ruff format --check` is clean on the three new files.
- `python -m sphinx -b html docs/source` → **build succeeded, 515 warnings**; the same build on
  the unmodified base is **502**, so the new module contributes 13, all of them the house
  `References:` / `Key characteristics:` bare-bullet and duplicate-object-description pattern that
  `keener.py` (12) and `massey.py` (18) already produce. Warning count is not a gate here.
- `benchmark_competitors` was run for real, not inferred from the signature check: the new
  end-to-end test asserts the arena's actual competitor objects carry no `_initial_rating` and
  keep ratings inside `[0, 1]`, and that the class benchmarks alongside Elo.
- Endurance: a 6-competitor `LambdaArena` over **2,500** scored matchups, asserting after every
  result that no rating leaves `[0, 1]`, that all six competitors exist, and that the leaderboard
  recovers the seeded strength ordering at both ends.

### Mutation testing (the tests are not vacuous)

Each mutation was applied to the shipped module, verified on disk, run with
`PYTHONDONTWRITEBYTECODE=1`, then restored and the suite re-run green.

| Mutation | Result |
| --- | --- |
| `_prior_points` → `0.0` (remove the prior) | **21 failed** across all six test files |
| log5 denominator → textbook `w_a + w_b - 2 w_a w_b` | **1 failed** — the lopsided-bounds test, on `1.0000000000000002` |
| drop the canonical ordering in `expected_score` | **1 failed** — the programmatically selected complementarity fixture |
| add `initial_rating` to the constructor | **2 failed**, including the real `benchmark_competitors` run |
| record the score pair reversed in `beat` | **16 failed**, including every known-value test |

Two of those are worth flagging: the textbook-denominator and dropped-ordering mutations are each
caught by exactly **one** test. The hand-written complementarity and bounds fixtures pass on both
mutations — the fixture that catches the ordering one was selected by searching random point
totals for a pair that actually differs, rather than by picking one that looked lopsided enough.